### PR TITLE
use orphaned Branding::ProductLogo as sidebar image

### DIFF
--- a/src/calamares/CalamaresWindow.cpp
+++ b/src/calamares/CalamaresWindow.cpp
@@ -96,7 +96,7 @@ CalamaresWindow::CalamaresWindow( QWidget* parent )
     logoLabel->setAlignment( Qt::AlignCenter );
     logoLabel->setFixedSize( 80, 80 );
     logoLabel->setPixmap( Calamares::Branding::instance()->
-                          image( Calamares::Branding::ProductIcon,
+                          image( Calamares::Branding::ProductLogo,
                                  logoLabel->size() ) );
     logoLayout->addWidget( logoLabel );
     logoLayout->addStretch();


### PR DESCRIPTION
the 'productLogo' field in src/branding/default/branding.desc is loaded into the 'Branding::ProductLogo' entity in src/libcalamaresui/Branding.cpp but never actually used anywhere in the program - the image entity 'Branding::ProductIcon' that is currently used for the sidebar is the same one that is used for the much smaller WM/DE icon  - it appears that the original intention was for the sidebar image to use the 'Branding::ProductLogo' entity and that the current  'Branding::ProductIcon' was probably a typo - note that it is rendered inside of a 'logoLabel' inside of a 'logoLayout'