### PR TITLE
[rawfs] Allow use of symlinks in configuration

### DIFF
--- a/src/modules/rawfs/main.py
+++ b/src/modules/rawfs/main.py
@@ -131,7 +131,7 @@ class RawFSItem:
     def __init__(self, config, device, fs):
         libcalamares.utils.debug("Adding an entry for raw copy of {} to {}".format(
                 config["source"], device))
-        self.source = config["source"]
+        self.source = os.path.realpath(config["source"])
         # If source is a mount point, look for the actual device mounted on it
         if os.path.ismount(self.source):
             procmounts = open("/proc/mounts", "r")


### PR DESCRIPTION
In its current state, the 'rawfs' module requires the source partition 
to be identified either by its mount point or device name, but using a 
symlink to either one (e.g '/dev/disk/by-uuid/...') would fail.

This patch fetches the real path of source partition, allowing the use 
of symlinks.