### PR TITLE
Small Python IO Cleanup

### DIFF
--- a/src/modules/bootloader/main.py
+++ b/src/modules/bootloader/main.py
@@ -106,7 +106,6 @@ def create_systemd_boot_conf(uuid, conf_path, kernel_line):
     with open(conf_path, 'w') as f:
         for l in lines:
             f.write(l)
-    f.close()
 
 
 def create_loader(loader_path):
@@ -126,7 +125,6 @@ def create_loader(loader_path):
     with open(loader_path, 'w') as f:
         for l in lines:
             f.write(l)
-    f.close()
 
 
 def install_systemd_boot(efi_directory):

--- a/src/modules/unpackfs/main.py
+++ b/src/modules/unpackfs/main.py
@@ -264,18 +264,14 @@ def run():
         fs_is_supported = False
 
         if os.path.isfile(PATH_PROCFS) and os.access(PATH_PROCFS, os.R_OK):
-            procfile = open(PATH_PROCFS, 'r')
-            filesystems = procfile.read()
-            procfile.close()
+            with open(PATH_PROCFS, 'r') as procfile:
+                filesystems = procfile.read()
+                filesystems = filesystems.replace("nodev", "").replace("\t", "").splitlines()
 
-            filesystems = filesystems.replace("nodev", "")
-            filesystems = filesystems.replace("\t", "")
-            filesystems = filesystems.splitlines()
-
-            # Check if the source filesystem is supported
-            for fs in filesystems:
-                if fs == sourcefs:
-                    fs_is_supported = True
+                # Check if the source filesystem is supported
+                for fs in filesystems:
+                    if fs == sourcefs:
+                        fs_is_supported = True
 
         if not fs_is_supported:
             return "Bad filesystem", "sourcefs=\"{}\"".format(sourcefs)


### PR DESCRIPTION
**'src/modules/bootloader/main.py'**
Contained 'close' functions after 'with'.  'with' will auto-close files so this is not needed.

**'src/modules/unpackfs/main.py'**
'PATH_PROCFS' was being opened, read, closed and then reopened later on without being closed... This resolves that and neatens it up a bit.
