### PR TITLE
grub, bootloader: Make the grub-* and /boot/grub names configurable.

### DIFF
--- a/src/modules/bootloader/bootloader.conf
+++ b/src/modules/bootloader/bootloader.conf
@@ -1,5 +1,5 @@
 ---
-# Gummiboot configuration files settings, set preffered distribution name and amount of time before 
+# Gummiboot configuration files settings, set preferred distribution name and amount of time before 
 # default selection boots
 distribution: KaOS-kf5
 kernel: /vmlinuz-linux
@@ -7,5 +7,9 @@ img: /initramfs-linux.img
 fallback: /initramfs-linux-fallback.img
 
 timeout: 10
-    
 
+# GRUB 2 binary names and boot directory
+# Some distributions (e.g. Fedora) use grub2-* (resp. /boot/grub2/) names.
+grubInstall: "grub-install"
+grubMkconfig: "grub-mkconfig"
+grubCfg: "/boot/grub/grub.cfg"

--- a/src/modules/bootloader/main.py
+++ b/src/modules/bootloader/main.py
@@ -143,8 +143,8 @@ def install_bootloader(boot_loader, fw_type):
         create_loader(loader_path)
     else:
         install_path = boot_loader["installPath"]
-        check_chroot_call(["grub-install", install_path])
-        check_chroot_call(["grub-mkconfig", "-o", "/boot/grub/grub.cfg"])
+        check_chroot_call([libcalamares.job.configuration["grubInstall"], install_path])
+        check_chroot_call([libcalamares.job.configuration["grubMkconfig"], "-o", libcalamares.job.configuration["grubCfg"]])
 
 
 def run():

--- a/src/modules/grub/grub.conf
+++ b/src/modules/grub/grub.conf
@@ -1,0 +1,6 @@
+---
+# GRUB 2 binary names and boot directory
+# Some distributions (e.g. Fedora) use grub2-* (resp. /boot/grub2/) names.
+grubInstall: "grub-install"
+grubMkconfig: "grub-mkconfig"
+grubCfg: "/boot/grub/grub.cfg"

--- a/src/modules/grub/main.py
+++ b/src/modules/grub/main.py
@@ -23,8 +23,8 @@ from libcalamares.utils import check_chroot_call
 
 def install_grub(boot_loader):
     install_path = boot_loader["installPath"]
-    check_chroot_call(["grub-install", install_path])
-    check_chroot_call(["grub-mkconfig", "-o", "/boot/grub/grub.cfg"])
+    check_chroot_call([libcalamares.job.configuration["grubInstall"], install_path])
+    check_chroot_call([libcalamares.job.configuration["grubMkconfig"], "-o", libcalamares.job.configuration["grubCfg"]])
 
 
 def run():


### PR DESCRIPTION
Some distributions (e.g. Fedora) use grub2-\* (resp. /boot/grub2/) names.

Fixes #123.
