### PR TITLE
move thisModule->isLoaded assert to after it's warning message

### DIFF
--- a/src/libcalamaresui/modulesystem/ModuleManager.cpp
+++ b/src/libcalamaresui/modulesystem/ModuleManager.cpp
@@ -290,10 +290,10 @@ ModuleManager::loadModules()
                     // If it's a ViewModule, it also appends the ViewStep to the ViewManager.
                     thisModule->loadSelf();
                     m_loadedModulesByInstanceKey.insert( instanceKey, thisModule );
-                    Q_ASSERT( thisModule->isLoaded() );
                     if ( !thisModule->isLoaded() )
                     {
                         cWarning() << "Module" << moduleName << "loading FAILED";
+                        Q_ASSERT( thisModule->isLoaded() );
                         continue;
                     }
                 }


### PR DESCRIPTION
this patch allows the warning message to display the name of the failing module before throwing just as the preceding "Q_ASSERT( thisModule );" does