### PR TITLE
Disallow assigning the same mountpoint to two partitions

### DIFF
--- a/src/modules/partition/gui/CreatePartitionDialog.cpp
+++ b/src/modules/partition/gui/CreatePartitionDialog.cpp
@@ -40,8 +40,9 @@
 // Qt
 #include <QComboBox>
 #include <QDir>
-#include <QSet>
 #include <QListWidgetItem>
+#include <QPushButton>
+#include <QSet>
 
 static QSet< FileSystem::Type > s_unmountableFS(
 {
@@ -52,12 +53,13 @@ static QSet< FileSystem::Type > s_unmountableFS(
     FileSystem::Lvm2_PV
 } );
 
-CreatePartitionDialog::CreatePartitionDialog( Device* device, PartitionNode* parentPartition, QWidget* parentWidget )
+CreatePartitionDialog::CreatePartitionDialog( Device* device, PartitionNode* parentPartition, const QStringList& usedMountPoints, QWidget* parentWidget )
     : QDialog( parentWidget )
     , m_ui( new Ui_CreatePartitionDialog )
     , m_partitionSizeController( new PartitionSizeController( this ) )
     , m_device( device )
     , m_parent( parentPartition )
+    , m_usedMountPoints( usedMountPoints )
 {
     m_ui->setupUi( this );
     m_ui->encryptWidget->setText( tr( "En&crypt" ) );
@@ -100,6 +102,8 @@ CreatePartitionDialog::CreatePartitionDialog( Device* device, PartitionNode* par
     // Connections
     connect( m_ui->fsComboBox, SIGNAL( activated( int ) ), SLOT( updateMountPointUi() ) );
     connect( m_ui->extendedRadioButton, SIGNAL( toggled( bool ) ), SLOT( updateMountPointUi() ) );
+
+    connect( m_ui->mountPointComboBox, &QComboBox::currentTextChanged, this, &CreatePartitionDialog::checkMountPointSelection );
 
     // Select a default
     m_ui->fsComboBox->setCurrentIndex( defaultFsIndex );
@@ -250,6 +254,18 @@ CreatePartitionDialog::updateMountPointUi()
     m_ui->mountPointComboBox->setEnabled( enabled );
     if ( !enabled )
         m_ui->mountPointComboBox->setCurrentText( QString() );
+}
+
+void
+CreatePartitionDialog::checkMountPointSelection(const QString& selection)
+{
+    if (m_usedMountPoints.contains(selection)) {
+        m_ui->labelMountPoint->setText("Mountpoint already used. Please select another one.");
+        m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+    } else {
+        m_ui->labelMountPoint->setText( QString() );
+        m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
+    }
 }
 
 void

--- a/src/modules/partition/gui/CreatePartitionDialog.cpp
+++ b/src/modules/partition/gui/CreatePartitionDialog.cpp
@@ -110,6 +110,8 @@ CreatePartitionDialog::CreatePartitionDialog( Device* device, PartitionNode* par
     updateMountPointUi();
 
     setupFlagsList();
+    // Checks the initial selection.
+    checkMountPointSelection();
 }
 
 CreatePartitionDialog::~CreatePartitionDialog()
@@ -257,10 +259,12 @@ CreatePartitionDialog::updateMountPointUi()
 }
 
 void
-CreatePartitionDialog::checkMountPointSelection(const QString& selection)
+CreatePartitionDialog::checkMountPointSelection()
 {
+    const QString& selection = m_ui->mountPointComboBox->currentText();
+
     if (m_usedMountPoints.contains(selection)) {
-        m_ui->labelMountPoint->setText("Mountpoint already used. Please select another one.");
+        m_ui->labelMountPoint->setText("Mountpoint already in use. Please select another one.");
         m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
     } else {
         m_ui->labelMountPoint->setText( QString() );

--- a/src/modules/partition/gui/CreatePartitionDialog.h
+++ b/src/modules/partition/gui/CreatePartitionDialog.h
@@ -61,7 +61,7 @@ public:
 
 private Q_SLOTS:
     void updateMountPointUi();
-    void checkMountPointSelection(const QString &);
+    void checkMountPointSelection();
 
 private:
     void setupFlagsList();

--- a/src/modules/partition/gui/CreatePartitionDialog.h
+++ b/src/modules/partition/gui/CreatePartitionDialog.h
@@ -42,7 +42,7 @@ class CreatePartitionDialog : public QDialog
 {
     Q_OBJECT
 public:
-    CreatePartitionDialog( Device* device, PartitionNode* parentPartition, QWidget* parentWidget = nullptr );
+    CreatePartitionDialog( Device* device, PartitionNode* parentPartition, const QStringList& usedMountPoints, QWidget* parentWidget = nullptr );
     ~CreatePartitionDialog();
 
     /**
@@ -61,6 +61,7 @@ public:
 
 private Q_SLOTS:
     void updateMountPointUi();
+    void checkMountPointSelection(const QString &);
 
 private:
     void setupFlagsList();
@@ -69,6 +70,7 @@ private:
     Device* m_device;
     PartitionNode* m_parent;
     PartitionRole m_role = PartitionRole( PartitionRole::None );
+    QStringList m_usedMountPoints;
 
     void initGptPartitionTypeUi();
     void initMbrPartitionTypeUi();

--- a/src/modules/partition/gui/CreatePartitionDialog.ui
+++ b/src/modules/partition/gui/CreatePartitionDialog.ui
@@ -108,7 +108,7 @@
        <property name="sizeHint" stdset="0">
         <size>
          <width>20</width>
-         <height>12</height>
+         <height>13</height>
         </size>
        </property>
       </spacer>
@@ -125,6 +125,9 @@
      </item>
      <item row="3" column="1">
       <widget class="QComboBox" name="fsComboBox"/>
+     </item>
+     <item row="4" column="1">
+      <widget class="EncryptWidget" name="encryptWidget" native="true"/>
      </item>
      <item row="5" column="1">
       <spacer name="verticalSpacer_2">
@@ -162,14 +165,26 @@
        </property>
       </widget>
      </item>
-     <item row="7" column="0">
+     <item row="7" column="1">
+      <widget class="QLabel" name="labelMountPoint">
+       <property name="font">
+        <font>
+         <italic>true</italic>
+        </font>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Flags:</string>
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
+     <item row="8" column="1">
       <widget class="QListWidget" name="m_listFlags">
        <property name="alternatingRowColors">
         <bool>true</bool>
@@ -182,7 +197,7 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="0">
+     <item row="9" column="0">
       <spacer name="verticalSpacer">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -194,9 +209,6 @@
         </size>
        </property>
       </spacer>
-     </item>
-     <item row="4" column="1">
-      <widget class="EncryptWidget" name="encryptWidget" native="true"/>
      </item>
     </layout>
    </item>

--- a/src/modules/partition/gui/EditExistingPartitionDialog.cpp
+++ b/src/modules/partition/gui/EditExistingPartitionDialog.cpp
@@ -43,13 +43,15 @@
 // Qt
 #include <QComboBox>
 #include <QDir>
+#include <QPushButton>
 
-EditExistingPartitionDialog::EditExistingPartitionDialog( Device* device, Partition* partition, QWidget* parentWidget )
+EditExistingPartitionDialog::EditExistingPartitionDialog( Device* device, Partition* partition, const QStringList& usedMountPoints, QWidget* parentWidget )
     : QDialog( parentWidget )
     , m_ui( new Ui_EditExistingPartitionDialog )
     , m_device( device )
     , m_partition( partition )
     , m_partitionSizeController( new PartitionSizeController( this ) )
+    , m_usedMountPoints( usedMountPoints )
 {
     m_ui->setupUi( this );
 
@@ -60,11 +62,14 @@ EditExistingPartitionDialog::EditExistingPartitionDialog( Device* device, Partit
     mountPoints.sort();
     m_ui->mountPointComboBox->addItems( mountPoints );
 
+    m_usedMountPoints.removeOne( PartitionInfo::mountPoint( partition ) );
+
     QColor color = ColorUtils::colorForPartition( m_partition );
     m_partitionSizeController->init( m_device, m_partition, color );
     m_partitionSizeController->setSpinBox( m_ui->sizeSpinBox );
 
     m_ui->mountPointComboBox->setCurrentText( PartitionInfo::mountPoint( partition ) );
+    connect( m_ui->mountPointComboBox, &QComboBox::currentTextChanged, this, &EditExistingPartitionDialog::checkMountPointSelection );
 
     replacePartResizerWidget();
 
@@ -290,4 +295,18 @@ EditExistingPartitionDialog::updateMountPointPicker()
     m_ui->mountPointComboBox->setEnabled( canMount );
     if ( !canMount )
         m_ui->mountPointComboBox->setCurrentText( QString() );
+}
+
+void
+EditExistingPartitionDialog::checkMountPointSelection()
+{
+    const QString& selection = m_ui->mountPointComboBox->currentText();
+
+    if (m_usedMountPoints.contains(selection)) {
+        m_ui->labelMountPoint->setText("Mountpoint already in use. Please select another one.");
+        m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+    } else {
+        m_ui->labelMountPoint->setText( QString() );
+        m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
+    }
 }

--- a/src/modules/partition/gui/EditExistingPartitionDialog.cpp
+++ b/src/modules/partition/gui/EditExistingPartitionDialog.cpp
@@ -62,8 +62,6 @@ EditExistingPartitionDialog::EditExistingPartitionDialog( Device* device, Partit
     mountPoints.sort();
     m_ui->mountPointComboBox->addItems( mountPoints );
 
-    m_usedMountPoints.removeOne( PartitionInfo::mountPoint( partition ) );
-
     QColor color = ColorUtils::colorForPartition( m_partition );
     m_partitionSizeController->init( m_device, m_partition, color );
     m_partitionSizeController->setSpinBox( m_ui->sizeSpinBox );

--- a/src/modules/partition/gui/EditExistingPartitionDialog.h
+++ b/src/modules/partition/gui/EditExistingPartitionDialog.h
@@ -40,16 +40,20 @@ class EditExistingPartitionDialog : public QDialog
 {
     Q_OBJECT
 public:
-    EditExistingPartitionDialog( Device* device, Partition* partition, QWidget* parentWidget = nullptr );
+    EditExistingPartitionDialog( Device* device, Partition* partition, const QStringList& usedMountPoints, QWidget* parentWidget = nullptr );
     ~EditExistingPartitionDialog();
 
     void applyChanges( PartitionCoreModule* module );
+
+private slots:
+    void checkMountPointSelection();
 
 private:
     QScopedPointer< Ui_EditExistingPartitionDialog > m_ui;
     Device* m_device;
     Partition* m_partition;
     PartitionSizeController* m_partitionSizeController;
+    QStringList m_usedMountPoints;
 
     PartitionTable::Flags newFlags() const;
     void setupFlagsList();

--- a/src/modules/partition/gui/EditExistingPartitionDialog.ui
+++ b/src/modules/partition/gui/EditExistingPartitionDialog.ui
@@ -139,14 +139,14 @@
      <item row="5" column="1">
       <widget class="QComboBox" name="fileSystemComboBox"/>
      </item>
-     <item row="7" column="0">
+     <item row="8" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
         <string>Flags:</string>
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
+     <item row="8" column="1">
       <widget class="QListWidget" name="m_listFlags">
        <property name="alternatingRowColors">
         <bool>true</bool>
@@ -156,6 +156,18 @@
        </property>
        <property name="sortingEnabled">
         <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QLabel" name="labelMountPoint">
+       <property name="font">
+        <font>
+         <italic>true</italic>
+        </font>
+       </property>
+       <property name="text">
+        <string/>
        </property>
       </widget>
      </item>

--- a/src/modules/partition/gui/PartitionPage.cpp
+++ b/src/modules/partition/gui/PartitionPage.cpp
@@ -280,7 +280,7 @@ PartitionPage::updatePartitionToCreate( Device* device, Partition* partition )
 void
 PartitionPage::editExistingPartition( Device* device, Partition* partition )
 {
-    QPointer<EditExistingPartitionDialog> dlg = new EditExistingPartitionDialog( device, partition, this );
+    QPointer<EditExistingPartitionDialog> dlg = new EditExistingPartitionDialog( device, partition, getCurrentUsedMountpoints(), this );
     if ( dlg->exec() == QDialog::Accepted )
         dlg->applyChanges( m_core );
     delete dlg;

--- a/src/modules/partition/gui/PartitionPage.cpp
+++ b/src/modules/partition/gui/PartitionPage.cpp
@@ -176,7 +176,7 @@ PartitionPage::onCreateClicked()
     Partition* partition = model->partitionForIndex( index );
     Q_ASSERT( partition );
 
-    QPointer<CreatePartitionDialog> dlg = new CreatePartitionDialog( model->device(), partition->parent(), this );
+    QPointer<CreatePartitionDialog> dlg = new CreatePartitionDialog( model->device(), partition->parent(), getCurrentUsedMountpoints(), this );
     dlg->initFromFreeSpace( partition );
     if ( dlg->exec() == QDialog::Accepted )
     {
@@ -265,7 +265,7 @@ PartitionPage::onPartitionViewActivated()
 void
 PartitionPage::updatePartitionToCreate( Device* device, Partition* partition )
 {
-    QPointer<CreatePartitionDialog> dlg = new CreatePartitionDialog( device, partition->parent(), this );
+    QPointer<CreatePartitionDialog> dlg = new CreatePartitionDialog( device, partition->parent(), getCurrentUsedMountpoints(), this );
     dlg->initFromPartitionToCreate( partition );
     if ( dlg->exec() == QDialog::Accepted )
     {
@@ -374,4 +374,23 @@ PartitionPage::updateBootLoaderIndex()
     if ( m_lastSelectedBootLoaderIndex >= 0 && m_ui->bootLoaderComboBox->count() ) {
         m_ui->bootLoaderComboBox->setCurrentIndex( m_lastSelectedBootLoaderIndex );
     }
+}
+
+QStringList
+PartitionPage::getCurrentUsedMountpoints()
+{
+    QModelIndex index = m_core->deviceModel()->index( m_ui->deviceComboBox->currentIndex(), 0 );
+    if ( !index.isValid() )
+        return QStringList();
+
+    Device* device = m_core->deviceModel()->deviceForIndex( index );
+    QStringList mountPoints;
+
+    for (Partition* partition : device->partitionTable()->children()) {
+        if (!partition->mountPoint().isEmpty()) {
+            mountPoints << partition->mountPoint();
+        }
+    }
+
+    return mountPoints;
 }

--- a/src/modules/partition/gui/PartitionPage.cpp
+++ b/src/modules/partition/gui/PartitionPage.cpp
@@ -266,7 +266,10 @@ PartitionPage::onPartitionViewActivated()
 void
 PartitionPage::updatePartitionToCreate( Device* device, Partition* partition )
 {
-    QPointer<CreatePartitionDialog> dlg = new CreatePartitionDialog( device, partition->parent(), getCurrentUsedMountpoints(), this );
+    QStringList mountPoints = getCurrentUsedMountpoints();
+    mountPoints.removeOne( PartitionInfo::mountPoint( partition ) );
+
+    QPointer<CreatePartitionDialog> dlg = new CreatePartitionDialog( device, partition->parent(), mountPoints, this );
     dlg->initFromPartitionToCreate( partition );
     if ( dlg->exec() == QDialog::Accepted )
     {
@@ -280,7 +283,10 @@ PartitionPage::updatePartitionToCreate( Device* device, Partition* partition )
 void
 PartitionPage::editExistingPartition( Device* device, Partition* partition )
 {
-    QPointer<EditExistingPartitionDialog> dlg = new EditExistingPartitionDialog( device, partition, getCurrentUsedMountpoints(), this );
+    QStringList mountPoints = getCurrentUsedMountpoints();
+    mountPoints.removeOne( PartitionInfo::mountPoint( partition ) );
+
+    QPointer<EditExistingPartitionDialog> dlg = new EditExistingPartitionDialog( device, partition, mountPoints, this );
     if ( dlg->exec() == QDialog::Accepted )
         dlg->applyChanges( m_core );
     delete dlg;

--- a/src/modules/partition/gui/PartitionPage.cpp
+++ b/src/modules/partition/gui/PartitionPage.cpp
@@ -23,6 +23,7 @@
 #include "core/BootLoaderModel.h"
 #include "core/DeviceModel.h"
 #include "core/PartitionCoreModule.h"
+#include "core/PartitionInfo.h"
 #include "core/PartitionModel.h"
 #include "core/KPMHelpers.h"
 #include "gui/CreatePartitionDialog.h"
@@ -387,8 +388,10 @@ PartitionPage::getCurrentUsedMountpoints()
     QStringList mountPoints;
 
     for (Partition* partition : device->partitionTable()->children()) {
-        if (!partition->mountPoint().isEmpty()) {
-            mountPoints << partition->mountPoint();
+        const QString& mountPoint = PartitionInfo::mountPoint( partition );
+
+        if (!mountPoint.isEmpty()) {
+            mountPoints << mountPoint;
         }
     }
 

--- a/src/modules/partition/gui/PartitionPage.h
+++ b/src/modules/partition/gui/PartitionPage.h
@@ -62,6 +62,8 @@ private:
     void updateFromCurrentDevice();
     void updateBootLoaderIndex();
 
+    QStringList getCurrentUsedMountpoints();
+
     QMutex m_revertMutex;
     int    m_lastSelectedBootLoaderIndex;
 };


### PR DESCRIPTION
When creating/editing a partition, get a list of mountpoints that were already "assigned" to other partitions (minus the current one, if it exists). In case the user tries to assign one of these mountpoints in the dialog, display an italic error message just below the combo box, and disable the Ok button of the dialog.

This fixes https://calamares.io/bugs/projects/CAL/issues/CAL-58

Tested in a Virtualbox with Chakra.