### PR TITLE
implement option to load package groups from netinstall.conf

### DIFF
--- a/src/modules/netinstall/NetInstallPage.h
+++ b/src/modules/netinstall/NetInstallPage.h
@@ -47,12 +47,28 @@ public:
 
     void onActivate();
 
-    /** @brief Retrieves the groups, with name, description and packages
+    /** @brief Retrieves the package groups and their metadata
      *
-     * Loads data from the given URL. This should be called before
-     * displaying the page.
+     * Loads package data from the given URL.
+     * This should be called before displaying the page.
+     * Mutually exclusive with parseGroupList().
      */
     void loadGroupList( const QString& url );
+
+    /** @brief Retrieves the package groups and their metadata
+     *
+     * Parses package data from netinstall.conf
+     * and converts it to YAML as equivalent to loadGroupList().
+     * This should be called before displaying the page.
+     * Mutually exclusive with loadGroupList().
+     */
+    void parseGroupList( const QVariantList& package_groups );
+
+    /** @brief Populates the package groups tree widget and enables the "next" button
+     *
+     * Should be called as the final step of loadGroupList() and parseGroupList().
+     */
+    void populateGroupsWidget( bool is_valid_package_data );
 
     // Sets the "required" state of netinstall data. Influences whether
     // corrupt or unavailable data causes checkReady() to be emitted
@@ -67,6 +83,7 @@ public:
     // selected in the view in this given moment. No data is cached here, so
     // this function does not have constant time.
     PackageModel::PackageItemDataList selectedPackages() const;
+
 
 public slots:
     void dataIsHere( QNetworkReply* );
@@ -87,6 +104,8 @@ private:
 
     PackageModel* m_groups;
     bool m_required;
+
+    static const char* HEADER_TEXT;
 };
 
 #endif // NETINSTALLPAGE_H

--- a/src/modules/netinstall/NetInstallViewStep.cpp
+++ b/src/modules/netinstall/NetInstallViewStep.cpp
@@ -184,14 +184,30 @@ NetInstallViewStep::setConfigurationMap( const QVariantMap& configurationMap )
     m_widget->setRequired( CalamaresUtils::getBool( configurationMap, "required", false ) );
 
     QString groupsUrl = CalamaresUtils::getString( configurationMap, "groupsUrl" );
+
+    // Load package groups from the network
     if ( !groupsUrl.isEmpty() )
     {
+        cDebug() << "Fetching package groups from 'groupsUrl':" << configurationMap.value( "groupsUrl" ).toString();
+
         // Keep putting groupsUrl into the global storage,
         // even though it's no longer used for in-module data-passing.
         Calamares::JobQueue::instance()->globalStorage()->insert( "groupsUrl", groupsUrl );
         m_widget->loadGroupList( groupsUrl );
     }
+
+    // Load package groups from netinstall.conf
+    else if ( configurationMap.contains( "packageGroups" ) &&
+                configurationMap.value( "packageGroups" ).type() == QVariant::List )
+    {
+        cDebug() << "Loading package groups from netinstall.conf";
+
+        QVariantList package_groups = configurationMap.value( "packageGroups" ).toList();
+
+        m_widget->parseGroupList( package_groups );
+    }
 }
+
 
 void
 NetInstallViewStep::nextIsReady( bool b )

--- a/src/modules/netinstall/netinstall.conf
+++ b/src/modules/netinstall/netinstall.conf
@@ -1,7 +1,7 @@
 ---
 # This is the URL that is retrieved to get the netinstall groups-and-packages
 # data (which should be in the format described in netinstall.yaml).
-groupsUrl: http://chakraos.org/netinstall.php
+# groupsUrl: http://chakraos.org/netinstall.php
 
 # If the installation can proceed without netinstall (e.g. the Live CD
 # can create a working installed system, but netinstall is preferred
@@ -11,3 +11,28 @@ groupsUrl: http://chakraos.org/netinstall.php
 # This only has an effect if the netinstall data cannot be retrieved,
 # or is corrupt: having "required" set, means the install cannot proceed.
 required: false
+
+
+# Package groups can be defined here rather than in a separate YAML file
+# if 'groupsUrl' is undefined.
+packageGroups:
+  - name: "Audio Production"
+    description: "Applications for Audio Production"
+    critical: false
+    packages:
+      - ardour
+  - name: "Video Production"
+    description: "Applications for Video Production"
+    critical: false
+    packages:
+      - kdenlive
+  - name: "Development"
+    description: "Applications for software development"
+    critical: false
+    packages:
+      - git
+  - name: "Graphics"
+    description: "Applications to work with graphics"
+    critical: false
+    packages:
+      - gimp

--- a/src/modules/netinstall/page_netinst.ui
+++ b/src/modules/netinstall/page_netinst.ui
@@ -15,6 +15,13 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
+    <widget class="QLabel" name="header">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="maximumSize">
       <size>


### PR DESCRIPTION
this patch allows the netinstall package groups to be defined in this netinstall.conf file for the purpose of offering a selecton of optional packages during offline install - to keep the delta small,  rather than overriding the YAML parsing method to handle the QT structs, i wrote a new method: 'parseGroupList()' that is analagous to and mutually exclusive with the existing 'loadGroupList()/dataIsHere()' pair; using the YAML library to convert the netinstall.conf QVariantMap to YAML and write that out to the local file specified as 'groupsUrl' - but then i decided it was better to avoid writing to the filesystem (and the additional include) and refactored the populating of the 'groupswidget' and enabling of the "next" button out of 'dataIsHere()' into a new method 'populateGroupsWidget()' to allow the two loader methods to share that functionality - the delta is larger this way but IMHO it makes the 'dataIsHere()' method more concise by consolidating the multiple 'reply->deleteLater()' and 'checkReady()' calls
