### PR TITLE
improve portage backend, so that properly removes reverse deps, whitout the need of HUGE package list in packages module configuration

### DIFF
--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -87,6 +87,7 @@ class PackageManager:
             check_target_env_call(["pacman", "-Rs", "--noconfirm"] + pkgs)
         elif self.backend == "portage":
             check_target_env_call(["emerge", "-C"] + pkgs)
+            check_target_env_call(["emerge", "--depclean", "-q"])
         elif self.backend == "entropy":
             check_target_env_call(["equo", "rm"] + pkgs)
 


### PR DESCRIPTION
emerge -C means remove package without checking for reverse dependencies. So in order to properly remove calamares and ALL it's reverse dependencies during system installation, one must provide a rather long list in packages module configuration.

faster way to do this is using emerge --depclean -q. It will check for reverse dependencies of packages removed with emerge -C and will clean the system. 

this line was inspired by apt backend, that uses a similar approach