### PR TITLE
Add configuration values into pythonqt modules

### DIFF
--- a/src/libcalamaresui/modulesystem/PythonQtViewModule.cpp
+++ b/src/libcalamaresui/modulesystem/PythonQtViewModule.cpp
@@ -96,7 +96,7 @@ PythonQtViewModule::loadSelf()
             cala.addObject( "utils", s_utils );
 
             // Append configuration object, in module PythonQt.calamares
-            cala.addVariable("configuration",m_configurationMap);
+            cala.addVariable("configuration", m_configurationMap);
 
             // Basic stdout/stderr handling
             QObject::connect( PythonQt::self(), &PythonQt::pythonStdOut,

--- a/src/libcalamaresui/modulesystem/PythonQtViewModule.cpp
+++ b/src/libcalamaresui/modulesystem/PythonQtViewModule.cpp
@@ -95,6 +95,9 @@ PythonQtViewModule::loadSelf()
                 s_utils = new ::Utils( Calamares::JobQueue::instance()->globalStorage() );
             cala.addObject( "utils", s_utils );
 
+            // Append configuration object, in module PythonQt.calamares
+            cala.addVariable("configuration",m_configurationMap);
+
             // Basic stdout/stderr handling
             QObject::connect( PythonQt::self(), &PythonQt::pythonStdOut,
                      []( const QString& message )


### PR DESCRIPTION
On pythonQt modules, configuration values aren't python context.
This patch append configuration by PythonQt library on calamares module.