### PR TITLE
new module : openrcdmcryptcfg - auto unlock encrypted partitions with OpenRC

### DIFF
--- a/src/modules/openrcdmcryptcfg/main.py
+++ b/src/modules/openrcdmcryptcfg/main.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# === This file is part of Calamares - <http://github.com/calamares> ===
+#
+#   Copyright 2017, Ghiunhan Mamut <venerix@redcorelinux.org>
+#
+#   Calamares is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Calamares is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with Calamares. If not, see <http://www.gnu.org/licenses/>.
+
+import libcalamares
+import os.path
+
+def write_dmcrypt_conf(partitions, root_mount_point, dmcrypt_conf_path):
+    crypto_target = ""
+    crypto_source = ""
+
+    for partition in partitions:
+        has_luks = "luksMapperName" in partition
+        skip_partitions = partition["mountPoint"] == "/" or partition["fs"] == "linuxswap"
+
+        if not has_luks and not skip_partitions:
+            libcalamares.utils.debug(
+                "Skip writing OpenRC LUKS configuration for partition {!s}".format(partition["mountPoint"]))
+
+        if has_luks and not skip_partitions:
+            crypto_target = partition["luksMapperName"]
+            crypto_source = "/dev/disk/by-uuid/{!s}".format(partition["uuid"])
+            libcalamares.utils.debug(
+                "Writing OpenRC LUKS configuration for partition {!s}".format(partition["mountPoint"]))
+
+            with open(os.path.join(root_mount_point, dmcrypt_conf_path), 'a+') as dmcrypt_file:
+                dmcrypt_file.write("\ntarget=" + crypto_target)
+                dmcrypt_file.write("\nsource=" + crypto_source)
+                dmcrypt_file.write("\nkey=/crypto_keyfile.bin")
+                dmcrypt_file.write("\n")
+
+        if has_luks and skip_partitions:
+            pass  # root and swap partitions should be handled by initramfs generators
+
+    return None
+
+def run():
+    """
+    This module configures OpenRC dmcrypt service for LUKS encrypted partitions.
+    :return:
+    """
+
+    root_mount_point = libcalamares.globalstorage.value("rootMountPoint")
+    dmcrypt_conf_path = libcalamares.job.configuration["configFilePath"]
+    partitions = libcalamares.globalstorage.value("partitions")
+
+    dmcrypt_conf_path = dmcrypt_conf_path.lstrip('/')
+
+    return write_dmcrypt_conf(partitions, root_mount_point, dmcrypt_conf_path)

--- a/src/modules/openrcdmcryptcfg/module.desc
+++ b/src/modules/openrcdmcryptcfg/module.desc
@@ -1,0 +1,5 @@
+---
+type:       "job"
+name:       "openrcdmcryptcfg"
+interface:  "python"
+script:     "main.py"

--- a/src/modules/openrcdmcryptcfg/openrcdmcryptcfg.conf
+++ b/src/modules/openrcdmcryptcfg/openrcdmcryptcfg.conf
@@ -1,0 +1,2 @@
+---
+configFilePath: /etc/conf.d/dmcrypt


### PR DESCRIPTION
Unlike systemd, OpenRC doesn't have a cryptsetup-generator which translates crypttab into native units, so one has to configure /etc/conf.d/dmcrypt in order to auto-unlock LUKS partitions (other than /root and swap which are handled by dracut, initcpio, or whatever initramfs generator) during system boot.

This module will allow to have any number of encrypted partitions on distributions using OpenRC. It will gatter the information needed from **globalstorage** and write it into **/etc/conf.d/dmcrypt**, so when OpenRC fires up dmcrypt service, it will unlock the partitions using the crypto_keyfile.bin .

This is an example of what it will write in /etc/conf.d/dmcrypt :

target=luks-152eced5-3a76-4645-8888-3eaab8193185
source=/dev/disk/by-uuid/152eced5-3a76-4645-8888-3eaab8193185
key=/crypto_keyfile.bin

And an output of OpenRC auto-unlocking the partition on a fresh install using this module patched in :

    Setting up dm-crypt mappings ...
    luks-152eced5-3a76-4645-8888-3eaab8193185 using: open /dev/disk/by-uuid/152eced5-3a76-4645-8888-3eaab8193185 luks-152eced5-3a76-4645-8888-3eaab8193185 ...

The module has been tested using multiple encrypted partitions on Redcore Linux, a Gentoo based distribution which uses OpenRC as init system, and it should work on any distribution that uses OpenRC. Any tests or feedback from Manjaro/Artix guys will be highly appreciated.

This is my second attempt to merge this. While the previous code only supported unlocking $HOME partition, the current improved code will work with any partition user chooses to encrypt. I did run autopep8 on the code, so CI shouldn't complain about it.