### PR TITLE
add rd.luks.uuid to GRUB_CMDLINE (fixes unbootable system with dracut…

### DIFF
--- a/src/modules/grubcfg/main.py
+++ b/src/modules/grubcfg/main.py
@@ -51,7 +51,9 @@ def modify_grub_default(partitions, root_mount_point, distributor):
             cryptdevice_params = [
                 "cryptdevice=UUID={!s}:{!s}".format(partition["luksUuid"],
                                                     partition["luksMapperName"]),
-                "root=/dev/mapper/{!s}".format(partition["luksMapperName"])
+                "root=/dev/mapper/{!s}".format(partition["luksMapperName"]),
+                # Fix for unbootable system with dracut --nohostonly
+                "rd.luks.uuid={!s}."format(partition["luksUuid"])
             ]
 
     kernel_params = ["quiet"]

--- a/src/modules/grubcfg/main.py
+++ b/src/modules/grubcfg/main.py
@@ -53,7 +53,7 @@ def modify_grub_default(partitions, root_mount_point, distributor):
                                                     partition["luksMapperName"]),
                 "root=/dev/mapper/{!s}".format(partition["luksMapperName"]),
                 # Fix for unbootable system with dracut --nohostonly
-                "rd.luks.uuid={!s}."format(partition["luksUuid"])
+                "rd.luks.uuid={!s}".format(partition["luksUuid"])
             ]
 
     kernel_params = ["quiet"]


### PR DESCRIPTION
… --nohostonly, and doesn't affect any other initramfs generators)