### PR TITLE
grubcfg: Only try to decrypt disk that /boot is on

### DIFF
--- a/src/modules/grubcfg/main.py
+++ b/src/modules/grubcfg/main.py
@@ -62,6 +62,12 @@ def modify_grub_default(partitions, root_mount_point, distributor):
 
     cryptdevice_params = []
 
+    # GRUB needs to decrypt the partition that /boot is on, which may be / or /boot
+    boot_mountpoint = "/"
+    for partition in partitions:
+        if partition["mountPoint"] == "/boot":
+            boot_mountpoint = "/boot"
+
     if have_dracut:
         for partition in partitions:
             has_luks = "luksMapperName" in partition
@@ -72,7 +78,7 @@ def modify_grub_default(partitions, root_mount_point, distributor):
                 swap_outer_uuid = partition["luksUuid"]
                 swap_outer_mappername = partition["luksMapperName"]
 
-            if (partition["mountPoint"] == "/" and has_luks):
+            if (partition["mountPoint"] == boot_mountpoint and has_luks):
                 cryptdevice_params = [
                     "rd.luks.uuid={!s}".format(partition["luksUuid"])
                     ]
@@ -82,7 +88,7 @@ def modify_grub_default(partitions, root_mount_point, distributor):
             if partition["fs"] == "linuxswap" and not has_luks:
                 swap_uuid = partition["uuid"]
 
-            if (partition["mountPoint"] == "/" and has_luks):
+            if (partition["mountPoint"] == boot_mountpoint and has_luks):
                 cryptdevice_params = [
                     "cryptdevice=UUID={!s}:{!s}".format(
                         partition["luksUuid"], partition["luksMapperName"]


### PR DESCRIPTION
Hi!
Previously, GRUB tried to decrypt the rootfs disk even if there was an unencrypted /boot partition holding an initramfs.
This is bad because the partition might actually be decrypted with a keyfile or have some other mechanisms involved that require the initramfs to be loaded and cryptsetup itself to unlock the disk.

Therefore, we should only have GRUB involved if the whole disk needs to be decrypted for the system to even start, i.e. if there is no separate /boot partition.
This patch changes grubcfg to check for that partition layout.

Cheers,
    Matthias
