### PR TITLE
Disk selections in partitioner are not sticky[CAL-361]

### DIFF
--- a/src/modules/partition/gui/PartitionPage.h
+++ b/src/modules/partition/gui/PartitionPage.h
@@ -60,8 +60,10 @@ private:
     void editExistingPartition( Device*, Partition* );
     void updateBootLoaderInstallPath();
     void updateFromCurrentDevice();
+    void updateBootLoaderIndex();
 
     QMutex m_revertMutex;
+    int    m_lastSelectedBootLoaderIndex;
 };
 
 #endif // PARTITIONPAGE_H


### PR DESCRIPTION
FIX bug: [[CAL-361](https://calamares.io/bugs/browse/CAL-361)]

I take this approach because the bootLoadercomboBox's currentTextChanged signal triggered both when it's users manually selecting or repopulation of the core reset. It makes it hard to differentiate between the two and mark the widget as dirty accordingly, so I only save the index right before the core reset happen and select it back right after the core reset.