### PR TITLE
Add a settings.conf option to disable "Cancel" button

### DIFF
--- a/settings.conf
+++ b/settings.conf
@@ -146,3 +146,12 @@ prompt-install: false
 #
 # YAML: boolean.
 dont-chroot: false
+
+# If this is set to true, the "Cancel" button will be disabled.
+# This can be useful if when e.g. calamares is used as a post-install configuration
+# tool and you require the user to go through all the configuration steps.
+#
+# Default is false.
+#
+# YAML: boolean.
+disable-cancel: false

--- a/src/libcalamares/Settings.cpp
+++ b/src/libcalamares/Settings.cpp
@@ -81,6 +81,7 @@ Settings::Settings( const QString& settingsFilePath,
     , m_debug( debugMode )
     , m_doChroot( true )
     , m_promptInstall( false )
+    , m_disableCancel( false )
 {
     cDebug() << "Using Calamares settings file at" << settingsFilePath;
     QFile file( settingsFilePath );
@@ -183,6 +184,7 @@ Settings::Settings( const QString& settingsFilePath,
             m_brandingComponentName = requireString( config, "branding" );
             m_promptInstall = requireBool( config, "prompt-install", false );
             m_doChroot = !requireBool( config, "dont-chroot", false );
+            m_disableCancel = requireBool( config, "disable-cancel", false );
         }
         catch ( YAML::Exception& e )
         {
@@ -243,6 +245,12 @@ bool
 Settings::doChroot() const
 {
     return m_doChroot;
+}
+
+bool
+Settings::disableCancel() const
+{
+    return m_disableCancel;
 }
 
 

--- a/src/libcalamares/Settings.h
+++ b/src/libcalamares/Settings.h
@@ -58,6 +58,8 @@ public:
 
     bool doChroot() const;
 
+    bool disableCancel() const;
+
 private:
     static Settings* s_instance;
 
@@ -71,6 +73,7 @@ private:
     bool m_debug;
     bool m_doChroot;
     bool m_promptInstall;
+    bool m_disableCancel;
 };
 
 }

--- a/src/libcalamaresui/ViewManager.cpp
+++ b/src/libcalamaresui/ViewManager.cpp
@@ -95,6 +95,10 @@ ViewManager::ViewManager( QObject* parent )
              this, &ViewManager::onInstallationFailed );
     connect( JobQueue::instance(), &JobQueue::finished,
              this, &ViewManager::next );
+
+    if (Calamares::Settings::instance()->disableCancel())
+        m_quit->setVisible( false );
+
 }
 
 
@@ -282,9 +286,13 @@ ViewManager::updateButtonLabels()
     {
         m_quit->setText( tr( "&Done" ) );
         m_quit->setToolTip( tr( "The installation is complete. Close the installer." ) );
+        if (Calamares::Settings::instance()->disableCancel())
+            m_quit->setVisible( true );
     }
     else
     {
+        if (Calamares::Settings::instance()->disableCancel())
+            m_quit->setVisible( false );
         m_quit->setText( tr( "&Cancel" ) );
         m_quit->setToolTip( tr( "Cancel installation without changing the system." ) );
     }


### PR DESCRIPTION
In some cases, e.g. when calamares is used as an "initial setup" tool,
we may want the user to go through all the configuration steps in order
to end up with a usable system.
Therefore, disabling the "Cancel" button can be useful in this case.

This commit adds an option to settings.conf which disables this button
when set to "true". If the option is not present in the settings file,
the default behavior ("Cancel" button enabled & visible) is enforced.