### PR TITLE
packageOperations should be a map between operation type and list of …

### DIFF
--- a/src/libcalamares/PythonHelper.h
+++ b/src/libcalamares/PythonHelper.h
@@ -28,7 +28,8 @@
 #include <boost/python/list.hpp>
 #include <boost/python/object.hpp>
 
-namespace CalamaresPython {
+namespace CalamaresPython
+{
 
 boost::python::object   variantToPyObject( const QVariant& variant );
 QVariant                variantFromPyObject( const boost::python::object& pyObject );
@@ -38,6 +39,9 @@ QVariantList            variantListFromPyList( const boost::python::list& pyList
 
 boost::python::dict     variantMapToPyDict( const QVariantMap& variantMap );
 QVariantMap             variantMapFromPyDict( const boost::python::dict& pyDict );
+
+boost::python::dict     variantHashToPyDict( const QVariantHash& variantHash );
+QVariantHash            variantHashFromPyDict( const boost::python::dict& pyDict );
 
 
 class Helper : public QObject

--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -124,6 +124,6 @@ def run():
         run_operations(pkgman, entry)
 
     if libcalamares.globalstorage.contains("packageOperations"):
-        run_operations(libcalamares.globalstorage.value("packageOperations"))
+        run_operations(pkgman, libcalamares.globalstorage.value("packageOperations"))
 
     return None

--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -124,9 +124,6 @@ def run():
         run_operations(pkgman, entry)
 
     if libcalamares.globalstorage.contains("packageOperations"):
-        operations = libcalamares.globalstorage.value("packageOperations")
-
-        for entry in operations:
-            run_operations(pkgman, entry)
+        run_operations(libcalamares.globalstorage.value("packageOperations"))
 
     return None


### PR DESCRIPTION
…packages. It does not make sense for it to be a list of dictionaries, all with the same format. Also makes conversions with QVariant harder.

Moreover, add conversion from/to pydict and QHash, mirroring the existing implementation for QMap. Nice addition :)

Found these while testing the netinstall module.