### PR TITLE
Add a webview module

### DIFF
--- a/src/modules/webview/CMakeLists.txt
+++ b/src/modules/webview/CMakeLists.txt
@@ -1,0 +1,20 @@
+find_package( Qt5 ${QT_VERSION} CONFIG REQUIRED WebKit WebKitWidgets )
+
+include_directories( ${PROJECT_BINARY_DIR}/src/libcalamaresui
+                     ${QT_QTWEBKIT_INCLUDE_DIR} )
+
+set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
+                       ${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules )
+
+
+calamares_add_plugin( webview
+    TYPE viewmodule
+    EXPORT_MACRO PLUGINDLLEXPORT_PRO
+    SOURCES
+        WebViewStep.cpp
+    LINK_LIBRARIES
+        calamaresui
+        Qt5::WebKit
+        Qt5::WebKitWidgets
+    SHARED_LIB
+)

--- a/src/modules/webview/WebViewStep.cpp
+++ b/src/modules/webview/WebViewStep.cpp
@@ -1,6 +1,6 @@
 /* === This file is part of Calamares - <http://github.com/calamares> ===
  *
- *   Copyright 2014-2015, Teo Mrnjavac <teo@kde.org>
+ *   Copyright 2015, Rohan Garg <rohan@garg.io>
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -72,7 +72,7 @@ WebViewStep::isNextEnabled() const
 bool
 WebViewStep::isBackEnabled() const
 {
-    return false;
+    return true;
 }
 
 

--- a/src/modules/webview/WebViewStep.cpp
+++ b/src/modules/webview/WebViewStep.cpp
@@ -1,0 +1,115 @@
+/* === This file is part of Calamares - <http://github.com/calamares> ===
+ *
+ *   Copyright 2014-2015, Teo Mrnjavac <teo@kde.org>
+ *
+ *   Calamares is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   Calamares is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with Calamares. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "WebViewStep.h"
+
+#include <QVariant>
+#include <QWebView>
+
+WebViewStep::WebViewStep( QObject* parent )
+    : Calamares::ViewStep( parent )
+{
+    emit nextStatusChanged( true );
+    m_view = new QWebView;
+}
+
+
+WebViewStep::~WebViewStep()
+{
+    if ( m_view && m_view->parent() == nullptr )
+        m_view->deleteLater();
+}
+
+
+QString
+WebViewStep::prettyName() const
+{
+    return m_prettyName;
+}
+
+
+QWidget*
+WebViewStep::widget()
+{
+    return m_view;
+}
+
+
+void
+WebViewStep::next()
+{
+    emit done();
+}
+
+
+void
+WebViewStep::back()
+{}
+
+
+bool
+WebViewStep::isNextEnabled() const
+{
+    return true;
+}
+
+
+bool
+WebViewStep::isBackEnabled() const
+{
+    return false;
+}
+
+
+bool
+WebViewStep::isAtBeginning() const
+{
+    return true;
+}
+
+
+bool
+WebViewStep::isAtEnd() const
+{
+    return true;
+}
+
+void WebViewStep::onActivate()
+{
+  m_view->load(QUrl(m_url));
+  m_view->show();
+}
+
+QList< Calamares::job_ptr >
+WebViewStep::jobs() const
+{
+    return QList< Calamares::job_ptr >();
+}
+
+
+void
+WebViewStep::setConfigurationMap( const QVariantMap& configurationMap )
+{
+  if ( configurationMap.contains("url") &&
+       configurationMap.value("url").type() == QVariant::String )
+    m_url = configurationMap.value("url").toString();
+
+  if ( configurationMap.contains("prettyName") &&
+       configurationMap.value("prettyName").type() == QVariant::String )
+    m_prettyName = configurationMap.value("prettyName").toString();
+}

--- a/src/modules/webview/WebViewStep.h
+++ b/src/modules/webview/WebViewStep.h
@@ -1,0 +1,66 @@
+/* === This file is part of Calamares - <http://github.com/calamares> ===
+ *
+ *   Copyright 2014-2015, Teo Mrnjavac <teo@kde.org>
+ *
+ *   Calamares is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   Calamares is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with Calamares. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef WEBVIEWPLUGIN_H
+#define WEBVIEWPLUGIN_H
+
+#include <QObject>
+
+#include "viewpages/ViewStep.h"
+#include "PluginDllMacro.h"
+
+#include <QVariantMap>
+
+class QWebView;
+
+class PLUGINDLLEXPORT WebViewStep : public Calamares::ViewStep
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA( IID "calamares.ViewModule/1.0" )
+
+    Q_INTERFACES( Calamares::ViewStep )
+
+public:
+    explicit WebViewStep( QObject* parent = nullptr );
+    virtual ~WebViewStep();
+
+    QString prettyName() const override;
+
+    QWidget* widget() override;
+
+    void next() override;
+    void back() override;
+    void onActivate() override;
+
+    bool isNextEnabled() const override;
+    bool isBackEnabled() const override;
+
+    bool isAtBeginning() const override;
+    bool isAtEnd() const override;
+
+    QList< Calamares::job_ptr > jobs() const override;
+
+    void setConfigurationMap( const QVariantMap& configurationMap ) override;
+
+private:
+    QWebView *m_view;
+    QString m_url;
+    QString m_prettyName;
+};
+
+#endif // WEBVIEWPLUGIN_H

--- a/src/modules/webview/WebViewStep.h
+++ b/src/modules/webview/WebViewStep.h
@@ -1,6 +1,6 @@
 /* === This file is part of Calamares - <http://github.com/calamares> ===
  *
- *   Copyright 2014-2015, Teo Mrnjavac <teo@kde.org>
+ *   Copyright 2015, Rohan Garg <rohan@garg.io>
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by

--- a/src/modules/webview/module.desc
+++ b/src/modules/webview/module.desc
@@ -1,0 +1,7 @@
+# Module metadata file for welcome viewmodule
+# Syntax is YAML 1.2
+---
+type:      "view"     #core or view
+name:      "webview"  #the module name. must be unique and same as the parent directory
+interface: "qtplugin" #can be: qtplugin, python, process, ...
+load:      "libcalamares_viewmodule_webview.so"

--- a/src/modules/webview/webview.conf
+++ b/src/modules/webview/webview.conf
@@ -1,0 +1,3 @@
+---
+prettyName: "Webview"
+url:        "https://calamares.io"


### PR DESCRIPTION
Add a webview module so that calamares can load a webpage.
This is useful when configuring webservices on your device such as
ownCloud.