### PR TITLE
Use which to find plymouth instead of hard coding /usr/bin

### DIFF
--- a/src/modules/grubcfg/main.py
+++ b/src/modules/grubcfg/main.py
@@ -33,11 +33,11 @@ def modify_grub_default(partitions, root_mount_point, distributor):
     default_dir = os.path.join(root_mount_point, "etc/default")
     default_grub = os.path.join(default_dir, "grub")
     distributor_replace = distributor.replace("'", "'\\''")
-    plymouth_bin = os.path.join(root_mount_point, "usr/bin/plymouth")
+    plymouth_bin = libcalamares.utils.chroot_call("sh -c \"which plymouth\"")
     use_splash = ""
     swap_uuid = ""
 
-    if os.path.exists(plymouth_bin):
+    if plymouth_bin == 0:
         use_splash = "splash"
 
     for partition in partitions:


### PR DESCRIPTION
Use 'which' to find plymouth instead of hard coding /usr/bin
    
Debian ships plymouth in  /bin instead of /usr/bin, so we should use
'which' to figure out if it's installed.
