### PR TITLE
do not set active flags on the to-be ESP

### DIFF
--- a/src/modules/partition/core/PartitionActions.cpp
+++ b/src/modules/partition/core/PartitionActions.cpp
@@ -160,7 +160,7 @@ doAutopartition( PartitionCoreModule* core, Device* dev, const QString& luksPass
             FileSystem::Fat32,
             firstFreeSector,
             lastSector,
-            PartitionTable::FlagEsp
+            PartitionTable::FlagNone
         );
         PartitionInfo::setFormat( efiPartition, true );
         PartitionInfo::setMountPoint( efiPartition, gs->value( "efiSystemPartition" )


### PR DESCRIPTION
having ESP as active flag AND then trying to set ESP means nothing is
set since kpmcore will think ESP is already set (it is listed as active
after all). this ultimately meant that nothing was set since there was
no delta between the requested flags and the already active flags.