### PR TITLE
Update CreateUserJob.cpp

### DIFF
--- a/src/modules/users/CreateUserJob.cpp
+++ b/src/modules/users/CreateUserJob.cpp
@@ -149,8 +149,6 @@ CreateUserJob::exec()
     int ec = CalamaresUtils::System::instance()->
              targetEnvCall( { "useradd",
                               "-m",
-                              "-s",
-                              "/bin/bash",
                               "-U",
                               "-c",
                               m_fullName,


### PR DESCRIPTION
Removal of the hardcoded shell, letting the `/etc/default/useradd` be responsible for the shell.

```
# useradd defaults file for Manjaro Linux
# useradd defaults file for ArchLinux
# original changes by TomK
GROUP=users
HOME=/home
INACTIVE=-1
EXPIRE=
SHELL=/bin/zsh
SKEL=/etc/skel
CREATE_MAIL_SPOOL=no

```