### PR TITLE
Show efi mountpoint when creating/editing partitions

### DIFF
--- a/src/modules/partition/gui/CreatePartitionDialog.cpp
+++ b/src/modules/partition/gui/CreatePartitionDialog.cpp
@@ -26,6 +26,8 @@
 #include <ui_CreatePartitionDialog.h>
 
 #include <utils/Logger.h>
+#include "GlobalStorage.h"
+#include "JobQueue.h"
 
 // CalaPM
 #include <core/device.h>
@@ -35,6 +37,7 @@
 
 // Qt
 #include <QComboBox>
+#include <QDir>
 #include <QSet>
 
 static QSet< FileSystem::Type > s_unmountableFS(
@@ -52,6 +55,14 @@ CreatePartitionDialog::CreatePartitionDialog( Device* device, PartitionNode* par
 {
     m_ui->setupUi( this );
 
+    QStringList mountPoints;
+    mountPoints << "/" << "/boot" << "/home" << "/opt" << "/usr" << "/var";
+    if ( QDir( "/sys/firmware/efi/efivars" ).exists() )
+        mountPoints << Calamares::JobQueue::instance()->globalStorage()->value( "efiSystemPartition" ).toString();
+    mountPoints.removeDuplicates();
+    mountPoints.sort();
+    m_ui->mountPointComboBox->addItems( mountPoints );
+    
     if ( device->partitionTable()->type() == PartitionTable::msdos )
         initMbrPartitionTypeUi();
     else

--- a/src/modules/partition/gui/CreatePartitionDialog.ui
+++ b/src/modules/partition/gui/CreatePartitionDialog.ui
@@ -130,36 +130,6 @@
        <property name="currentIndex">
         <number>-1</number>
        </property>
-       <item>
-        <property name="text">
-         <string>/</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>/boot</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>/home</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>/opt</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>/usr</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>/var</string>
-        </property>
-       </item>
       </widget>
      </item>
      <item row="7" column="0">

--- a/src/modules/partition/gui/EditExistingPartitionDialog.cpp
+++ b/src/modules/partition/gui/EditExistingPartitionDialog.cpp
@@ -27,6 +27,8 @@
 #include <ui_EditExistingPartitionDialog.h>
 
 #include <utils/Logger.h>
+#include "GlobalStorage.h"
+#include "JobQueue.h"
 
 // CalaPM
 #include <core/device.h>
@@ -35,6 +37,7 @@
 
 // Qt
 #include <QComboBox>
+#include <QDir>
 
 EditExistingPartitionDialog::EditExistingPartitionDialog( Device* device, Partition* partition, QWidget* parentWidget )
     : QDialog( parentWidget )
@@ -44,6 +47,14 @@ EditExistingPartitionDialog::EditExistingPartitionDialog( Device* device, Partit
     , m_partitionSizeController( new PartitionSizeController( this ) )
 {
     m_ui->setupUi( this );
+
+    QStringList mountPoints;
+    mountPoints << "/" << "/boot" << "/home" << "/opt" << "/usr" << "/var";
+    if ( QDir( "/sys/firmware/efi/efivars" ).exists() )
+        mountPoints << Calamares::JobQueue::instance()->globalStorage()->value( "efiSystemPartition" ).toString();
+    mountPoints.removeDuplicates();
+    mountPoints.sort();
+    m_ui->mountPointComboBox->addItems( mountPoints );
 
     QColor color = ColorUtils::colorForPartition( m_partition );
     m_partitionSizeController->init( m_device, m_partition, color );

--- a/src/modules/partition/gui/EditExistingPartitionDialog.ui
+++ b/src/modules/partition/gui/EditExistingPartitionDialog.ui
@@ -105,36 +105,6 @@
        <property name="currentIndex">
         <number>-1</number>
        </property>
-       <item>
-        <property name="text">
-         <string>/</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>/boot</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>/home</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>/opt</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>/usr</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>/var</string>
-        </property>
-       </item>
       </widget>
      </item>
      <item row="1" column="0">


### PR DESCRIPTION
Remove fixed mountpoint list in the .ui file and create a list of mount points including the customizable efi mount point, when running in an efi capable system.