### PR TITLE
Complete setup mode messages adjustements

### DIFF
--- a/src/calamares/CalamaresWindow.cpp
+++ b/src/calamares/CalamaresWindow.cpp
@@ -2,6 +2,7 @@
  *
  *   Copyright 2014-2015, Teo Mrnjavac <teo@kde.org>
  *   Copyright 2017-2018, Adriaan de Groot <groot@kde.org>
+ *   Copyright 2019, Collabora Ltd <arnaud.ferraris@collabora.com>
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -53,8 +54,10 @@ CalamaresWindow::CalamaresWindow( QWidget* parent )
     , m_viewManager( nullptr )
 {
     CALAMARES_RETRANSLATE(
-        setWindowTitle( tr( "%1 Installer" )
-                        .arg( *Calamares::Branding::ProductName ) );
+        setWindowTitle( Calamares::Settings::instance()->isSetupMode()
+                            ? tr( "%1 Setup Program" ).arg( *Calamares::Branding::ProductName )
+                            : tr( "%1 Installer" ).arg( *Calamares::Branding::ProductName )
+                         );
     )
 
     const Calamares::Branding* const branding = Calamares::Branding::instance();

--- a/src/modules/finished/FinishedPage.cpp
+++ b/src/modules/finished/FinishedPage.cpp
@@ -2,6 +2,7 @@
  *
  *   Copyright 2014-2015, Teo Mrnjavac <teo@kde.org>
  *   Copyright 2017-2018, Adriaan de Groot <groot@kde.org>
+ *   Copyright 2019, Collabora Ltd <arnaud.ferraris@collabora.com>
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -33,7 +34,7 @@
 #include <QProcess>
 
 #include "Branding.h"
-
+#include "Settings.h"
 
 FinishedPage::FinishedPage( QWidget* parent )
     : QWidget( parent )
@@ -48,12 +49,33 @@ FinishedPage::FinishedPage( QWidget* parent )
 
     CALAMARES_RETRANSLATE(
         ui->retranslateUi( this );
-        ui->mainText->setText( tr( "<h1>All done.</h1><br/>"
-                                   "%1 has been installed on your computer.<br/>"
-                                   "You may now restart into your new system, or continue "
-                                   "using the %2 Live environment." )
-                               .arg( *Calamares::Branding::VersionedName )
-                               .arg( *Calamares::Branding::ProductName ) );
+        if ( Calamares::Settings::instance()->isSetupMode() )
+        {
+            ui->mainText->setText( tr( "<h1>All done.</h1><br/>"
+                                       "%1 has been set up on your computer.<br/>"
+                                       "You may now start using your new system." )
+                                   .arg( *Calamares::Branding::VersionedName )
+                                   .arg( *Calamares::Branding::ProductName ) );
+            ui->restartCheckBox->setToolTip( tr ( "<html><head/><body>"
+                                                  "<p>When this box is checked, your system will "
+                                                  "restart immediately when you click on "
+                                                  "<span style=\"font-style:italic;\">Done</span> "
+                                                  "or close the setup program.</p></body></html>" ) );
+       }
+       else
+       {
+            ui->mainText->setText( tr( "<h1>All done.</h1><br/>"
+                                       "%1 has been installed on your computer.<br/>"
+                                       "You may now restart into your new system, or continue "
+                                       "using the %2 Live environment." )
+                                   .arg( *Calamares::Branding::VersionedName )
+                                   .arg( *Calamares::Branding::ProductName ) );
+            ui->restartCheckBox->setToolTip( tr ( "<html><head/><body>"
+                                                  "<p>When this box is checked, your system will "
+                                                  "restart immediately when you click on "
+                                                  "<span style=\"font-style:italic;\">Done</span> "
+                                                  "or close the installer.</p></body></html>" ) );
+       }
     )
 }
 
@@ -106,10 +128,17 @@ void
 FinishedPage::onInstallationFailed( const QString& message, const QString& details )
 {
     Q_UNUSED( details );
-    ui->mainText->setText( tr( "<h1>Installation Failed</h1><br/>"
-                               "%1 has not been installed on your computer.<br/>"
-                               "The error message was: %2." )
-                           .arg( *Calamares::Branding::VersionedName )
-                           .arg( message ) );
+    if ( Calamares::Settings::instance()->isSetupMode() )
+        ui->mainText->setText( tr( "<h1>Setup Failed</h1><br/>"
+                                   "%1 has not been set up on your computer.<br/>"
+                                   "The error message was: %2." )
+                               .arg( *Calamares::Branding::VersionedName )
+                               .arg( message ) );
+    else
+        ui->mainText->setText( tr( "<h1>Installation Failed</h1><br/>"
+                                   "%1 has not been installed on your computer.<br/>"
+                                   "The error message was: %2." )
+                               .arg( *Calamares::Branding::VersionedName )
+                               .arg( message ) );
     setRestartNowEnabled( false );
 }

