### PR TITLE
finished: use generic shutdown command

### DIFF
--- a/src/modules/finished/FinishedViewStep.cpp
+++ b/src/modules/finished/FinishedViewStep.cpp
@@ -178,7 +178,7 @@ FinishedViewStep::setConfigurationMap( const QVariantMap& configurationMap )
                     configurationMap.value( "restartNowCommand" ).type() == QVariant::String )
                 m_widget->setRestartNowCommand( configurationMap.value( "restartNowCommand" ).toString() );
             else
-                m_widget->setRestartNowCommand( "systemctl -i reboot" );
+                m_widget->setRestartNowCommand( "shutdown -r now" );
         }
     }
     if ( configurationMap.contains( "notifyOnFinished" ) &&


### PR DESCRIPTION
- it doesn't make any sense to have restartNowCommand and fallback
  set to the same command.
- also fallback should be something generic every init supports