### PR TITLE
Changes to fstab module and addition of initramfscfg module to support luks/FDE on Debian-based distros

### DIFF
--- a/src/modules/fstab/main.py
+++ b/src/modules/fstab/main.py
@@ -152,20 +152,22 @@ class FstabGenerator(object):
         if not mapper_name or not luks_uuid:
             return None
 
-        if mount_point == "/":
+        if mount_point != "/":
             return None
 
         return dict(
             name=mapper_name,
             device="UUID=" + luks_uuid,
             password="/crypto_keyfile.bin",
+            options="luks,keyscript=/bin/cat",
         )
 
     def print_crypttab_line(self, dct, file=None):
         """ Prints line to '/etc/crypttab' file. """
-        line = "{:21} {:<45} {}".format(dct["name"],
+        line = "{:21} {:<45} {} {}".format(dct["name"],
                                         dct["device"],
                                         dct["password"],
+                                        dct["options"],
                                        )
 
         print(line, file=file)

--- a/src/modules/initramfscfg/encrypt_hook
+++ b/src/modules/initramfscfg/encrypt_hook
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+  PREREQ=""
+
+  prereqs()
+  {
+          echo "$PREREQ"
+  }
+
+  case $1 in
+  # get pre-requisites
+  prereqs)
+          prereqs
+          exit 0
+          ;;
+  esac
+
+  . /usr/share/initramfs-tools/hook-functions
+  if [ -f /crypto_keyfile.bin ]
+  then
+  	cp /crypto_keyfile.bin ${DESTDIR}
+  fi
+  if [ -f /etc/crypttab ]
+  then
+  	cp /etc/crypttab ${DESTDIR}/etc/
+  fi

--- a/src/modules/initramfscfg/main.py
+++ b/src/modules/initramfscfg/main.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# === This file is part of Calamares - <http://github.com/calamares> ===
+#
+#   Copyright 2014, Rohan Garg <rohan@kde.org>
+#   Copyright 2015, Philip Müller <philm@manjaro.org>
+#   Copyright 2016, David McKinney <mckinney@subgraph.com>
+#
+#   Calamares is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Calamares is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with Calamares. If not, see <http://www.gnu.org/licenses/>.
+
+import libcalamares
+import os
+import shutil
+
+def copy_initramfs_hooks(partitions, root_mount_point):
+    """ Copies initramfs hooks so they are picked up by update-initramfs
+
+    :param partitions:
+    :param root_mount_point:
+    """
+    encrypt_hook = False
+
+    for partition in partitions:
+        if partition["mountPoint"] == "/" and "luksMapperName" in partition:
+            encrypt_hook = True
+
+    if encrypt_hook:
+        shutil.copy2("/usr/lib/calamares/modules/initramfscfg/encrypt_hook", "{!s}/usr/share/initramfs-tools/hooks/".format(root_mount_point))
+        os.chmod("{!s}/usr/share/initramfs-tools/hooks/encrypt_hook".format(root_mount_point), 0o755)
+
+def run():
+    """ Calls routine with given parameters to configure initramfs
+
+    :return:
+    """
+    partitions = libcalamares.globalstorage.value("partitions")
+    root_mount_point = libcalamares.globalstorage.value("rootMountPoint")
+    copy_initramfs_hooks(partitions, root_mount_point)
+
+    return None

--- a/src/modules/initramfscfg/module.desc
+++ b/src/modules/initramfscfg/module.desc
@@ -1,0 +1,5 @@
+---
+type:       "job"
+name:       "initramfscfg"
+interface:  "python"
+script:     "main.py"


### PR DESCRIPTION
This pull request contains the following changes:
1- Patches to the fstab module to make luks/FDE work on Debian-based distros. These were needed because the current code was failing to generate correct entries for the `/etc/crypttab` file. I have not tested this at all with Arch-based or other distros so I don't know it is will break existing setups. 


2- I also added an entire module (initramfscfg) to handle the pre-configuration of the initramfs vs update-initramfs (in the `initramfs`) module. When FDE is enabled, this module will copy a hook and the `/etc/crypttab` file into the initramfs that will be generated by update-initramfs. 

The caveat to using this module successfully in Debian live-based distros is that the packages module must be configured to removed '^live-*' packages so that update-initramfs can run properly, otherwise the initramfs hook will never run. The following `packages.conf` should suffice:
```
backend: apt

operations:
    - remove:
        - '^live-*'
```

Lastly, this does not handle the swap case. That is on my TODO list.
