### PR TITLE
Modify Hostname input validation to accept number as first character

### DIFF
--- a/src/modules/users/UsersPage.h
+++ b/src/modules/users/UsersPage.h
@@ -65,7 +65,7 @@ private:
     Ui::Page_UserSetup* ui;
 
     const QRegExp USERNAME_RX = QRegExp( "^[a-z_][a-z0-9_-]*[$]?$" );
-    const QRegExp HOSTNAME_RX = QRegExp( "^[a-zA-Z][-a-zA-Z0-9_]*$" );
+    const QRegExp HOSTNAME_RX = QRegExp( "^[a-zA-Z0-9][-a-zA-Z0-9_]*$" );
     const int USERNAME_MAX_LENGTH = 31;
     const int HOSTNAME_MIN_LENGTH = 2;
     const int HOSTNAME_MAX_LENGTH = 24;


### PR DESCRIPTION
Input validation for Hostname accept a letter or a digit as the first character to conform to [rfc1123](http://tools.ietf.org/html/rfc1123#page-13 ) . Fixing [CAL-346](https://calamares.io/bugs/browse/CAL-346)