### PR TITLE
Update calamares_fr.ts

### DIFF
--- a/lang/calamares_fr.ts
+++ b/lang/calamares_fr.ts
@@ -1254,7 +1254,7 @@ L&apos;installateur se fermera et les changements seront perdus.</translation>
     <message>
         <location filename="../src/modules/users/page_usersetup.ui" line="36"/>
         <source>What is your name?</source>
-        <translation>Quel est vote nom ?</translation>
+        <translation>Quel est votre nom ?</translation>
     </message>
     <message>
         <location filename="../src/modules/users/page_usersetup.ui" line="117"/>


### PR DESCRIPTION
Fixed French typo as reported at https://issues.openmandriva.org/show_bug.cgi?id=1568