### PR TITLE
Creating the option to copy an install log to target

### DIFF
--- a/src/modules/umount/README.md
+++ b/src/modules/umount/README.md
@@ -1,0 +1,17 @@
+### Umount Module
+---------
+This module represents the last part of the installation, the unmounting of partitions used for the install.  It is also the last place where it is possible to copy files to the target system, thus the best place to copy an installation log.
+
+To be able to use the copy an installation log of this module you will need to include a log creation to your launcher script or add it to the used calamares.desktop, example of a launcher script:
+
+```
+#!/bin/sh
+sudo /usr/bin/calamares -d > installation.log 
+```
+Example desktop line:
+```
+Exec=sudo /usr/bin/calamares -d > installation.log
+```
+Set the source and destination path of your install log in umount.conf
+If you do not wish to use the copy of an install log feature, no action needed, the module will not execute the copy of a log code if no log is present.
+

--- a/src/modules/umount/README.md
+++ b/src/modules/umount/README.md
@@ -2,7 +2,8 @@
 ---------
 This module represents the last part of the installation, the unmounting of partitions used for the install.  It is also the last place where it is possible to copy files to the target system, thus the best place to copy an installation log.
 
-To be able to use the copy an installation log of this module you will need to include a log creation to your launcher script or add it to the used calamares.desktop, example of a launcher script:
+You can either use the default ```/root/.cache/Calamares/Calamares/Calamares.log``` 
+to copy or if you want to use the full output of ```sudo calamares -d``` to create a log you will need to include a log creation to your launcher script or add it to the used calamares.desktop, example of a launcher script:
 
 ```
 #!/bin/sh
@@ -12,6 +13,6 @@ Example desktop line:
 ```
 Exec=sudo /usr/bin/calamares -d > installation.log
 ```
-Set the source and destination path of your install log in umount.conf
-If you do not wish to use the copy of an install log feature, no action needed, the module will not execute the copy of a log code if no log is present.
+Set the source and destination path of your install log in umount.conf.
+If you do not wish to use the copy of an install log feature, no action needed, the default settings do not execute the copy of an install log in this module.
 

--- a/src/modules/umount/main.py
+++ b/src/modules/umount/main.py
@@ -4,6 +4,7 @@
 # === This file is part of Calamares - <http://github.com/calamares> ===
 #
 #   Copyright 2014, Aurélien Gâteau <agateau@kde.org>
+#   Copyright 2016, Anke Boersma <demm@kaosx.us>
 #
 #   Calamares is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -20,6 +21,7 @@
 
 import os
 import subprocess
+import shutil
 
 import libcalamares
 
@@ -47,6 +49,13 @@ def run():
     :return:
     """
     root_mount_point = libcalamares.globalstorage.value("rootMountPoint")
+    log_source = libcalamares.job.configuration["srcLog"]
+    log_destination = libcalamares.job.configuration["destLog"]
+    
+    # copy installation log before umount
+    if(os.path.exists('{!s}'.format(log_source))):
+        shutil.copy2('{!s}'.format(log_source), '{!s}/{!s}'.format(
+            root_mount_point, log_destination))
 
     if not root_mount_point:
         return ("No mount point for root partition in globalstorage",

--- a/src/modules/umount/umount.conf
+++ b/src/modules/umount/umount.conf
@@ -1,0 +1,3 @@
+---
+srcLog:     "/home/live/installation.log"
+destLog:    "/var/log/installation.log"

--- a/src/modules/umount/umount.conf
+++ b/src/modules/umount/umount.conf
@@ -1,3 +1,9 @@
 ---
-srcLog:     "/home/live/installation.log"
-destLog:    "/var/log/installation.log"
+scrLog:       "/path/to/installation.log"
+destLog:      "/var/log/installation.log"
+# example when using the Calamares created log:
+#srcLog:      "/root/.cache/Calamares/Calamares/Calamares.log"
+#destLog:     "/var/log/Calamares.log"
+# example when creating with a sudo calamares -d log:
+#srcLog:      "/home/live/installation.log"
+#destLog:     "/var/log/installation.log"


### PR DESCRIPTION
instead of having to hope users save an installation log before leaving live mode,
this commit gives distributions the option to have a full calamares -d log available on
the newly installed system
see the readme.md for details
this is fully tested and working properly, using the example launcher script & .desktop line
as noted in the readme