### PR TITLE
Make PythonLibs truly an optional component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package( YamlCpp 0.5.1 REQUIRED )
 
 option( WITH_PYTHON "Enable Python modules support." ON )
 
-macro_optional_find_package( PythonLibs 3.3 REQUIRED )
+macro_optional_find_package( PythonLibs 3.3 )
 macro_log_feature(
     PYTHONLIBS_FOUND
     "Python"


### PR DESCRIPTION
PythonLibs is an optional dependency, remove REQUIRED otherwise the
build fails when it is not found.
