### PR TITLE
[plymouthcfg] add module to configure Plymouth

### DIFF
--- a/settings.conf
+++ b/settings.conf
@@ -79,6 +79,7 @@ sequence:
   - localecfg
 #  - luksbootkeyfile
 #  - luksopenswaphookcfg
+#  - plymouthcfg
   - initcpiocfg
   - initcpio
   - users

--- a/src/modules/grubcfg/main.py
+++ b/src/modules/grubcfg/main.py
@@ -23,7 +23,6 @@ import libcalamares
 import os
 import re
 
-
 def modify_grub_default(partitions, root_mount_point, distributor):
     """ Configures '/etc/default/grub' for hibernation and plymouth.
 
@@ -35,14 +34,12 @@ def modify_grub_default(partitions, root_mount_point, distributor):
     default_dir = os.path.join(root_mount_point, "etc/default")
     default_grub = os.path.join(default_dir, "grub")
     distributor_replace = distributor.replace("'", "'\\''")
-    plymouth_bin = libcalamares.utils.target_env_call(["sh", "-c", "which plymouth"])
     use_splash = ""
     swap_uuid = ""
 
-    libcalamares.utils.debug("which plymouth exit code: {!s}".format(plymouth_bin))
-
-    if plymouth_bin == 0:
-        use_splash = "splash"
+    if libcalamares.globalstorage.contains("hasPlymouth"):
+        if libcalamares.globalstorage.value("hasPlymouth"):
+            use_splash = "splash"
 
     cryptdevice_params = []
 

--- a/src/modules/plymouthcfg/main.py
+++ b/src/modules/plymouthcfg/main.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# === This file is part of Calamares - <http://github.com/calamares> ===
+#
+#   Copyright 2016, Artoo <artoo@manjaro.org>
+#
+#   Calamares is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Calamares is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with Calamares. If not, see <http://www.gnu.org/licenses/>.
+
+import libcalamares
+
+from libcalamares.utils import debug, target_env_call
+
+
+class PlymouthController:
+
+    def __init__(self):
+        self.__root = libcalamares.globalstorage.value('rootMountPoint')
+
+    @property
+    def root(self):
+        return self.__root
+
+    def setTheme(self):
+        plymouth_theme = libcalamares.job.configuration["plymouth_theme"]
+        target_env_call(["sed", "-e", 's|^.*Theme=.*|Theme=' +
+                         plymouth_theme + '|', "-i", "/etc/plymouth/plymouthd.conf"])
+
+    def detect(self):
+        isPlymouth = target_env_call(["which", "plymouth"])
+        debug("which plymouth exit code: {!s}".format(isPlymouth))
+
+        if isPlymouth == 0:
+            libcalamares.globalstorage.insert("hasPlymouth", True)
+        else:
+            libcalamares.globalstorage.insert("hasPlymouth", False)
+
+        return isPlymouth
+
+    def run(self):
+        if self.detect() == 0:
+            if "plymouth_theme" in libcalamares.job.configuration and libcalamares.job.configuration["plymouth_theme"] is not None:
+                self.setTheme()
+        return None
+
+
+def run():
+    pc = PlymouthController()
+    return pc.run()
+

--- a/src/modules/plymouthcfg/module.desc
+++ b/src/modules/plymouthcfg/module.desc
@@ -1,0 +1,5 @@
+---
+type:       "job"
+name:       "plymouthcfg"
+interface:  "python"
+script:     "main.py"

--- a/src/modules/plymouthcfg/plymouthcfg.conf
+++ b/src/modules/plymouthcfg/plymouthcfg.conf
@@ -1,0 +1,4 @@
+---
+# The plymouth theme to be set if plymouth binary is present
+# leave commented if packaged default theme should be used
+# plymouth_theme: spinfinity


### PR DESCRIPTION
This module is used by **Manjaro Linux** to configure plymouth. It is designed to be used optionally.

* introduces globalstorage variable **hasPlymouth**
* adds new module **plymouthcfg**