### PR TITLE
do not set boot flag on ESP

### DIFF
--- a/src/modules/partition/core/PartitionActions.cpp
+++ b/src/modules/partition/core/PartitionActions.cpp
@@ -165,7 +165,7 @@ doAutopartition( PartitionCoreModule* core, Device* dev, const QString& luksPass
         PartitionInfo::setFormat( efiPartition, true );
         PartitionInfo::setMountPoint( efiPartition, gs->value( "efiSystemPartition" )
                                                         .toString() );
-        core->createPartition( dev, efiPartition, PartitionTable::FlagEsp | PartitionTable::FlagBoot );
+        core->createPartition( dev, efiPartition, PartitionTable::FlagEsp );
         firstFreeSector = lastSector + 1;
     }
     else


### PR DESCRIPTION
ESP == boot. at best this is duplicated information, at worst kpmcore may
implode if you try to set a boot flag since that is technically an MBR
type flag and means nothing within the context of GPT where ESP is the flag
to set.