### PR TITLE
grub: add --target=i386-pc for bios systems

### DIFF
--- a/src/modules/grub/main.py
+++ b/src/modules/grub/main.py
@@ -36,7 +36,7 @@ def install_grub(boot_loader, fw_type):
         check_chroot_call([libcalamares.job.configuration["grubInstall"], "--target=x86_64-efi", "--efi-directory={!s}".format(efi_directory), "--bootloader-id={!s}".format(efi_bootloader_id)])
     else:
         install_path = boot_loader["installPath"]
-        check_chroot_call([libcalamares.job.configuration["grubInstall"], install_path])
+        check_chroot_call([libcalamares.job.configuration["grubInstall"], "--target=i386-pc", install_path])
 
     check_chroot_call([libcalamares.job.configuration["grubMkconfig"], "-o", libcalamares.job.configuration["grubCfg"]])
 


### PR DESCRIPTION
From Arch wiki:
--target=i386-pc instructs grub-install to install for BIOS systems only. It is recommended
to always use this option to remove ambiguity in grub-install.