--- a/src/modules/finished/FinishedPage.ui
+++ b/src/modules/finished/FinishedPage.ui
@@ -92,7 +92,7 @@
        <item>
         <widget class="QCheckBox" name="restartCheckBox">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When this box is checked, your system will restart immediately when you click on &lt;span style=&quot; font-style:italic;&quot;&gt;Done&lt;/span&gt; or close the installer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;Restart checkbox tooltip&gt;</string>
          </property>
          <property name="text">
           <string>&amp;Restart now</string>

--- a/src/modules/finished/FinishedViewStep.cpp
+++ b/src/modules/finished/FinishedViewStep.cpp
@@ -2,6 +2,7 @@
  *
  *   Copyright 2014-2015, Teo Mrnjavac <teo@kde.org>
  *   Copyright 2017, Adriaan de Groot <groot@kde.org>
+ *   Copyright 2019, Collabora Ltd <arnaud.ferraris@collabora.com>
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -29,6 +30,7 @@
 #include <QVariantMap>
 
 #include "Branding.h"
+#include "Settings.h"
 
 FinishedViewStep::FinishedViewStep( QObject* parent )
     : Calamares::ViewStep( parent )
@@ -109,8 +111,12 @@ FinishedViewStep::sendNotification()
                                           QString( "Calamares" ),
                                           QVariant( 0U ),
                                           QString( "calamares" ),
-                                          tr( "Installation Complete" ),
-                                          tr( "The installation of %1 is complete." ).arg( *Calamares::Branding::VersionedName ),
+                                          Calamares::Settings::instance()->isSetupMode()
+                                              ? tr( "Setup Complete" )
+                                              : tr( "Installation Complete" ),
+                                          Calamares::Settings::instance()->isSetupMode()
+                                              ? tr( "The setup of %1 is complete." ).arg( *Calamares::Branding::VersionedName )
+                                              : tr( "The installation of %1 is complete." ).arg( *Calamares::Branding::VersionedName ),
                                           QStringList(),
                                           QVariantMap(),
                                           QVariant( 0 )

