### PR TITLE
Allow passing a LOCALE variable in the package list

### DIFF
--- a/src/modules/locale/LocaleConfiguration.cpp
+++ b/src/modules/locale/LocaleConfiguration.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "LocaleConfiguration.h"
+#include <QLocale>
 
 LocaleConfiguration::LocaleConfiguration()
 {
@@ -41,6 +42,7 @@ LocaleConfiguration::fromLanguageAndLocation( const QString& languageLocale,
 {
     LocaleConfiguration lc = LocaleConfiguration();
     QString language = languageLocale.split( '_' ).first();
+    lc.myLanguageLocaleBcp47 = QLocale(language).bcp47Name();
 
     QStringList linesForLanguage;
     for ( const QString &line : availableLocales )

--- a/src/modules/locale/LocaleConfiguration.h
+++ b/src/modules/locale/LocaleConfiguration.h
@@ -38,6 +38,7 @@ public:
     // avoid confusion with locale.h.
     QString lang, lc_numeric, lc_time, lc_monetary, lc_paper, lc_name, lc_address,
             lc_telephone, lc_measurement, lc_identification;
+    QString myLanguageLocaleBcp47;
     QMap< QString, QString > toMap();
 };
 

--- a/src/modules/locale/LocalePage.cpp
+++ b/src/modules/locale/LocalePage.cpp
@@ -474,6 +474,8 @@ LocalePage::updateGlobalStorage()
             ->insert( "locationRegion", location.region );
     Calamares::JobQueue::instance()->globalStorage()
             ->insert( "locationZone", location.zone );
+    Calamares::JobQueue::instance()->globalStorage()
+            ->insert( "locale", m_selectedLocaleConfiguration.myLanguageLocaleBcp47);
 
     // If we're in chroot mode (normal install mode), then we immediately set the
     // timezone on the live system.

--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -21,7 +21,7 @@
 import subprocess
 import libcalamares
 from libcalamares.utils import check_target_env_call, target_env_call
-
+from string import Template
 
 class PackageManager:
     """ Package manager class.
@@ -109,6 +109,20 @@ class PackageManager:
             check_target_env_call(["equo", "update"])
 
 
+def subst_locale(list):
+    ret = []
+    locale = libcalamares.globalstorage.value("locale")
+    if locale:
+        for e in list:
+            if  locale != "en":
+                entry = Template(e)
+                ret.append(entry.safe_substitute(LOCALE=locale))
+            elif 'LOCALE' not in e:
+                ret.append(e)
+    else:
+        ret = list
+    return ret
+
 def run_operations(pkgman, entry):
     """ Call package manager with given parameters.
 
@@ -116,6 +130,7 @@ def run_operations(pkgman, entry):
     :param entry:
     """
     for key in entry.keys():
+        entry[key] = subst_locale(entry[key])
         if key == "install":
             pkgman.install(entry[key])
         elif key == "try_install":


### PR DESCRIPTION
This allows for installing locale packages. This can be achieved
by adding a entry of the format packagename-${LOCALE} in the
packages configuration module.