### PR TITLE
[unpackfs] skip error check when rm of tmp folder fails

### DIFF
--- a/src/modules/unpackfs/main.py
+++ b/src/modules/unpackfs/main.py
@@ -218,7 +218,7 @@ class UnpackOperation:
 
             return None
         finally:
-            shutil.rmtree(source_mount_path)
+            shutil.rmtree(source_mount_path, ignore_errors=True, onerror=None)
 
     def mount_image(self, entry, imgmountdir):
         """


### PR DESCRIPTION
but it does without help

Unhandled exeptions are bad in calamares - and backtraces not exactly user-friendly.