### PR TITLE
[partition] Add max size parameter

### DIFF
--- a/src/modules/partition/core/PartitionCoreModule.cpp
+++ b/src/modules/partition/core/PartitionCoreModule.cpp
@@ -774,6 +774,7 @@ PartitionCoreModule::initLayout( const QVariantList& config )
 {
     QString sizeString;
     QString minSizeString;
+    QString maxSizeString;
 
     m_partLayout = new PartitionLayout();
 
@@ -791,11 +792,17 @@ PartitionCoreModule::initLayout( const QVariantList& config )
         else
             minSizeString = CalamaresUtils::getString( pentry, "minSize" );
 
+        if ( pentry.contains("maxSize") && CalamaresUtils::getString( pentry, "maxSize" ).isEmpty() )
+            maxSizeString.setNum( CalamaresUtils::getInteger( pentry, "maxSize", 100 ) );
+        else
+            maxSizeString = CalamaresUtils::getString( pentry, "maxSize" );
+
         m_partLayout->addEntry( CalamaresUtils::getString( pentry, "name" ),
                                 CalamaresUtils::getString( pentry, "mountPoint" ),
                                 CalamaresUtils::getString( pentry, "filesystem" ),
                                 sizeString,
-                                minSizeString
+                                minSizeString,
+                                maxSizeString
                               );
     }
 }

--- a/src/modules/partition/core/PartitionLayout.h
+++ b/src/modules/partition/core/PartitionLayout.h
@@ -47,11 +47,13 @@ public:
         PartUtils::SizeUnit partSizeUnit = PartUtils::SizeUnit::Percent;
         double partMinSize = 0.0L;
         PartUtils::SizeUnit partMinSizeUnit = PartUtils::SizeUnit::Percent;
+        double partMaxSize = 100.0L;
+        PartUtils::SizeUnit partMaxSizeUnit = PartUtils::SizeUnit::Percent;
 
         /// @brief All-zeroes PartitionEntry
         PartitionEntry() {};
-        /// @brief Parse @p size and @p min to their respective member variables
-        PartitionEntry( const QString& size, const QString& min );
+        /// @brief Parse @p size, @p min and @p max to their respective member variables
+        PartitionEntry( const QString& size, const QString& min, const QString& max );
     };
 
     PartitionLayout();
@@ -60,8 +62,8 @@ public:
     ~PartitionLayout();
 
     void addEntry( PartitionEntry entry );
-    void addEntry( const QString& mountPoint, const QString& size, const QString& min = QString() );
-    void addEntry( const QString& label, const QString& mountPoint, const QString& fs, const QString& size, const QString& min = QString() );
+    void addEntry( const QString& mountPoint, const QString& size, const QString& min = QString(), const QString& max = QString() );
+    void addEntry( const QString& label, const QString& mountPoint, const QString& fs, const QString& size, const QString& min = QString(), const QString& max = QString() );
 
     /**
      * @brief Apply the current partition layout to the selected drive space.

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -100,6 +100,7 @@ defaultFileSystemType:  "ext4"
 #       mountPoint: "/"
 #       size: 20%
 #       minSize: 500M
+#       maxSize: 10G
 #     - name: "home"
 #       filesystem: "ext4"
 #       mountPoint: "/home"
@@ -118,3 +119,4 @@ defaultFileSystemType:  "ext4"
 #           or
 #           % of the available drive space if a '%' is appended to the value
 #   - minSize: minimum partition size (optional parameter)
+#   - maxSize: maximum partition size (optional parameter)


### PR DESCRIPTION
When using a custom partition layout with partition sizes in %, it can
be useful to set an upper limit to the partition size.

For instance, using a 20% size for the `/` partition will create a 24GB
partition on a 120GB drive, but a 200GB partition on a 1TB drive, which
is not useful, and could be avoided by setting a maximum partition size.

This commit adds the `maxSize` parameter (with a default value of 100%).