### PR TITLE
[partition] Fixing LVM scanning according to new kpmcore API

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ Andrius Štikonas
 Bernhard Landauer
 Bezzy1999
 bill-auger
+Caio Jordão Carvalho
 crispg72
 demmm
 Gabriel Craciunescu

--- a/src/modules/partition/core/PartitionCoreModule.cpp
+++ b/src/modules/partition/core/PartitionCoreModule.cpp
@@ -55,6 +55,7 @@
 #include <kpmcore/core/device.h>
 #include <kpmcore/core/lvmdevice.h>
 #include <kpmcore/core/partition.h>
+#include <kpmcore/core/volumemanagerdevice.h>
 #include <kpmcore/backend/corebackend.h>
 #include <kpmcore/backend/corebackendmanager.h>
 #include <kpmcore/fs/filesystemfactory.h>
@@ -686,12 +687,13 @@ PartitionCoreModule::scanForLVMPVs()
         }
     }
 
-    // Update LVM::pvList
-    LvmDevice::scanSystemLVM( physicalDevices );
-
 #ifdef WITH_KPMCOREGT33
+    VolumeManagerDevice::scanDevices( physicalDevices );
+
     for ( auto p : LVM::pvList::list() )
 #else
+    LvmDevice::scanSystemLVM( physicalDevices );
+
     for ( auto p : LVM::pvList )
 #endif
     {

--- a/src/modules/partition/core/PartitionCoreModule.cpp
+++ b/src/modules/partition/core/PartitionCoreModule.cpp
@@ -551,26 +551,22 @@ PartitionCoreModule::lvmPVs() const
 bool
 PartitionCoreModule::hasVGwithThisName( const QString& name ) const
 {
-    for ( DeviceInfo* d : m_deviceInfos )
-        if ( dynamic_cast<LvmDevice*>(d->device.data()) &&
-             d->device.data()->name() == name)
-            return true;
+    auto condition = [ name ]( DeviceInfo* d ) {
+        return dynamic_cast<LvmDevice*>(d->device.data()) && d->device.data()->name() == name;
+    };
 
-    return false;
+    return std::find_if( m_deviceInfos.begin(), m_deviceInfos.end(), condition ) != m_deviceInfos.end();
 }
 
 bool
 PartitionCoreModule::isInVG( const Partition *partition ) const
 {
-    for ( DeviceInfo* d : m_deviceInfos )
-    {
-        LvmDevice* vg = dynamic_cast<LvmDevice*>( d->device.data() );
+    auto condition = [ partition ]( DeviceInfo* d ) {
+        LvmDevice* vg = dynamic_cast<LvmDevice*>( d->device.data());
+        return vg && vg->physicalVolumes().contains( partition );
+    };
 
-        if ( vg && vg->physicalVolumes().contains( partition ))
-            return true;
-    }
-
-    return false;
+    return std::find_if( m_deviceInfos.begin(), m_deviceInfos.end(), condition ) != m_deviceInfos.end();
 }
 
 void


### PR DESCRIPTION
To scan LVM devices, it was needed to call LvmDevice::scanDevices from kpmcore before. However, there is a change in this API, as we need to force the scanning of the other types of volume groups before scanning LVM, because it needs to check for PVs in other devices and some clients may call this API without considering these other types of volume groups. This scanning process now is done using VolumeManagerDevice::scanDevices to force the scanning of all the types of volumes groups before LVM.