### PR TITLE
[partition] Ignoring LVM devices in PartUtils::getDevices to prevent installing bootloader in LVM VG.

### DIFF
--- a/src/modules/partition/core/DeviceList.cpp
+++ b/src/modules/partition/core/DeviceList.cpp
@@ -129,7 +129,12 @@ QList< Device* > getDevices( DeviceType which, qint64 minimumSize )
 
     // Remove the device which contains / from the list
     for ( DeviceList::iterator it = devices.begin(); it != devices.end(); )
-        if ( ! ( *it ) ||
+        if ( (*it)->type() != Device::Type::Disk_Device )
+        {
+            cDebug() << " .. Removing device that is not a Disk_Device from list " << it;
+            it = erase(devices, it );
+        }
+        else if ( ! ( *it ) ||
                 ( *it )->deviceNode().startsWith( "/dev/zram" )
         )
         {
@@ -150,11 +155,6 @@ QList< Device* > getDevices( DeviceType which, qint64 minimumSize )
         else if ( (minimumSize >= 0) && !( (*it)->capacity() > minimumSize ) )
         {
             cDebug() << "  .. Removing too-small" << it;
-            it = erase(devices, it );
-        }
-        else if ( (*it)->type() == Device::LVM_Device )
-        {
-            cDebug() << " .. Removing LVM device from list " << it;
             it = erase(devices, it );
         }
         else

--- a/src/modules/partition/core/DeviceList.cpp
+++ b/src/modules/partition/core/DeviceList.cpp
@@ -152,6 +152,11 @@ QList< Device* > getDevices( DeviceType which, qint64 minimumSize )
             cDebug() << "  .. Removing too-small" << it;
             it = erase(devices, it );
         }
+        else if ( (*it)->type() == Device::LVM_Device )
+        {
+            cDebug() << " .. Removing LVM device from list " << it;
+            it = erase(devices, it );
+        }
         else
             ++it;
 

--- a/src/modules/partition/gui/CreatePartitionDialog.cpp
+++ b/src/modules/partition/gui/CreatePartitionDialog.cpp
@@ -261,7 +261,9 @@ CreatePartitionDialog::updateMountPointUi()
         FileSystem::Type type = FileSystem::typeForName( m_ui->fsComboBox->currentText() );
         enabled = !s_unmountableFS.contains( type );
 
-        if ( FS::luks::canEncryptType( type ) )
+        if ( FileSystemFactory::map()[FileSystem::Type::Luks]->supportCreate() &&
+             FS::luks::canEncryptType( type ) &&
+             !m_role.has( PartitionRole::Extended ) )
         {
             m_ui->encryptWidget->show();
             m_ui->encryptWidget->reset();


### PR DESCRIPTION
Related to: https://github.com/calamares/calamares/issues/887