### PR TITLE
calamares: sidebarTextHighlight for branding

### DIFF
--- a/src/calamares/progresstree/ProgressTreeDelegate.cpp
+++ b/src/calamares/progresstree/ProgressTreeDelegate.cpp
@@ -104,7 +104,8 @@ ProgressTreeDelegate::paintViewStep( QPainter* painter,
     {
         painter->setPen( Calamares::Branding::instance()->
                          styleString( Calamares::Branding::SidebarTextSelect ) );
-        painter->setBrush( APP->mainWindow()->palette().background() );
+        painter->setBrush( QColor( Calamares::Branding::instance()->
+                           styleString( Calamares::Branding::SidebarTextHighlight ) ) );
     }
 
     painter->fillRect( option.rect, painter->brush().color() );

--- a/src/libcalamaresui/Branding.cpp
+++ b/src/libcalamaresui/Branding.cpp
@@ -71,7 +71,8 @@ QStringList Branding::s_styleEntryStrings =
 {
     "sidebarBackground",
     "sidebarText",
-    "sidebarTextSelect"
+    "sidebarTextSelect",
+    "sidebarTextHighlight"
 };
 
 

--- a/src/libcalamaresui/Branding.h
+++ b/src/libcalamaresui/Branding.h
@@ -62,7 +62,8 @@ public:
     {
         SidebarBackground,
         SidebarText,
-        SidebarTextSelect
+        SidebarTextSelect,
+        SidebarTextHighlight
     };
 
     static Branding* instance();


### PR DESCRIPTION
This commit adds support for distribution to define `sidebarTextHighlight` to their `branding.desc` file, to control the left panel (sidebar) with highlight behind the current step (`isCurrent`) text label.

And here attaches a screenshot showing what the parameter does.

![screenshot_20160106_200615](https://cloud.githubusercontent.com/assets/5006263/12161258/04f81cf8-b4b1-11e5-97f1-87f94974e80f.png)
