### PR TITLE
Branding

### DIFF
--- a/src/calamares/CalamaresWindow.cpp
+++ b/src/calamares/CalamaresWindow.cpp
@@ -35,6 +35,7 @@
 #include <QLabel>
 #include <QTreeView>
 #include <QFile>
+#include <QFileInfo>
 
 CalamaresWindow::CalamaresWindow( QWidget* parent )
     : QWidget( parent )
@@ -161,7 +162,7 @@ CalamaresWindow::CalamaresWindow( QWidget* parent )
     QString brandingQSSDescriptorPath = QString( "/etc/calamares/branding/%1/stylesheet.qss" )
                                         .arg( brandingComponentName );
 
-    importQSSPath = QFileInfo( brandingQSSDescriptorPath );
+    QFileInfo importQSSPath = QFileInfo( brandingQSSDescriptorPath );
     if ( importQSSPath.exists() && importQSSPath.isReadable() )
     {
         QFile File(importQSSPath);

--- a/src/calamares/CalamaresWindow.cpp
+++ b/src/calamares/CalamaresWindow.cpp
@@ -165,7 +165,7 @@ CalamaresWindow::CalamaresWindow( QWidget* parent )
     QFileInfo importQSSPath = QFileInfo( brandingQSSDescriptorPath );
     if ( importQSSPath.exists() && importQSSPath.isReadable() )
     {
-        QFile File(importQSSPath);
+        QFile File(brandingQSSDescriptorPath);
         File.open(QFile::ReadOnly);
         QString StyleSheet = QLatin1String(File.readAll());
         this->setStyleSheet(StyleSheet);

--- a/src/calamares/CalamaresWindow.cpp
+++ b/src/calamares/CalamaresWindow.cpp
@@ -34,6 +34,7 @@
 #include <QDesktopWidget>
 #include <QLabel>
 #include <QTreeView>
+#include <QFile>
 
 CalamaresWindow::CalamaresWindow( QWidget* parent )
     : QWidget( parent )
@@ -51,7 +52,8 @@ CalamaresWindow::CalamaresWindow( QWidget* parent )
     using CalamaresUtils::windowPreferredWidth;
 
     QSize availableSize = qApp->desktop()->availableGeometry( this ).size();
-
+    this->setObjectName("mainApp");
+    
     cDebug() << "Available size" << availableSize;
 
     if ( ( availableSize.width() < windowPreferredWidth ) || ( availableSize.height() < windowPreferredHeight ) )
@@ -71,10 +73,12 @@ CalamaresWindow::CalamaresWindow( QWidget* parent )
     setLayout( mainLayout );
 
     QWidget* sideBox = new QWidget( this );
+    sideBox->setObjectName("sidebarApp");
     mainLayout->addWidget( sideBox );
 
     QBoxLayout* sideLayout = new QVBoxLayout;
     sideBox->setLayout( sideLayout );
+    // Set this attribute into qss file
     sideBox->setFixedWidth( qBound( 100, CalamaresUtils::defaultFontHeight() * 12, w < windowPreferredWidth ? 100 : 190 ) );
     sideBox->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
 
@@ -82,6 +86,8 @@ CalamaresWindow::CalamaresWindow( QWidget* parent )
     sideLayout->addLayout( logoLayout );
     logoLayout->addStretch();
     QLabel* logoLabel = new QLabel( sideBox );
+    logoLabel->setObjectName("logoApp");
+    //Define all values into qss file
     {
         QPalette plt = sideBox->palette();
         sideBox->setAutoFillBackground( true );
@@ -142,6 +148,11 @@ CalamaresWindow::CalamaresWindow( QWidget* parent )
     connect( m_viewManager, &Calamares::ViewManager::enlarge, this, &CalamaresWindow::enlarge );
 
     mainLayout->addWidget( m_viewManager->centralWidget() );
+    QFile File("/etc/calamares/stylesheet.qss");
+    File.open(QFile::ReadOnly);
+    QString StyleSheet = QLatin1String(File.readAll());
+    this->setStyleSheet(StyleSheet);
+
 }
 
 void

--- a/src/calamares/CalamaresWindow.cpp
+++ b/src/calamares/CalamaresWindow.cpp
@@ -53,7 +53,7 @@ CalamaresWindow::CalamaresWindow( QWidget* parent )
 
     QSize availableSize = qApp->desktop()->availableGeometry( this ).size();
     this->setObjectName("mainApp");
-    
+
     cDebug() << "Available size" << availableSize;
 
     if ( ( availableSize.width() < windowPreferredWidth ) || ( availableSize.height() < windowPreferredHeight ) )
@@ -148,10 +148,27 @@ CalamaresWindow::CalamaresWindow( QWidget* parent )
     connect( m_viewManager, &Calamares::ViewManager::enlarge, this, &CalamaresWindow::enlarge );
 
     mainLayout->addWidget( m_viewManager->centralWidget() );
-    QFile File("/etc/calamares/stylesheet.qss");
-    File.open(QFile::ReadOnly);
-    QString StyleSheet = QLatin1String(File.readAll());
-    this->setStyleSheet(StyleSheet);
+
+
+
+    QString brandingComponentName = Calamares::Settings::instance()->brandingComponentName();
+    if ( brandingComponentName.simplified().isEmpty() )
+    {
+        cError() << "FATAL: branding component not set in settings.conf";
+        ::exit( EXIT_FAILURE );
+    }
+
+    QString brandingQSSDescriptorPath = QString( "/etc/calamares/branding/%1/stylesheet.qss" )
+                                        .arg( brandingComponentName );
+
+    importQSSPath = QFileInfo( brandingQSSDescriptorPath );
+    if ( importQSSPath.exists() && importQSSPath.isReadable() )
+    {
+        QFile File(importQSSPath);
+        File.open(QFile::ReadOnly);
+        QString StyleSheet = QLatin1String(File.readAll());
+        this->setStyleSheet(StyleSheet);
+    }
 
 }
 

--- a/src/calamares/progresstree/ProgressTreeView.cpp
+++ b/src/calamares/progresstree/ProgressTreeView.cpp
@@ -35,6 +35,7 @@ ProgressTreeView::ProgressTreeView( QWidget* parent )
 {
     s_instance = this; //FIXME: should assert when s_instance gets written and it wasn't nullptr
 
+    this->setObjectName("sidebarMenuApp");
     setFrameShape( QFrame::NoFrame );
     setContentsMargins( 0, 0, 0, 0 );
 

--- a/src/modules/partition/gui/BootInfoWidget.cpp
+++ b/src/modules/partition/gui/BootInfoWidget.cpp
@@ -32,6 +32,8 @@ BootInfoWidget::BootInfoWidget( QWidget* parent )
     , m_bootIcon( new QLabel )
     , m_bootLabel( new QLabel )
 {
+    m_bootIcon->setObjectName("bootInfoIcon");
+    m_bootLabel->setObjectName("bootInfoLabel");
     QHBoxLayout* mainLayout = new QHBoxLayout;
     setLayout( mainLayout );
 
@@ -47,7 +49,7 @@ BootInfoWidget::BootInfoWidget( QWidget* parent )
     m_bootIcon->setPixmap( CalamaresUtils::defaultPixmap( CalamaresUtils::BootEnvironment,
                                                           CalamaresUtils::Original,
                                                           iconSize ) );
-
+    
     QFontMetrics fm = QFontMetrics( QFont() );
     m_bootLabel->setMinimumWidth( fm.boundingRect( "BIOS" ).width() + CalamaresUtils::defaultFontHeight() / 2 );
     m_bootLabel->setAlignment( Qt::AlignCenter );

--- a/src/modules/partition/gui/DeviceInfoWidget.cpp
+++ b/src/modules/partition/gui/DeviceInfoWidget.cpp
@@ -39,7 +39,8 @@ DeviceInfoWidget::DeviceInfoWidget( QWidget* parent )
     setLayout( mainLayout );
 
     CalamaresUtils::unmarginLayout( mainLayout );
-
+    m_ptLabel->setObjectName("deviceInfoLabel");
+    m_ptIcon->setObjectName("deviceInfoIcon");
     mainLayout->addWidget( m_ptIcon );
     mainLayout->addWidget( m_ptLabel );
 

--- a/src/modules/partition/gui/PartitionBarsView.cpp
+++ b/src/modules/partition/gui/PartitionBarsView.cpp
@@ -57,6 +57,7 @@ PartitionBarsView::PartitionBarsView( QWidget* parent )
     , canBeSelected( []( const QModelIndex& ) { return true; } )
     , m_hoveredIndex( QModelIndex() )
 {
+    this->setObjectName("partitionBarView");
     setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
     setFrameStyle( QFrame::NoFrame );
     setSelectionBehavior( QAbstractItemView::SelectRows );

--- a/src/modules/partition/gui/PartitionLabelsView.cpp
+++ b/src/modules/partition/gui/PartitionLabelsView.cpp
@@ -61,7 +61,7 @@ PartitionLabelsView::PartitionLabelsView( QWidget* parent )
     setFrameStyle( QFrame::NoFrame );
     setSelectionBehavior( QAbstractItemView::SelectRows );
     setSelectionMode( QAbstractItemView::SingleSelection );
-
+    this->setObjectName("partitionLabel");
     // Debug
     connect( this, &PartitionLabelsView::clicked,
              this, [=]( const QModelIndex& index )

--- a/src/modules/summary/SummaryPage.cpp
+++ b/src/modules/summary/SummaryPage.cpp
@@ -39,6 +39,7 @@ SummaryPage::SummaryPage( const SummaryViewStep* thisViewStep, QWidget* parent )
     , m_contentWidget( nullptr )
     , m_scrollArea( new QScrollArea( this ) )
 {
+    this->setObjectName("summaryStep");
     Q_UNUSED( parent );
     Q_ASSERT( m_thisViewStep );
     QVBoxLayout* layout = new QVBoxLayout( this );


### PR DESCRIPTION
This patch enables the thematization of all calamares interface elements with qss technology without having to modify system's qt theme.
Style file is located in /etc/calamares/branding/THEMENAME/stylesheet.qss

To achieve this, I have set names to every calamares qt element, shown in the following attached file.
![calamares](https://user-images.githubusercontent.com/876616/40297881-8bb714da-5ce1-11e8-9fd8-4e5a455ed4fb.png)




