### PR TITLE
Add "MB" suffix to the "edit partition" size box.

### DIFF
--- a/src/modules/partition/gui/CreatePartitionDialog.ui
+++ b/src/modules/partition/gui/CreatePartitionDialog.ui
@@ -45,7 +45,7 @@
      <item row="0" column="1">
       <widget class="QSpinBox" name="sizeSpinBox">
        <property name="suffix">
-        <string> MB</string>
+        <string> MiB</string>
        </property>
       </widget>
      </item>

--- a/src/modules/partition/gui/EditExistingPartitionDialog.ui
+++ b/src/modules/partition/gui/EditExistingPartitionDialog.ui
@@ -126,7 +126,7 @@
      <item row="1" column="1">
       <widget class="QSpinBox" name="sizeSpinBox">
        <property name="suffix">
-        <string> MB</string>
+        <string> MiB</string>
        </property>
       </widget>
      </item>

--- a/src/modules/partition/gui/EditExistingPartitionDialog.ui
+++ b/src/modules/partition/gui/EditExistingPartitionDialog.ui
@@ -124,7 +124,11 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QSpinBox" name="sizeSpinBox"/>
+      <widget class="QSpinBox" name="sizeSpinBox">
+       <property name="suffix">
+        <string> MB</string>
+       </property>
+      </widget>
      </item>
      <item row="5" column="0">
       <widget class="QLabel" name="fileSystemLabel">


### PR DESCRIPTION
Makes it easier to know which unit Calamares is using when
resizing a partition. The "Create partition" dialog has
it already.