### PR TITLE
[partition] Only bootloader model should ignore devices that are not of Disk_Device type

### DIFF
--- a/src/modules/partition/core/DeviceList.cpp
+++ b/src/modules/partition/core/DeviceList.cpp
@@ -129,12 +129,7 @@ QList< Device* > getDevices( DeviceType which, qint64 minimumSize )
 
     // Remove the device which contains / from the list
     for ( DeviceList::iterator it = devices.begin(); it != devices.end(); )
-        if ( (*it)->type() != Device::Type::Disk_Device )
-        {
-            cDebug() << " .. Removing device that is not a Disk_Device from list " << it;
-            it = erase(devices, it );
-        }
-        else if ( ! ( *it ) ||
+        if ( ! ( *it ) ||
                 ( *it )->deviceNode().startsWith( "/dev/zram" )
         )
         {

--- a/src/modules/partition/core/PartitionCoreModule.cpp
+++ b/src/modules/partition/core/PartitionCoreModule.cpp
@@ -164,7 +164,18 @@ PartitionCoreModule::doInit()
     for ( auto deviceInfo : m_deviceInfos )
         deviceInfo->partitionModel->init( deviceInfo->device.data(), m_osproberLines );
 
-    m_bootLoaderModel->init( devices );
+    DeviceList bootLoaderDevices;
+
+    for ( DeviceList::Iterator it = devices.begin(); it != devices.end(); ++it)
+        if ( (*it)->type() != Device::Type::Disk_Device )
+        {
+            cDebug() << "Ignoring device that is not Disk_Device to bootLoaderDevices list.";
+            continue;
+        }
+        else
+            bootLoaderDevices.append(*it);
+
+    m_bootLoaderModel->init( bootLoaderDevices );
 
     //FIXME: this should be removed in favor of
     //       proper KPM support for EFI


### PR DESCRIPTION
Fixing bug related to https://github.com/calamares/calamares/pull/945, because only bootloader model should ignore devices that aren't of Disk_Device type in PartitionCoreModule::doInit().