### PR TITLE
RequirementsChecker.cpp: rearrange cDebug() output

### DIFF
--- a/src/modules/welcome/checker/RequirementsChecker.cpp
+++ b/src/modules/welcome/checker/RequirementsChecker.cpp
@@ -2,6 +2,7 @@
  *
  *   Copyright 2014-2017, Teo Mrnjavac <teo@kde.org>
  *   Copyright 2017, Adriaan de Groot <groot@kde.org>
+ *   Copyright 2017, Gabriel Craciunescu <crazy@frugalware.org>
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -99,8 +100,12 @@ RequirementsChecker::RequirementsChecker( QObject* parent )
         if ( m_entriesToCheck.contains( "root" ) )
             isRoot = checkIsRoot();
 
-        cDebug() << "enoughStorage, enoughRam, hasPower, hasInternet, isRoot: "
-                 << enoughStorage << enoughRam << hasPower << hasInternet << isRoot;
+        cDebug() << "RequirementsChecker output:"
+                 << " enoughStorage:" << enoughStorage
+                 << " enoughRam:" << enoughRam
+                 << " hasPower:" << hasPower
+                 << " hasInternet:" << hasInternet
+                 << " isRoot:" << isRoot;
 
         QList< PrepareEntry > checkEntries;
         foreach ( const QString& entry, m_entriesToCheck )


### PR DESCRIPTION
sending now without fixes for /partition/ ( these after KPMcore things )
and /users/ ( will open an extra PR since the configuration file need some fixes too)