### PR TITLE
Set boot flag & CAL may delete partitions during disk-probe

### DIFF
--- a/src/modules/partition/core/PartUtils.cpp
+++ b/src/modules/partition/core/PartUtils.cpp
@@ -158,15 +158,14 @@ canBeResized( PartitionCoreModule* core, const QString& partitionPath )
 }
 
 
+
 static FstabEntryList
 lookForFstabEntries( const QString& partitionPath )
 {
     FstabEntryList fstabEntries;
     QTemporaryDir mountsDir;
-    mountsDir.setAutoRemove( false );
 
-    int exit = QProcess::execute( "mount", { partitionPath, mountsDir.path() } );
-    if ( !exit ) // if all is well
+    if ( QProcess::execute( "mount", { "-o", "ro,noload", partitionPath, mountsDir.path() } ) == 0) // if all is well
     {
         QFile fstabFile( mountsDir.path() + "/etc/fstab" );
         if ( fstabFile.open( QIODevice::ReadOnly | QIODevice::Text ) )
@@ -180,7 +179,7 @@ lookForFstabEntries( const QString& partitionPath )
             std::remove_if( fstabEntries.begin(), fstabEntries.end(), [](const FstabEntry& x) { return !x.isValid(); } );
         }
 
-        if ( QProcess::execute( "umount", { "-R", mountsDir.path() } ) )
+        if ( QProcess::execute( "umount", { "-R", mountsDir.path() } ) != 0) // if failed
         {
             cWarning() << "Could not unmount" << mountsDir.path();
             // There is stuff left in there, really don't remove
@@ -190,6 +189,7 @@ lookForFstabEntries( const QString& partitionPath )
 
     return fstabEntries;
 }
+
 
 
 static QString

--- a/src/modules/partition/core/PartitionActions.cpp
+++ b/src/modules/partition/core/PartitionActions.cpp
@@ -220,7 +220,15 @@ doAutopartition( PartitionCoreModule* core, Device* dev, const QString& luksPass
     }
     PartitionInfo::setFormat( rootPartition, true );
     PartitionInfo::setMountPoint( rootPartition, "/" );
-    core->createPartition( dev, rootPartition, PartitionTable::FlagBoot );
+    if( isEfi )
+    {
+        core->createPartition( dev, rootPartition );
+    }
+    else
+    {
+        // Some buggy BIOSes test if the bootflag of at least one partition is set. Otherwise they ignore the device in boot-order. 
+        core->createPartition( dev, rootPartition, PartitionTable::FlagBoot )
+    }
 
     if ( shouldCreateSwap )
     {

--- a/src/modules/partition/core/PartitionActions.cpp
+++ b/src/modules/partition/core/PartitionActions.cpp
@@ -156,8 +156,7 @@ doAutopartition( PartitionCoreModule* core, Device* dev, const QString& luksPass
             PartitionRole( PartitionRole::Primary ),
             FileSystem::Fat32,
             firstFreeSector,
-            lastSector,
-            PartitionTable::FlagNone
+            lastSector
         );
         PartitionInfo::setFormat( efiPartition, true );
         PartitionInfo::setMountPoint( efiPartition, gs->value( "efiSystemPartition" )
@@ -221,7 +220,7 @@ doAutopartition( PartitionCoreModule* core, Device* dev, const QString& luksPass
     }
     PartitionInfo::setFormat( rootPartition, true );
     PartitionInfo::setMountPoint( rootPartition, "/" );
-    core->createPartition( dev, rootPartition );
+    core->createPartition( dev, rootPartition, PartitionTable::FlagBoot );
 
     if ( shouldCreateSwap )
     {

--- a/src/modules/partition/core/PartitionActions.cpp
+++ b/src/modules/partition/core/PartitionActions.cpp
@@ -227,7 +227,7 @@ doAutopartition( PartitionCoreModule* core, Device* dev, const QString& luksPass
     else
     {
         // Some buggy BIOSes test if the bootflag of at least one partition is set. Otherwise they ignore the device in boot-order. 
-        core->createPartition( dev, rootPartition, PartitionTable::FlagBoot )
+        core->createPartition( dev, rootPartition, PartitionTable::FlagBoot );
     }
 
     if ( shouldCreateSwap )


### PR DESCRIPTION
Set boot flag
https://github.com/calamares/calamares/issues/1046

CAL may delete partitions during disk-probe
https://github.com/calamares/calamares/issues/1044