### PR TITLE
displaymanager: Detect SDDM session type

### DIFF
--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -171,6 +171,11 @@ def set_autologin(username, displaymanagers, root_mount_point):
                 # User= line, possibly commented out
                 if re.match('\\s*(?:#\\s*)?User=', line):
                     line = 'User={}\n'.format(username)
+                # Session= line, commented out or with empty value
+                if re.match('\\s*#\\s*Session=|\\s*Session=$', line):
+                    default_desktop_environment = find_desktop_environment(root_mount_point)
+                    if default_desktop_environment != None:
+                        line = 'Session={}.desktop\n'.format(default_desktop_environment.desktop_file)
                 sddm_conf.write(line)
        
     return None


### PR DESCRIPTION
This set of commits refactors the desktop environment detection in the displaymanager module so it is no longer copied&pasted for every display manager, adds KDE Plasma (5 and 4) and GNOME to the list of detectable desktop environments, fixes the SDDM autologin setup to not clobber the RememberLastUser= line, and fixes the SDDM autologin setup to set Session= if not already set (using the refactored desktop environment detection).

This should be applied on top of pull request #139. Together, they make autologin setup for SDDM work for me.
