### PR TITLE
returns if there is a real connection and not only the enabled device

### DIFF
--- a/src/modules/welcome/checker/RequirementsChecker.cpp
+++ b/src/modules/welcome/checker/RequirementsChecker.cpp
@@ -36,7 +36,9 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QLabel>
-#include <QNetworkAccessManager>
+#include <QNetworkConfigurationManager>
+#include <QNetworkConfiguration>
+
 #include <QProcess>
 #include <QTimer>
 
@@ -337,8 +339,20 @@ RequirementsChecker::checkHasPower()
 bool
 RequirementsChecker::checkHasInternet()
 {
-    // default to true in the QNetworkAccessManager::UnknownAccessibility case
-    bool hasInternet = QNetworkAccessManager(this).networkAccessible() != QNetworkAccessManager::NotAccessible;
+    // doc from: https://doc.qt.io/qt-5/qnetworkconfigurationmanager.html#isOnline
+    bool hasInternet = false;
+
+    QNetworkConfigurationManager mgr;
+    QList<QNetworkConfiguration> activeConfigs = mgr.allConfigurations(QNetworkConfiguration::Active);
+
+    if (activeConfigs.count() > 0) {
+        Q_ASSERT(mgr.isOnline());
+        hasInternet = mgr.isOnline();
+    }
+    else {
+        Q_ASSERT(!mgr.isOnline());
+    }
+
     Calamares::JobQueue::instance()->globalStorage()->insert( "hasInternet", hasInternet );
     return hasInternet;
 }


### PR DESCRIPTION
refactoring of the checkHasInternet() function.
based on https://doc.qt.io/qt-5/qnetworkconfigurationmanager.html#isOnline the isOnline returns the real status if the connection is available, no ping requests are required.

This patch should fix CAL-404 and CAL-432