### PR TITLE
Fix unknown partition-type Fat32 at mount and in fstab

### DIFF
--- a/src/modules/fstab/main.py
+++ b/src/modules/fstab/main.py
@@ -224,7 +224,7 @@ class FstabGenerator(object):
 
     def generate_fstab_line_info(self, partition):
         """ Generates information for each fstab entry. """
-        filesystem = partition["fs"]
+        filesystem = partition["fs"].lower()
         mount_point = partition["mountPoint"]
         disk_name = disk_name_for_partition(partition)
         is_ssd = disk_name in self.ssd_disks

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -38,7 +38,7 @@ def mount_partitions(root_mount_point, partitions):
         # Create mount point with `+` rather than `os.path.join()` because
         # `partition["mountPoint"]` starts with a '/'.
         mount_point = root_mount_point + partition["mountPoint"]
-        fstype = partition.get("fs", "")
+        fstype = partition.get("fs", "").lower()
 
         if fstype == "fat16" or fstype == "fat32":
             fstype = "vfat"


### PR DESCRIPTION
Only the string "fat32" and "fat16" will be replaced with vfat. If an
case sensitive "Fat32" some problems occure:
- mount: partition cannot be mounted (e.g. a fat32 efi partition)
- fstab: system won't even boot because fstab does not know the type "Fat32"