### PR TITLE
Switch from pep8 to pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ notifications:
 
 install:
   - docker build -t calamares .
-  - pip install pep8
+  - pip install pycodestyle
 
 script:
   - docker run -v $PWD:/build calamares bash -lc "cd /build && cmake -DWEBVIEW_FORCE_WEBKIT=1 -DKDE_INSTALL_USE_QT_SYS_PATHS=ON . && make -j2"
-  - pep8 $PWD
+  - pycodestyle $PWD


### PR DESCRIPTION
Reason: pycodestyle is the successor of pep8, same team, same program
        different name
        https://github.com/PyCQA/pycodestyle

```
/home/travis/build/calamares/calamares/src/modules/bootloader/main.py:113:35: W503 line break before binary operator
/home/travis/build/calamares/calamares/src/modules/bootloader/main.py:114:35: W503 line break before binary operator
/home/travis/build/calamares/calamares/src/modules/bootloader/main.py:115:35: W503 line break before binary operator
/home/travis/build/calamares/calamares/src/modules/bootloader/main.py:117:35: W503 line break before binary operator
/home/travis/build/calamares/calamares/src/modules/bootloader/main.py:318:13: W503 line break before binary operator
```
with the latest pep8 changes it isn't a warning anymore - it's now the preferred coding style.
https://github.com/PyCQA/pycodestyle/issues/197