### PR TITLE
partition: use always double click to activate a partition tree view item

### DIFF
--- a/src/modules/partition/gui/PartitionPage.cpp
+++ b/src/modules/partition/gui/PartitionPage.cpp
@@ -96,7 +96,7 @@ PartitionPage::PartitionPage( PartitionCoreModule* core, QWidget* parent )
 
     connect( m_core, &PartitionCoreModule::isDirtyChanged, m_ui->revertButton, &QWidget::setEnabled );
 
-    connect( m_ui->partitionTreeView, &QAbstractItemView::activated, this, &PartitionPage::onPartitionViewActivated );
+    connect( m_ui->partitionTreeView, &QAbstractItemView::doubleClicked, this, &PartitionPage::onPartitionViewActivated );
     connect( m_ui->revertButton, &QAbstractButton::clicked, this, &PartitionPage::onRevertClicked );
     connect( m_ui->newPartitionTableButton, &QAbstractButton::clicked, this, &PartitionPage::onNewPartitionTableClicked );
     connect( m_ui->createButton, &QAbstractButton::clicked, this, &PartitionPage::onCreateClicked );


### PR DESCRIPTION
Using activated signal may use single or double click depending on environment settings.

At Manjaro we tested with **sudo** only. There it is always double-click also without our patch. However by using **sudo -E** or **pkgexec** with [additional theme patch](https://github.com/manjaro/packages-extra/blob/master/polkit/x11vars.patch) it always resulted in the way how the environment settings were configured for mouse behaviour.

This patch fixes it, to have always double-click for selecting partitions.