### PR TITLE
[libcalamaresui] Fix sidebar label for setup mode

### DIFF
--- a/src/libcalamaresui/ExecutionViewStep.cpp
+++ b/src/libcalamaresui/ExecutionViewStep.cpp
@@ -78,7 +78,9 @@ ExecutionViewStep::ExecutionViewStep( QObject* parent )
 QString
 ExecutionViewStep::prettyName() const
 {
-    return tr( "Install" );
+    return Calamares::Settings::instance()->isSetupMode()
+        ? tr( "Set up" )
+        : tr( "Install" );
 }
 
 


### PR DESCRIPTION
In the sidebar, the "Install" step should be named "Set Up" when in
setup mode, which will be more consistent with the other UI texts,
including button labels.