### PR TITLE
use private env var for travis IRC notify channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 
 notifications:
   irc:
-    - "chat.freenode.net#calamares"
+    - "$IRC_NOTIFY_CHANNEL"
 
 install:
   - docker build -t calamares .


### PR DESCRIPTION
this will (hopefully) prevent downstreams CI from notifying the upstream IRC channel

NOTE: in order to notify IRC, someone from each fork with access to the travis account will need to declare an environment variable in the travis control panel

for the upstream that would be like:

IRC_NOTIFY_CHANNEL with a value of chat.freenode.net#calamares


unrelated: but i noticed some warnings with the .travis.yml
```
$ travis lint ./.travis.yml
Warnings for ./.travis.yml:
[x] in language section: does not support multiple values, dropping python
[x] specified python, but setting is not relevant for cpp
```