### PR TITLE
add support onLeave and onActivate to pythonqt plugins

### DIFF
--- a/src/libcalamaresui/viewpages/PythonQtViewStep.cpp
+++ b/src/libcalamaresui/viewpages/PythonQtViewStep.cpp
@@ -159,6 +159,24 @@ PythonQtViewStep::isAtEnd() const
                                             "is_at_end" } ).toBool();
 }
 
+void
+PythonQtViewStep::onActivate() 
+{
+    CalamaresUtils::lookupAndCall( m_obj,
+                                          { "onActivate",
+                                            "onactivate",
+                                            "on_activate" });
+}
+
+void
+PythonQtViewStep::onLeave()
+{
+    CalamaresUtils::lookupAndCall( m_obj,
+                                          { "onLeave",
+                                            "onleave",
+                                            "on_leave" });
+}
+
 
 JobList
 PythonQtViewStep::jobs() const

--- a/src/libcalamaresui/viewpages/PythonQtViewStep.h
+++ b/src/libcalamaresui/viewpages/PythonQtViewStep.h
@@ -39,6 +39,8 @@ public:
 
     void next() override;
     void back() override;
+    void onLeave() override;
+    void onActivate() override;
 
     bool isNextEnabled() const override;
     bool isBackEnabled() const override;


### PR DESCRIPTION
PythonQt plugins don't have support to Activate and Leave events. This patch adds these events.