### PR TITLE
add URL option in greeting page

### DIFF
--- a/src/branding/default/branding.desc
+++ b/src/branding/default/branding.desc
@@ -9,6 +9,8 @@ strings:
     versionedName:       Generic GNU/Linux 1.0 LTS "Rusty Trombone"
     shortVersionedName:  Generic 1.0
     bootloaderEntryName: Generic
+    productURL:          http://calamares.github.io/
+    urlText:             Known Issues
 
 images:
     productLogo:         "squid.png"

--- a/src/libcalamaresui/Branding.cpp
+++ b/src/libcalamaresui/Branding.cpp
@@ -1,6 +1,6 @@
 /* === This file is part of Calamares - <http://github.com/calamares> ===
  *
- *   Copyright 2014, Teo Mrnjavac <teo@kde.org>
+ *   Copyright 2014-2015, Teo Mrnjavac <teo@kde.org>
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -52,7 +52,9 @@ QStringList Branding::s_stringEntryStrings =
     "versionedName",
     "shortVersionedName",
     "shortProductName",
-    "bootloaderEntryName"
+    "bootloaderEntryName",
+    "productURL",
+    "urlText"
 };
 
 

--- a/src/libcalamaresui/Branding.h
+++ b/src/libcalamaresui/Branding.h
@@ -1,6 +1,6 @@
 /* === This file is part of Calamares - <http://github.com/calamares> ===
  *
- *   Copyright 2014, Teo Mrnjavac <teo@kde.org>
+ *   Copyright 2014-2015, Teo Mrnjavac <teo@kde.org>
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -44,7 +44,9 @@ public:
         VersionedName,
         ShortVersionedName,
         ShortProductName,
-        BootloaderEntryName
+        BootloaderEntryName,
+        ProductURL,
+        UrlText
     };
 
     enum ImageEntry : short

--- a/src/modules/greeting/GreetingPage.cpp
+++ b/src/modules/greeting/GreetingPage.cpp
@@ -1,6 +1,6 @@
 /* === This file is part of Calamares - <http://github.com/calamares> ===
  *
- *   Copyright 2014, Teo Mrnjavac <teo@kde.org>
+ *   Copyright 2014-2015, Teo Mrnjavac <teo@kde.org>
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -123,11 +123,19 @@ GreetingPage::GreetingPage( QWidget* parent )
     CALAMARES_RETRANSLATE(
         ui->mainText->setText( tr( "<h1>Welcome to the %1 installer.</h1><br/>"
                              "This program will ask you some questions and "
-                             "set up %2 on your computer." )
+                             "set up %2 on your computer." 
+                             " Remember, this installer is still in an early stage.<br/>"
+                             "Not implemented yet is LUKS/LVM or RAID and<br/>"
+                             "using one of the automated partitioning options for UEFI installs.<br/>" 
+                             "For <b>GPT partioning on BIOS</b> systems and other instructions, read<a href=\"%3\"> %4 </a>" )
                          .arg( Calamares::Branding::instance()->
                                string( Calamares::Branding::VersionedName ) )
                          .arg( Calamares::Branding::instance()->
-                               string( Calamares::Branding::ProductName ) ) );
+                               string( Calamares::Branding::ProductName ) ) 
+                         .arg( Calamares::Branding::instance()->
+                               string( Calamares::Branding::ProductURL ) )
+                         .arg( Calamares::Branding::instance()->
+                               string( Calamares::Branding::UrlText ) ) );
     )
 
     ui->aboutButton->setIcon( CalamaresUtils::defaultPixmap( CalamaresUtils::Information,


### PR DESCRIPTION
URL is a variable set in branding.desc, distros cna link to a Known Issues page
text for the URL is also possible to set in branding, known issues is default
advantage is any text possible as distros see fit
disadvantage, not part of translated strings
if most agree, Known Issues can be set as hard coded text, not in branding.desc