### PR TITLE
Fix default fs

### DIFF
--- a/src/modules/partition/core/PartUtils.h
+++ b/src/modules/partition/core/PartUtils.h
@@ -22,6 +22,10 @@
 
 #include "OsproberEntry.h"
 
+// KPMcore
+#include <kpmcore/fs/filesystem.h>
+
+// Qt
 #include <QString>
 
 class PartitionCoreModule;
@@ -73,6 +77,15 @@ bool isEfiSystem();
  * the partition table layout, this may mean different flags.
  */
 bool isEfiBootable( const Partition* candidate );
+
+/** @brief translate @p fsName into a recognized name and type
+ *
+ * Makes several attempts to translate the string into a
+ * name that KPMCore will recognize.
+ * The corresponding filesystem type is stored in @p fsType, and
+ * its value is FileSystem::Unknown if @p fsName is not recognized.
+ */
+QString findFS( QString fsName, FileSystem::Type* fsType );
 }
 
 #endif // PARTUTILS_H

--- a/src/modules/partition/core/PartitionLayout.cpp
+++ b/src/modules/partition/core/PartitionLayout.cpp
@@ -45,18 +45,18 @@ getDefaultFileSystemType()
 
 PartitionLayout::PartitionLayout()
 {
-    defaultFsType = getDefaultFileSystemType();
+    m_defaultFsType = getDefaultFileSystemType();
 }
 
 PartitionLayout::PartitionLayout( PartitionLayout::PartitionEntry entry )
 {
-    defaultFsType = getDefaultFileSystemType();
-    partLayout.append( entry );
+    m_defaultFsType = getDefaultFileSystemType();
+    m_partLayout.append( entry );
 }
 
 PartitionLayout::PartitionLayout( const PartitionLayout& layout )
-    : partLayout( layout.partLayout )
-    , defaultFsType( layout.defaultFsType )
+    : m_partLayout( layout.m_partLayout )
+    , m_defaultFsType( layout.m_defaultFsType )
 {
 }
 
@@ -67,7 +67,7 @@ PartitionLayout::~PartitionLayout()
 void
 PartitionLayout::addEntry( PartitionLayout::PartitionEntry entry )
 {
-    partLayout.append( entry );
+    m_partLayout.append( entry );
 }
 
 static double
@@ -133,9 +133,9 @@ PartitionLayout::addEntry( const QString& mountPoint, const QString& size, const
     PartitionLayout::PartitionEntry entry( size, min );
 
     entry.partMountPoint = mountPoint;
-    entry.partFileSystem = defaultFsType;
+    entry.partFileSystem = m_defaultFsType;
 
-    partLayout.append( entry );
+    m_partLayout.append( entry );
 }
 
 void
@@ -147,9 +147,9 @@ PartitionLayout::addEntry( const QString& label, const QString& mountPoint, cons
     entry.partMountPoint = mountPoint;
     entry.partFileSystem = FileSystem::typeForName( fs );
     if ( entry.partFileSystem == FileSystem::Unknown )
-        entry.partFileSystem = defaultFsType;
+        entry.partFileSystem = m_defaultFsType;
 
-    partLayout.append( entry );
+    m_partLayout.append( entry );
 }
 
 static qint64
@@ -195,7 +195,7 @@ PartitionLayout::execute( Device *dev, qint64 firstSector,
     // TODO: Refine partition sizes to make sure there is room for every partition
     // Use a default (200-500M ?) minimum size for partition without minSize
 
-    foreach( const PartitionLayout::PartitionEntry& part, partLayout )
+    foreach( const PartitionLayout::PartitionEntry& part, m_partLayout )
     {
         Partition *currentPartition = nullptr;
 

--- a/src/modules/partition/core/PartitionLayout.h
+++ b/src/modules/partition/core/PartitionLayout.h
@@ -76,6 +76,7 @@ public:
     QList< Partition* > execute( Device *dev, qint64 firstSector, qint64 lastSector, QString luksPassphrase, PartitionNode* parent, const PartitionRole& role );
 
 private:
+    int defaultFsType;
     QList< PartitionEntry > partLayout;
 };
 

--- a/src/modules/partition/core/PartitionLayout.h
+++ b/src/modules/partition/core/PartitionLayout.h
@@ -76,8 +76,8 @@ public:
     QList< Partition* > execute( Device *dev, qint64 firstSector, qint64 lastSector, QString luksPassphrase, PartitionNode* parent, const PartitionRole& role );
 
 private:
-    int defaultFsType;
-    QList< PartitionEntry > partLayout;
+    int m_defaultFsType;
+    QList< PartitionEntry > m_partLayout;
 };
 
 #endif /* PARTITIONLAYOUT_H */

--- a/src/modules/partition/core/PartitionLayout.h
+++ b/src/modules/partition/core/PartitionLayout.h
@@ -24,6 +24,7 @@
 
 // KPMcore
 #include <kpmcore/core/partitiontable.h>
+#include <kpmcore/fs/filesystem.h>
 
 // Qt
 #include <QList>
@@ -48,7 +49,7 @@ public:
     {
         QString partLabel;
         QString partMountPoint;
-        int partFileSystem = 0;
+        FileSystem::Type partFileSystem = FileSystem::Unknown;
         double partSize = 0.0L;
         SizeUnit partSizeUnit = Percent;
         double partMinSize = 0.0L;
@@ -76,7 +77,7 @@ public:
     QList< Partition* > execute( Device *dev, qint64 firstSector, qint64 lastSector, QString luksPassphrase, PartitionNode* parent, const PartitionRole& role );
 
 private:
-    int m_defaultFsType;
+    FileSystem::Type m_defaultFsType;
     QList< PartitionEntry > m_partLayout;
 };
 


### PR DESCRIPTION
When using the default partition layout (only a `/` partition), the
filesystem used was ext4, ignoring the `defaultFileSystemType`
configuration option.

This commit fixes this bug, so that any supported filesystem can now be
used for the default partitioning scheme.

Fixes #1093 