### PR TITLE
[rawfs] Add rawfs source to the `partitions` entry in global storage

### DIFF
--- a/src/modules/rawfs/main.py
+++ b/src/modules/rawfs/main.py
@@ -156,8 +156,10 @@ def update_global_storage(item, gs):
                 libcalamares.utils.debug("Setting {} UUID to {}".format(item.destination,
                         ret.stdout.rstrip()))
                 gs[gs.index(partition)]["uuid"] = ret.stdout.rstrip()
-                libcalamares.globalstorage.remove("partitions")
-                libcalamares.globalstorage.insert("partitions", gs)
+                gs[gs.index(partition)]["source"] = item.source
+
+    libcalamares.globalstorage.remove("partitions")
+    libcalamares.globalstorage.insert("partitions", gs)
 
 def run():
     """Raw filesystem copy module"""


### PR DESCRIPTION
When using the `rawfs` module for copying data, it may be useful to
save the source device used for later checks or actions. This commit
therefore adds a `source` field to each corresponding partition entry in
global storage, so that this information can be retrieved later during
the installation process.

Another small improvement is that global storage is now modified only
once (it was previously modified as many times as there were entries
processed by the `rawfs` module).