### PR TITLE
openrc-services module

### DIFF
--- a/src/modules/services-openrc/main.py
+++ b/src/modules/services-openrc/main.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# === This file is part of Calamares - <https://github.com/calamares> ===
+#
+#   Copyright 2014, Philip Müller <philm@manjaro.org>
+#   Copyright 2014, Teo Mrnjavac <teo@kde.org>
+#   Copyright 2017, Alf Gaida <agaida@siduction.org>
+#   Copyright 2018, Gabriel Craciunescu <crazy@frugalware.org>
+#   Copyright 2018, Ghiunhan Mamut <venerix@redcorelinux.org>
+#
+#   Calamares is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Calamares is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with Calamares. If not, see <http://www.gnu.org/licenses/>.
+
+import libcalamares
+
+
+def run():
+    """
+    Setup openrc services
+    """
+    services = libcalamares.job.configuration['services']
+    disable = libcalamares.job.configuration['disable']
+
+    # enable services
+    for svc in services:
+        ec = libcalamares.utils.target_env_call(
+            ['rc-update', 'add', '{}'.format(svc['name']), 'default']
+            )
+
+        if ec != 0:
+            if svc['mandatory']:
+                return ("Cannot enable openrc service {}".format(svc['name']),
+                        "rc-update add  call in chroot returned error code "
+                        "{}".format(ec)
+                        )
+            else:
+                libcalamares.utils.debug(
+                    "Cannot enable openrc service {}".format(svc['name'])
+                    )
+                libcalamares.utils.debug(
+                    "rc-update call in chroot returned error code "
+                    "{}".format(ec)
+                    )
+
+    # disable services
+    for dbl in disable:
+        ec = libcalamares.utils.target_env_call(
+            ['rc-update', 'del', '{}'.format(dbl['name']), 'default']
+            )
+
+        if ec != 0:
+            if dbl['mandatory']:
+                return ("Cannot disable openrc service"
+                        "{}".format(dbl['name']),
+                        "rc-update del call in chroot returned error code"
+                        "{}".format(ec))
+            else:
+                libcalamares.utils.debug(
+                    "Cannot disable openrc service {}".format(dbl['name'])
+                    )
+                libcalamares.utils.debug(
+                    "rc-update del call in chroot returned error code"
+                    "{}".format(ec)
+                    )
+
+    return None

--- a/src/modules/services-openrc/module.desc
+++ b/src/modules/services-openrc/module.desc
@@ -1,0 +1,6 @@
+---
+type:       "job"
+name:       "services-openrc"
+interface:  "python"
+requires:   []
+script:     "main.py"

--- a/src/modules/services-openrc/services-openrc.conf
+++ b/src/modules/services-openrc/services-openrc.conf
@@ -1,0 +1,24 @@
+---
+##
+# NOTE: allowing any other level but default 
+# would be insane , therefore 'level' is static
+###
+###
+# openrc services example:
+#
+# services:
+#   - name: "NetworkManager"  #name of the service file
+#     mandatory: false        #true=> if enabling fails the installer errors out and quits
+#                             #false=>if enabling fails print warning to console and continue
+#   - name: "cups"
+#     mandatory: false
+# disable:
+#   - name: ""
+#     mandatory: false
+#
+# Example to express an empty list:
+# disable: []
+###
+
+services: []
+disable: []


### PR DESCRIPTION
* openrc-services module
* why reivent stuff? take existing code from systemd one and reuse it
* runlevel is static and 'default' only, any other runlevel setup is insane

This is my implementation of openrc-services module, thanks to @abucodonosor for forcing me to write this.

As my comments in the other PR with similar functionality, any other runlevel setup is redundant, so this is limited to 'default' only. I reused as much code as possible from systemd one...