### PR TITLE
EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+
+[*.{py,cpp,h}]
+indent_style = space
+indent_size = 4
+insert_final_newline = true

--- a/HACKING.md
+++ b/HACKING.md
@@ -70,6 +70,8 @@ You can use the `hacking/calamaresstyle` script to run
 [astyle](http://astyle.sf.net) on your code and have it formatted the right
 way.
 
+**NOTE:** An .editorconfig file is included to assist with formatting. In order to take advantage of this functionality you will need to acquire the [EditorConfig](http://editorconfig.org/#download) plug-in for your editor.
+
 Naming
 ------
 * Use CamelCase for everything.


### PR DESCRIPTION
This adds a '.editorconfig' file and a reference to the config within 'HACKING.md'.  [EditorConfig](http://editorconfig.org/) is a simple config file that defines a basic style guide for the project.  The EditorConfig plug-in (that is available for most popular editors) will read the config and automatically adjust its settings to match the style guide.

I figure this is a simple addition to assist future contributers with staying within the 'HACKING' guidelines.