### PR TITLE
[packages] add support for target system upgrade

### DIFF
--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -8,6 +8,7 @@
 #   Copyright 2016-2017, Kyle Robbertze <kyle@aims.ac.za>
 #   Copyright 2017, Alf Gaida <agaida@siduction.org>
 #   Copyright 2018, Adriaan de Groot <groot@kde.org>
+#   Copyright 2018, Philip Müller <philm@manjaro.org>
 #
 #   Calamares is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -153,6 +154,9 @@ class PMPackageKit(PackageManager):
     def update_db(self):
         check_target_env_call(["pkcon", "refresh"])
 
+    def update_system(self):
+        # Doesn't need to update the system explicitly
+        pass
 
 class PMZypp(PackageManager):
     backend = "zypp"
@@ -170,6 +174,9 @@ class PMZypp(PackageManager):
     def update_db(self):
         check_target_env_call(["zypper", "--non-interactive", "update"])
 
+    def update_system(self):
+        # Doesn't need to update the system explicitly
+        pass
 
 class PMYum(PackageManager):
     backend = "yum"
@@ -185,6 +192,9 @@ class PMYum(PackageManager):
         # Doesn't need updates
         pass
 
+    def update_system(self):
+        # Doesn't need to update the system explicitly
+        pass
 
 class PMDnf(PackageManager):
     backend = "dnf"
@@ -199,7 +209,11 @@ class PMDnf(PackageManager):
                          "remove"] + pkgs)
 
     def update_db(self):
-        # Doesn't need to update explicitly
+        # Doesn't need updates
+        pass
+
+    def update_system(self):
+        # Doesn't need to update the system explicitly
         pass
 
 
@@ -218,6 +232,10 @@ class PMUrpmi(PackageManager):
     def update_db(self):
         check_target_env_call(["urpmi.update", "-a"])
 
+    def update_system(self):
+        # Doesn't need to update the system explicitly
+        pass
+
 
 class PMApt(PackageManager):
     backend = "apt"
@@ -234,6 +252,10 @@ class PMApt(PackageManager):
     def update_db(self):
         check_target_env_call(["apt-get", "update"])
 
+    def update_system(self):
+        # Doesn't need to update the system explicitly
+        pass
+
 
 class PMPacman(PackageManager):
     backend = "pacman"
@@ -242,7 +264,7 @@ class PMPacman(PackageManager):
         if from_local:
             pacman_flags = "-U"
         else:
-            pacman_flags = "-Sy"
+            pacman_flags = "-S"
 
         check_target_env_call(["pacman", pacman_flags,
                                "--noconfirm"] + pkgs)
@@ -252,6 +274,9 @@ class PMPacman(PackageManager):
 
     def update_db(self):
         check_target_env_call(["pacman", "-Sy"])
+
+    def update_system(self):
+        check_target_env_call(["pacman", "-Su"])
 
 
 class PMPortage(PackageManager):
@@ -267,6 +292,10 @@ class PMPortage(PackageManager):
     def update_db(self):
         check_target_env_call(["emerge", "--sync"])
 
+    def update_system(self):
+        # Doesn't need to update the system explicitly
+        pass
+
 
 class PMEntropy(PackageManager):
     backend = "entropy"
@@ -280,6 +309,10 @@ class PMEntropy(PackageManager):
     def update_db(self):
         check_target_env_call(["equo", "update"])
 
+    def update_system(self):
+        # Doesn't need to update the system explicitly
+        pass
+
 
 class PMDummy(PackageManager):
     backend = "dummy"
@@ -292,6 +325,9 @@ class PMDummy(PackageManager):
 
     def update_db(self):
         libcalamares.utils.debug("Updating DB")
+
+    def update_system(self):
+        libcalamares.utils.debug("Updating System")
 
     def run(self, script):
         libcalamares.utils.debug("Running script '" + str(script) + "'")
@@ -308,6 +344,10 @@ class PMPisi(PackageManager):
 
     def update_db(self):
         check_target_env_call(["pisi", "update-repo"])
+
+    def update_system(self):
+        # Doesn't need to update the system explicitly
+        pass
 
 
 # Collect all the subclasses of PackageManager defined above,
@@ -451,6 +491,10 @@ def run():
     update_db = libcalamares.job.configuration.get("update_db", False)
     if update_db and libcalamares.globalstorage.value("hasInternet"):
         pkgman.update_db()
