### PR TITLE
Let pacman do complete system upgardes instead of partial upgardes

### DIFF
--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -242,7 +242,7 @@ class PMPacman(PackageManager):
         if from_local:
             pacman_flags = "-U"
         else:
-            pacman_flags = "-Sy"
+            pacman_flags = "-Syu"
 
         check_target_env_call(["pacman", pacman_flags,
                                "--noconfirm"] + pkgs)
@@ -251,7 +251,7 @@ class PMPacman(PackageManager):
         check_target_env_call(["pacman", "-Rs", "--noconfirm"] + pkgs)
 
     def update_db(self):
-        check_target_env_call(["pacman", "-Sy"])
+        check_target_env_call(["pacman", "-Syu"])
 
 
 class PMPortage(PackageManager):


### PR DESCRIPTION
While pacman supports partial upgrades, there are no distributions that support
this behaviour. As calamares doesn't support a "upgrade_system" routine we can't
just rely on "pacman -S" being sufficient for an installer, as it might pull in
packages that doesn't exists in the mirror. As "-Sy" might break systems because
of this, we are better off dispatching complete system upgrades instead of
leaving user systems broken.