### PR TITLE
[modules]: fix broken logic introduced with plymouthcfg modules

### DIFF
--- a/src/modules/grubcfg/main.py
+++ b/src/modules/grubcfg/main.py
@@ -44,16 +44,21 @@ def modify_grub_default(partitions, root_mount_point, distributor):
     dracut_bin = libcalamares.utils.target_env_call(
         ["sh", "-c", "which dracut"]
         )
-    have_dracut = dracut_bin == 0  # Shell exit value 0 means success
+    plymouth_bin = libcalamares.utils.target_env_call(
+        ["sh", "-c", "which plymouth"]
+        )
+
+    # Shell exit value 0 means success
+    have_plymouth = plymouth_bin == 0
+    have_dracut = dracut_bin == 0
 
     use_splash = ""
     swap_uuid = ""
     swap_outer_uuid = ""
     swap_outer_mappername = None
 
-    if libcalamares.globalstorage.contains("hasPlymouth"):
-        if libcalamares.globalstorage.value("hasPlymouth"):
-            use_splash = "splash"
+    if have_plymouth:
+        use_splash = "splash"
 
     cryptdevice_params = []
 

--- a/src/modules/plymouthcfg/main.py
+++ b/src/modules/plymouthcfg/main.py
@@ -40,13 +40,8 @@ class PlymouthController:
                          "/etc/plymouth/plymouthd.conf"])
 
     def detect(self):
-        isPlymouth = target_env_call(["which", "plymouth"])
+        isPlymouth = target_env_call(["sh", "-c", "which plymouth"])
         debug("which plymouth exit code: {!s}".format(isPlymouth))
-
-        if isPlymouth == 0:
-            libcalamares.globalstorage.insert("hasPlymouth", True)
-        else:
-            libcalamares.globalstorage.insert("hasPlymouth", False)
 
         return isPlymouth
 


### PR DESCRIPTION
  plymouthcfg is optional. Also Distributions with sane packages
  won't even want to use it ( even docs suggest that ).

  However , now grubcfg literally depends on plymouthcfg to run
  bc the gs value to add 'splash' to grub is set in plymouthcfg.

  Revert to calamares 2.x logic and drop exporting gs value
  in plymouthcfg since pointless.

  Fixes ea1c8a0e5ddfc6b72311cf744e2ac514c6630009