### PR TITLE
displaymanager: write processed DM list to globalstorage

### DIFF
--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -295,8 +295,8 @@ def run():
     if "displaymanagers" in libcalamares.job.configuration:
         displaymanagers = libcalamares.job.configuration["displaymanagers"]
 
-    if libcalamares.globalstorage.contains("displaymanagers"):
-        displaymanagers = libcalamares.globalstorage.value("displaymanagers")
+    if libcalamares.globalstorage.contains("displayManagers"):
+        displaymanagers = libcalamares.globalstorage.value("displayManagers")
 
     if displaymanagers is None:
         return "No display managers selected for the displaymanager module.", \
@@ -434,4 +434,6 @@ def run():
     else:
         libcalamares.utils.debug("Unsetting autologin.")
 
+    libcalamares.globalstorage.insert("displayManagers", displaymanagers)
+    
     return set_autologin(username, displaymanagers, default_desktop_environment, root_mount_point)


### PR DESCRIPTION
displaymanager: write processed DM list to globalstorage so other modules can use it.

Perhaps a detection module would make sense later on, that only writes to globalstorage and collects information, eg DM or init system.
Not sure the required line in module.desc can be used to create depends? Our postcfg module consumes new global storage DM @teo 