### PR TITLE
CAL-345: don't set default "users" group on home dirs

### DIFF
--- a/src/modules/users/CreateUserJob.cpp
+++ b/src/modules/users/CreateUserJob.cpp
@@ -33,13 +33,11 @@
 CreateUserJob::CreateUserJob( const QString& userName,
                               const QString& fullName,
                               bool autologin,
-                              const QString& userGroup,
                               const QStringList& defaultGroups )
     : Calamares::Job()
     , m_userName( userName )
     , m_fullName( fullName )
     , m_autologin( autologin )
-    , m_userGroup( userGroup )
     , m_defaultGroups( defaultGroups )
 {
 }
@@ -151,7 +149,7 @@ CreateUserJob::exec()
                       targetEnvCall( { "chown",
                                        "-R",
                                        QString( "%1:%2" ).arg( m_userName )
-                                                         .arg( m_userGroup ),
+                                                         .arg( m_userName ),
                                        QString( "/home/%1" ).arg( m_userName ) } );
     if ( ec )
         return Calamares::JobResult::error( tr( "Cannot set home directory ownership for user %1." )

--- a/src/modules/users/CreateUserJob.h
+++ b/src/modules/users/CreateUserJob.h
@@ -30,7 +30,6 @@ public:
     CreateUserJob( const QString& userName,
                    const QString& fullName,
                    bool autologin,
-                   const QString& userGroup,
                    const QStringList& defaultGroups );
     QString prettyName() const override;
     QString prettyDescription() const override;
@@ -41,7 +40,6 @@ private:
     QString m_userName;
     QString m_fullName;
     bool m_autologin;
-    QString m_userGroup;
     QStringList m_defaultGroups;
 };
 

--- a/src/modules/users/UsersPage.cpp
+++ b/src/modules/users/UsersPage.cpp
@@ -105,7 +105,7 @@ UsersPage::isReady()
 
 
 QList< Calamares::job_ptr >
-UsersPage::createJobs( const QString& defaultUserGroup, const QStringList& defaultGroupsList )
+UsersPage::createJobs( const QStringList& defaultGroupsList )
 {
     QList< Calamares::job_ptr > list;
     if ( !isReady() )
@@ -117,7 +117,6 @@ UsersPage::createJobs( const QString& defaultUserGroup, const QStringList& defau
                                ui->textBoxUsername->text() :
                                ui->textBoxFullName->text(),
                            ui->checkBoxAutoLogin->isChecked(),
-                           defaultUserGroup,
                            defaultGroupsList );
     list.append( Calamares::job_ptr( j ) );
 

--- a/src/modules/users/UsersPage.h
+++ b/src/modules/users/UsersPage.h
@@ -40,8 +40,7 @@ public:
 
     bool isReady();
 
-    QList< Calamares::job_ptr > createJobs( const QString& defaultUserGroup,
-                                            const QStringList& defaultGroupsList );
+    QList< Calamares::job_ptr > createJobs( const QStringList& defaultGroupsList );
 
     void onActivate();
 

--- a/src/modules/users/UsersViewStep.cpp
+++ b/src/modules/users/UsersViewStep.cpp
@@ -115,21 +115,13 @@ UsersViewStep::onLeave()
 {
     m_jobs.clear();
 
-    m_jobs.append( m_widget->createJobs( m_userGroup, m_defaultGroups ) );
+    m_jobs.append( m_widget->createJobs( m_defaultGroups ) );
 }
 
 
 void
 UsersViewStep::setConfigurationMap( const QVariantMap& configurationMap )
 {
-    if ( configurationMap.contains( "userGroup" ) &&
-         configurationMap.value( "userGroup" ).type() == QVariant::String )
-    {
-        m_userGroup = configurationMap.value( "userGroup" ).toString();
-    }
-    if ( m_userGroup.isEmpty() )
-        m_userGroup = QStringLiteral( "users" );
-
     if ( configurationMap.contains( "defaultGroups" ) &&
          configurationMap.value( "defaultGroups" ).type() == QVariant::List )
     {

--- a/src/modules/users/UsersViewStep.h
+++ b/src/modules/users/UsersViewStep.h
@@ -62,7 +62,6 @@ private:
     UsersPage* m_widget;
     QList< Calamares::job_ptr > m_jobs;
 
-    QString m_userGroup;
     QStringList m_defaultGroups;
 };
 

--- a/src/modules/users/users.conf
+++ b/src/modules/users/users.conf
@@ -1,6 +1,6 @@
 ---
-userGroup:       users
 defaultGroups:
+    - users
     - lp
     - video
     - network


### PR DESCRIPTION
Fixes CAL-345.

Changing group of home dir to the default "users" group might be a security risk
because every user which belongs to the default "users" group
might be able to access private data on home dirs of other users.