### PR TITLE
avoid pinging hard-coded server for netinstall.yaml

### DIFF
--- a/src/modules/netinstall/netinstall.conf
+++ b/src/modules/netinstall/netinstall.conf
@@ -1,7 +1,10 @@
 ---
 # This is the URL that is retrieved to get the netinstall groups-and-packages
-# data (which should be in the format described in netinstall.yaml).
-groupsUrl: http://chakraos.org/netinstall.php
+# data (which should be in the format described in netinstall.yaml), e.g.:
+#   groupsUrl: http://example.org/netinstall.php
+# or it can be a locally installed file:
+#   groupsUrl: file:///usr/share/calamares/netinstall.yaml
+# groupsUrl: file:///usr/share/calamares/netinstall.yaml
 
 # If the installation can proceed without netinstall (e.g. the Live CD
 # can create a working installed system, but netinstall is preferred


### PR DESCRIPTION
groupsUrl is optional and should be commented out by default - also this URL is 404 - also only chakra would ever want to ping the chakra server anyways