--- a/src/modules/plasmalnf/PlasmaLnfPage.cpp
+++ b/src/modules/plasmalnf/PlasmaLnfPage.cpp
@@ -1,6 +1,7 @@
 /* === This file is part of Calamares - <https://github.com/calamares> ===
  *
  *   Copyright 2017-2018, Adriaan de Groot <groot@kde.org>
+ *   Copyright 2019, Collabora Ltd <arnaud.ferraris@collabora.com>
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -22,6 +23,7 @@
 
 #include "utils/Logger.h"
 #include "utils/Retranslator.h"
+#include "Settings.h"
 
 #include <QAbstractButton>
 
@@ -64,11 +66,18 @@ PlasmaLnfPage::PlasmaLnfPage( QWidget* parent )
     CALAMARES_RETRANSLATE(
     {
         ui->retranslateUi( this );
-        ui->generalExplanation->setText( tr(
-            "Please choose a look-and-feel for the KDE Plasma Desktop. "
-            "You can also skip this step and configure the look-and-feel "
-            "once the system is installed. Clicking on a look-and-feel "
-            "selection will give you a live preview of that look-and-feel.") );
+        if ( Calamares::Settings::instance()->isSetupMode() )
+            ui->generalExplanation->setText( tr(
+                "Please choose a look-and-feel for the KDE Plasma Desktop. "
+                "You can also skip this step and configure the look-and-feel "
+                "once the system is set up. Clicking on a look-and-feel "
+                "selection will give you a live preview of that look-and-feel.") );
+        else
+            ui->generalExplanation->setText( tr(
+                "Please choose a look-and-feel for the KDE Plasma Desktop. "
+                "You can also skip this step and configure the look-and-feel "
+                "once the system is installed. Clicking on a look-and-feel "
+                "selection will give you a live preview of that look-and-feel.") );
         updateThemeNames();
         fillUi();
     }

--- a/src/modules/summary/SummaryPage.cpp
+++ b/src/modules/summary/SummaryPage.cpp
@@ -2,6 +2,7 @@
  *
  *   Copyright 2014-2015, Teo Mrnjavac <teo@kde.org>
  *   Copyright 2017, Adriaan de Groot <groot@kde.org>
+ *   Copyright 2019, Collabora Ltd <arnaud.ferraris@collabora.com>
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -25,6 +26,7 @@
 #include "utils/Retranslator.h"
 #include "utils/CalamaresUtilsGui.h"
 #include "utils/Logger.h"
+#include "Settings.h"
 #include "ViewManager.h"
 
 #include <QBoxLayout>
@@ -46,8 +48,12 @@ SummaryPage::SummaryPage( const SummaryViewStep* thisViewStep, QWidget* parent )
 
     QLabel* headerLabel = new QLabel( this );
     CALAMARES_RETRANSLATE(
-        headerLabel->setText( tr( "This is an overview of what will happen once you start "
-                                  "the install procedure." ) );
+        if ( Calamares::Settings::instance()->isSetupMode() )
+            headerLabel->setText( tr( "This is an overview of what will happen once you start "
+                                      "the setup procedure." ) );
+        else
+            headerLabel->setText( tr( "This is an overview of what will happen once you start "
+                                      "the install procedure." ) );
     )
     layout->addWidget( headerLabel );
     layout->addWidget( m_scrollArea );

--- a/src/modules/users/UsersPage.cpp
+++ b/src/modules/users/UsersPage.cpp
@@ -2,6 +2,7 @@
  *
  *   Copyright 2014-2017, Teo Mrnjavac <teo@kde.org>
  *   Copyright 2017-2018, Adriaan de Groot <groot@kde.org>
+ *   Copyright 2019, Collabora Ltd <arnaud.ferraris@collabora.com>
  *
  *   Portions from the Manjaro Installation Framework
  *   by Roland Singer <roland@manjaro.org>
@@ -31,6 +32,7 @@
 #include "utils/Logger.h"
 #include "utils/CalamaresUtilsGui.h"
 #include "utils/Retranslator.h"
+#include "Settings.h"
 
 #include <QBoxLayout>
 #include <QLabel>
@@ -106,7 +108,21 @@ UsersPage::UsersPage( QWidget* parent )
     ui->hostname_extra_label_2->setMaximumWidth( 3 * boxWidth );
     ui->password_extra_label_3->setMaximumWidth( 3 * boxWidth );
 
-    CALAMARES_RETRANSLATE( ui->retranslateUi( this ); )
+    CALAMARES_RETRANSLATE(
+        ui->retranslateUi( this );
+        if ( Calamares::Settings::instance()->isSetupMode() )
+        {
+            ui->username_extra_label_2->setText( tr( "<small>If more than one person will "
+                                                     "use this computer, you can create multiple "
+                                                     "accounts after setup.</small>" ) );
+        }
+        else
+        {
+            ui->username_extra_label_2->setText( tr( "<small>If more than one person will "
+                                                     "use this computer, you can create multiple "
+                                                     "accounts after installation.</small>" ) );
+        }
+    )
 }
 
 

--- a/src/modules/users/page_usersetup.ui
+++ b/src/modules/users/page_usersetup.ui
@@ -197,7 +197,7 @@
       <string notr="true">font-weight: normal</string>
      </property>
      <property name="text">
-      <string>&lt;small&gt;If more than one person will use this computer, you can set up multiple accounts after installation.&lt;/small&gt;</string>
+      <string>&lt;Username extra label 2 text&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/modules/welcome/checker/GeneralRequirements.cpp
+++ b/src/modules/welcome/checker/GeneralRequirements.cpp
@@ -3,6 +3,7 @@
  *   Copyright 2014-2017, Teo Mrnjavac <teo@kde.org>
  *   Copyright 2017-2018, Adriaan de Groot <groot@kde.org>
  *   Copyright 2017, Gabriel Craciunescu <crazy@frugalware.org>
+ *   Copyright 2019, Collabora Ltd <arnaud.ferraris@collabora.com>
  *
  *   Calamares is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -30,7 +31,7 @@
 #include "utils/Retranslator.h"
 #include "utils/CalamaresUtilsSystem.h"
 #include "utils/Units.h"
-
+#include "Settings.h"
 
 #include "JobQueue.h"
 #include "GlobalStorage.h"
@@ -141,7 +142,9 @@ Calamares::RequirementsList GeneralRequirements::checkRequirements()
             checkEntries.append( {
                 entry,
                 [this]{ return QString(); }, //we hide it
-                [this]{ return tr( "The installer is not running with administrator rights." ); },
+                [this]{ return Calamares::Settings::instance()->isSetupMode()
+                            ? tr( "The setup program is not running with administrator rights." )
+                            : tr( "The installer is not running with administrator rights." ); },
                 isRoot,
                 m_entriesToRequire.contains( entry )
             } );
@@ -149,7 +152,9 @@ Calamares::RequirementsList GeneralRequirements::checkRequirements()
             checkEntries.append( {
                 entry,
                 [this]{ return QString(); }, // we hide it
-                [this]{ return tr( "The screen is too small to display the installer." ); },
+                [this]{ return Calamares::Settings::instance()->isSetupMode()
+                            ? tr( "The screen is too small to display the setup program." )
+                            : tr( "The screen is too small to display the installer." ); },
                 enoughScreen,
                 false
             } );


### PR DESCRIPTION
This PR changes the window title in setup mode, and tweaks messages & UI texts for the following modules:

- finished
- users
- plasmalnf
- summary
- welcome

The `tracking` module texts contain the word *installation*, but in a sense that don't seem likely to cause any confusion, it has therefore been left untouched.
Other modules do not contain reference to the installation process or are not likely to be used in setup mode (e.g. the `partition` module).