### PR TITLE
Never show Calamares in software centers

### DIFF
--- a/calamares.desktop
+++ b/calamares.desktop
@@ -11,7 +11,7 @@ Icon=calamares
 Terminal=false
 StartupNotify=true
 Categories=Qt;System;
-
+X-AppStream-Ignore=true
 
 
 


### PR DESCRIPTION
Users will never want to install the distribution installer from a
software center like KDE Discover or GNOME Software, so exclude it from
the AppStream metadata collection.