### PR TITLE
CreateUserJob: do not force any autologin group

### DIFF
--- a/src/modules/users/CreateUserJob.cpp
+++ b/src/modules/users/CreateUserJob.cpp
@@ -115,13 +115,12 @@ CreateUserJob::exec()
     {
         QString autologinGroup;
         if ( gs->contains( "autologinGroup" ) &&
-             !gs->value( "autologinGroup" ).toString().isEmpty() )
+                !gs->value( "autologinGroup" ).toString().isEmpty() )
+        {
             autologinGroup = gs->value( "autologinGroup" ).toString();
-        else
-            autologinGroup = QStringLiteral( "autologin" );
-
-        CalamaresUtils::System::instance()->targetEnvCall( { "groupadd", autologinGroup } );
-        defaultGroups.append( QString( ",%1" ).arg( autologinGroup ) );
+            CalamaresUtils::System::instance()->targetEnvCall( { "groupadd", autologinGroup } );
+            defaultGroups.append( QString( ",%1" ).arg( autologinGroup ) );
+        }
     }
 
     // If we're looking to reuse the contents of an existing /home


### PR DESCRIPTION
 There is no need to force folks haing a random group
 bc that is a Distro think. SDDM/GDM works just fine without
 having a group for the user to autologin.
 Just setup a group in users.conf .. is why we have a configuration
 option for that.