### PR TITLE
make gummiboot kernel/distro agnostic

### DIFF
--- a/src/modules/bootloader/bootloader.conf
+++ b/src/modules/bootloader/bootloader.conf
@@ -1,7 +1,10 @@
 ---
 # Gummiboot configuration files settings, set preffered distribution name and amount of time before 
 # default selection boots
-distribution: KaOS
+distribution: KaOS-kf5
+kernel: /vmlinuz-linux
+img: /initramfs-linux.img
+fallback: /initramfs-linux-fallback.img
 
 timeout: 10
     


### PR DESCRIPTION
add hibernate option to .conf
create a fallback entry in gummiboot menu
re-add firmware to globalstorage, simplifies this module, will be needed to add more OS to gummi