+
+    update_system = libcalamares.job.configuration.get("update_system", False)
+    if update_system and libcalamares.globalstorage.value("hasInternet"):
+        pkgman.update_system()
 
     operations = libcalamares.job.configuration.get("operations", [])
     if libcalamares.globalstorage.contains("packageOperations"):

--- a/src/modules/packages/packages.conf
+++ b/src/modules/packages/packages.conf
@@ -16,18 +16,25 @@ backend: dummy
 
 # Often package installation needs an internet connection.
 # Since you may allow system installation without a connection
-# and want to offer **optional** package installation, it's
+# and want to offer OPTIONAL package installation, it's
 # possible to have no internet, yet have this packages module
 # enabled in settings.
 #
 # You can skip the whole module when there is no internet
-# by setting *skip_if_no_internet* to true.
+# by setting "skip_if_no_internet" to true.
 #
 # You can run a package-manager specific update procedure
 # before installing packages (for instance, to update the
 # list of packages and dependencies); this is done only if there
-# is an internet connection. Set *update_db* and/or *update_system*
-# to true to do so.
+# is an internet connection.
+#
+# Set "update_db" to 'true' for refreshing the database on the
+# target system. 
+#
+# On target installations, which got installed by unsquashing
+# a full system update is may be needed, to be able to post-install
+# additional packages. Therefore set also "update_system" to 'true'. 
+#
 skip_if_no_internet: false
 update_db: true
 update_system: false
@@ -88,14 +95,14 @@ update_system: false
 #
 # - if the system locale is English (any variety), then the package is not
 #   installed at all,
-# - otherwise $LOCALE or ${LOCALE} is replaced by the **lower-cased** BCP47
-#   name of the **language** part of the selected system locale (not the
-#   country/region/dialect part), e.g. selecting *nl_BE* will use *nl*
+# - otherwise $LOCALE or ${LOCALE} is replaced by the 'lower-cased' BCP47
+#   name of the 'language' part of the selected system locale (not the
+#   country/region/dialect part), e.g. selecting "nl_BE" will use "nl"
 #   here.
 #
 # Take care that just plain LOCALE will not be replaced, so foo-LOCALE will
 # be left unchanged, while foo-$LOCALE will be changed. However, foo-LOCALE
-# **will** be removed from the list of packages, if English is selected.
+# 'will' be removed from the list of packages, if English is selected.
 #
 # The following installs localizations for vi, if they are relevant; if
 # there is no localization, installation continues normally.

--- a/src/modules/packages/packages.conf
+++ b/src/modules/packages/packages.conf
@@ -26,9 +26,11 @@ backend: dummy
 # You can run a package-manager specific update procedure
 # before installing packages (for instance, to update the
 # list of packages and dependencies); this is done only if there
-# is an internet connection. Set *update_db* to true to do so.
+# is an internet connection. Set *update_db* and/or *update_system*
+# to true to do so.
 skip_if_no_internet: false
 update_db: true
+update_system: false
 
 #
 # List of maps with package operations such as install or remove.

--- a/src/modules/packages/packages.conf
+++ b/src/modules/packages/packages.conf
@@ -14,6 +14,7 @@
 #
 backend: dummy
 
+#
 # Often package installation needs an internet connection.
 # Since you may allow system installation without a connection
 # and want to offer OPTIONAL package installation, it's
@@ -29,11 +30,10 @@ backend: dummy
 # is an internet connection.
 #
 # Set "update_db" to 'true' for refreshing the database on the
-# target system. 
-#
-# On target installations, which got installed by unsquashing
-# a full system update is may be needed, to be able to post-install
-# additional packages. Therefore set also "update_system" to 'true'. 
+# target system. On target installations, which got installed by
+# unsquashing, a full system update may be needed. Otherwise 
+# post-installing additional packages may result in conflicts.
+# Therefore set also "update_system" to 'true'. 
 #
 skip_if_no_internet: false
 update_db: true


### PR DESCRIPTION
Currently our **packages** module doesn't support yet a full system upgrade call. This is however needed in the following use-case:

If you use, for example an arch-based Distro, which unsquashes a snapshot of packages via the **unpackfs** module and additional adds an option to optional install additional packages via the **packages** module, a full system upgrade is needed be-forehanded. Otherwise it may result in conflicts having outdated dependencies on your target system which don't match the dependencies needed by the currently available remote packages. This also corrects the command for installing remote packages via **pacman**.

---
This makes #989 obsolete.