### PR TITLE
Enable the correct language in the locale.gen list

### DIFF
--- a/src/modules/localecfg/main.py
+++ b/src/modules/localecfg/main.py
@@ -65,12 +65,15 @@ def run():
         with open("{!s}/etc/locale.gen".format(install_path), "w") as gen:
             for line in text:
                 # always enable en_US
-                if en_us_locale in line and line[0] == "#":
+                if line.startswith(en_us_locale, 1):
                     # uncomment line
                     line = line[1:].lstrip()
 
                 for locale_value in locale_values:
-                    if locale_value in line and line[0] == "#":
+                    # check the locale value starting from
+                    # the second index because we expect that
+                    # the first one is a '#'
+                    if line.startswith(locale_value, 1):
                         # uncomment line
                         line = line[1:].lstrip()
 

--- a/src/modules/localecfg/main.py
+++ b/src/modules/localecfg/main.py
@@ -65,15 +65,12 @@ def run():
         with open("{!s}/etc/locale.gen".format(install_path), "w") as gen:
             for line in text:
                 # always enable en_US
-                if line.startswith(en_us_locale, 1):
+                if line.startswith("#" + en_us_locale):
                     # uncomment line
                     line = line[1:].lstrip()
 
                 for locale_value in locale_values:
-                    # check the locale value starting from
-                    # the second index because we expect that
-                    # the first one is a '#'
-                    if line.startswith(locale_value, 1):
+                    if line.startswith("#" + locale_value):
                         # uncomment line
                         line = line[1:].lstrip()
 


### PR DESCRIPTION
The original code does not distinguish the document comments inside the locale.gen file from the real locale list. The language was then enabled from the header comments of the file instead of the correct value in the list.

The new code verify that the complete locale string is just after the first character of the string, enabling only the correct value of the locale list.
An example:
```
#  en_US.UTF-8 UTF-8 --> document header, should not be enabled
#en_US.UTF-8 UTF-8 --> correct section to enable
```

Related to this request:
https://code.chakralinux.org/tools/calamares-chakra/issues/2