### PR TITLE
Allow local installs with the packages module

### DIFF
--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -91,7 +91,7 @@ def run_operations(pkgman, entry):
             pkgman.install(entry[key])
         elif key == "remove":
             pkgman.remove(entry[key])
-        elif key == "local_install":
+        elif key == "localInstall":
             pkgman.install(entry[key], from_local=True)
 
 

--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -30,7 +30,7 @@ class PackageManager:
     def __init__(self, backend):
         self.backend = backend
 
-    def install(self, pkgs):
+    def install(self, pkgs, from_local=False):
         """ Installs packages.
 
         :param pkgs:
@@ -53,7 +53,8 @@ class PackageManager:
         elif self.backend == "apt":
             check_chroot_call(["apt-get", "-q", "-y", "install"] + pkgs)
         elif self.backend == "pacman":
-            check_chroot_call(["pacman", "-Sy", "--noconfirm"] + pkgs)
+            pacman_flags = "-Sy" if from_local else "-U"
+            check_chroot_call(["pacman", pacman_flags, "--noconfirm"] + pkgs)
 
     def remove(self, pkgs):
         """ Removes packages.
@@ -90,6 +91,8 @@ def run_operations(pkgman, entry):
             pkgman.install(entry[key])
         elif key == "remove":
             pkgman.remove(entry[key])
+        elif key == "local_install":
+            pkgman.install(entry[key], from_local=True)
 
 
 def run():

--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -53,7 +53,7 @@ class PackageManager:
         elif self.backend == "apt":
             check_chroot_call(["apt-get", "-q", "-y", "install"] + pkgs)
         elif self.backend == "pacman":
-            pacman_flags = "-Sy" if from_local else "-U"
+            pacman_flags = "-U" if from_local else "-Sy"
             check_chroot_call(["pacman", pacman_flags, "--noconfirm"] + pkgs)
 
     def remove(self, pkgs):

--- a/src/modules/packages/packages.conf
+++ b/src/modules/packages/packages.conf
@@ -39,5 +39,5 @@ backend: packagekit
 #    install:
 #      - pkgs6
 #      - pkg7
-#  - local_install:
+#  - localInstall:
 #      - /path/to/pkg8

--- a/src/modules/packages/packages.conf
+++ b/src/modules/packages/packages.conf
@@ -39,3 +39,5 @@ backend: packagekit
 #    install:
 #      - pkgs6
 #      - pkg7
+#  - local_install:
+#      - /path/to/pkg8


### PR DESCRIPTION
Courtesy of @Inkane. Adds the ability to use pacman -U to install
local packages.

Note: the `local_install` option in the YAML will work for pacman only,
until someone edits `install` to support the rest.