### PR TITLE
Preserve current device when going to manual partitioning and back

### DIFF
--- a/src/modules/partition/gui/ChoicePage.cpp
+++ b/src/modules/partition/gui/ChoicePage.cpp
@@ -2,6 +2,7 @@
  *
  *   Copyright 2014-2017, Teo Mrnjavac <teo@kde.org>
  *   Copyright 2017-2018, Adriaan de Groot <groot@kde.org>
+ *   Copyright 2019, Collabora Ltd
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -1522,4 +1523,17 @@ ChoicePage::updateSwapChoicesTr(QComboBox* box)
                 cWarning() << "Box item" << index << box->itemText( index ) << "has role" << value;
         }
     }
+}
+
+int
+ChoicePage::lastSelectedDeviceIndex()
+{
+    return m_lastSelectedDeviceIndex;
+}
+
+void
+ChoicePage::setLastSelectedDeviceIndex( int index )
+{
+    m_lastSelectedDeviceIndex = index;
+    m_drivesCombo->setCurrentIndex( m_lastSelectedDeviceIndex );
 }

--- a/src/modules/partition/gui/ChoicePage.h
+++ b/src/modules/partition/gui/ChoicePage.h
@@ -2,6 +2,7 @@
  *
  *   Copyright 2014-2016, Teo Mrnjavac <teo@kde.org>
  *   Copyright 2018, Adriaan de Groot <groot@kde.org>
+ *   Copyright 2019, Collabora Ltd
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -96,6 +97,9 @@ public:
      * @param choice the partitioning action choice.
      */
     void applyActionChoice( ChoicePage::InstallChoice choice );
+
+    int lastSelectedDeviceIndex();
+    void setLastSelectedDeviceIndex( int index );
 
 signals:
     void nextStatusChanged( bool );

--- a/src/modules/partition/gui/PartitionPage.cpp
+++ b/src/modules/partition/gui/PartitionPage.cpp
@@ -5,6 +5,7 @@
  *   Copyright 2018, Adriaan de Groot <groot@kde.org>
  *   Copyright 2018, Andrius Štikonas <andrius@stikonas.eu>
  *   Copyright 2018, Caio Jordão Carvalho <caiojcarvalho@gmail.com>
+ *   Copyright 2019, Collabora Ltd
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -608,4 +609,16 @@ PartitionPage::getCurrentUsedMountpoints()
     }
 
     return mountPoints;
+}
+
+int
+PartitionPage::selectedDeviceIndex()
+{
+    return m_ui->deviceComboBox->currentIndex();
+}
+
+void
+PartitionPage::selectDeviceByIndex ( int index )
+{
+        m_ui->deviceComboBox->setCurrentIndex( index );
 }

--- a/src/modules/partition/gui/PartitionPage.h
+++ b/src/modules/partition/gui/PartitionPage.h
@@ -2,6 +2,7 @@
  *
  *   Copyright 2014, Aurélien Gâteau <agateau@kde.org>
  *   Copyright 2018, Adriaan de Groot <groot@kde.org>
+ *   Copyright 2019, Collabora Ltd
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -45,6 +46,9 @@ public:
     ~PartitionPage();
 
     void onRevertClicked();
+
+    int selectedDeviceIndex();
+    void selectDeviceByIndex( int index );
 
 private:
     QScopedPointer< Ui_PartitionPage > m_ui;

--- a/src/modules/partition/gui/PartitionViewStep.cpp
+++ b/src/modules/partition/gui/PartitionViewStep.cpp
@@ -3,6 +3,7 @@
  *   Copyright 2014, Aurélien Gâteau <agateau@kde.org>
  *   Copyright 2014-2017, Teo Mrnjavac <teo@kde.org>
  *   Copyright 2018, Adriaan de Groot <groot@kde.org>
+ *   Copyright 2019, Collabora Ltd
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -286,6 +287,7 @@ PartitionViewStep::next()
         if ( m_choicePage->currentChoice() == ChoicePage::Manual )
         {
             m_widget->setCurrentWidget( m_manualPartitionPage );
+            m_manualPartitionPage->selectDeviceByIndex( m_choicePage->lastSelectedDeviceIndex() );
             if ( m_core->isDirty() )
                 m_manualPartitionPage->onRevertClicked();
         }
@@ -315,7 +317,10 @@ void
 PartitionViewStep::back()
 {
     if ( m_widget->currentWidget() != m_choicePage )
+    {
         m_widget->setCurrentWidget( m_choicePage );
+        m_choicePage->setLastSelectedDeviceIndex( m_manualPartitionPage->selectedDeviceIndex() );
+    }
 }
 
 


### PR DESCRIPTION
The device selected in the choice page (where the user can select "Erase" / "Replace" / ...) is automatically selected by default when switching to the manual partitioning page.
Likewise, any device selection change during manual partitioning will be applied to the choice page in case the user goes back.

Fixes #1043 