### PR TITLE
Enable support for 32bit UEFI systems with Grub

### DIFF
--- a/src/modules/bootloader/main.py
+++ b/src/modules/bootloader/main.py
@@ -176,7 +176,16 @@ def install_grub(efi_directory, fw_type):
             distribution = branding["bootloaderEntryName"]
             file_name_sanitizer = str.maketrans(" /", "_-")
             efi_bootloader_id = distribution.translate(file_name_sanitizer)
-        check_target_env_call([libcalamares.job.configuration["grubInstall"], "--target=x86_64-efi",
+        # get bitness of the underlying UEFI
+        try:
+            f = open("/sys/firmware/efi/fw_platform_size", "r")
+            efi_bitness = f.read(2)
+        except:
+            # if the kernel is older than 4.0, the UEFI bitness likely isn't exposed to the userspace
+            # so we assume a 64 bit UEFI here
+            efi_bitness = "64"
+        bitness_translate = {"32": "--target=i386-efi", "64": "--target=x86_64-efi"}
+        check_target_env_call([libcalamares.job.configuration["grubInstall"], bitness_translate[efi_bitness],
                            "--efi-directory={!s}".format(efi_directory),
                            "--bootloader-id={!s}".format(efi_bootloader_id),
                            "--force"])


### PR DESCRIPTION
Read the UEFI bitness exposed to the file system and install the correct
variant of Grub, depending on the UEFI bitness.