### PR TITLE
Enhancement of initcpio config supporting cases where squashfs image doesn't contain kernel image

### DIFF
--- a/src/modules/initcpio/initcpio.conf
+++ b/src/modules/initcpio/initcpio.conf
@@ -1,3 +1,4 @@
 # Run mkinitcpio(8) with the given preset value
 ---
-kernel: linux312
+kernel: linux
+image_source: /run/archiso/bootmnt/arch/boot/x86_64/vmlinuz

--- a/src/modules/initcpio/initcpio.conf
+++ b/src/modules/initcpio/initcpio.conf
@@ -1,4 +1,22 @@
 # Run mkinitcpio(8) with the given preset value
 ---
 kernel: linux
-image_source: /run/archiso/bootmnt/arch/boot/x86_64/vmlinuz
+
+# For some ISO's (e.g. with archiso generated ISO's) the squashfs image doesn't
+# contain a kernel image file. Therefore, the kernel image file needs to be
+# copied to the corresponding target. For this, the source and the target path
+# can be specified with the configuration parameters image_source and
+# image_target.
+#
+# Both parameters are optional. If image_source is not set, the system assumes
+# that the squashfs image already contains a kernel image file, and image_target
+# is ignored (if it is set).
+# If image_source is set, the kernel image is copied to the target specified
+# with image_target. If image_target is not set, /boot/vmlinuz-linux is
+# assumed to be the target path of the image. The image_target needs to be
+# consistent with the kernel image path in the mkinitcpio preset.
+#
+# For ISO's generated with archiso, the following configuration is needed:
+#
+# image_source: /run/archiso/bootmnt/arch/boot/x86_64/vmlinuz
+

--- a/src/modules/initcpio/initcpio.conf
+++ b/src/modules/initcpio/initcpio.conf
@@ -1,6 +1,6 @@
 # Run mkinitcpio(8) with the given preset value
 ---
-kernel: linux
+kernel: linux312
 
 # For some ISO's (e.g. with archiso generated ISO's) the squashfs image doesn't
 # contain a kernel image file. Therefore, the kernel image file needs to be

--- a/src/modules/initcpio/main.py
+++ b/src/modules/initcpio/main.py
@@ -22,8 +22,6 @@
 
 import gettext
 import libcalamares
-from libcalamares.job import configuration
-from lincalamares.globalstorage import value
 from subprocess import CalledProcessError
 from subprocess import check_call
 
@@ -41,16 +39,16 @@ def run():
 
     :return:
     """
-    print("image_source=", configuration["image_source"])
+    print("image_source=", libcalamares.job.configuration["image_source"])
 
     check_call(["cp",
                 "/run/archiso/bootmnt/arch/boot/x86_64/vmlinuz",
-                value("rootMoountPoint") + "/boot/vmlinuz-linux"])
+                libcalamares.globalstorage.value("rootMoountPoint") + "/boot/vmlinuz-linux"])
 
     try:
         check_target_env_call(["mkinitcpio",
                                "-p",
-                               configuration["kernel"]])
+                               libcalamares.job.configuration["kernel"]])
     except CalledProcessError as e:
         libcalamares.utils.warning(str(e))
         return ( _( "Process Failed" ),

--- a/src/modules/initcpio/main.py
+++ b/src/modules/initcpio/main.py
@@ -1,4 +1,4 @@
-/usr/bin/env python3
+#/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # === This file is part of Calamares - <https://github.com/calamares> ===
@@ -22,37 +22,35 @@
 
 import gettext
 import libcalamares
-import subprocess
+from libcalamares.job import configuration
+from lincalamares.globalstorage import value
+from subprocess import CalledProcessError
+from subprocess import check_call
 
-
-#from libcalamares.utils import check_target_env_call
-#from libcalamares.utils import *
-
-#import gettext
 _ = gettext.translation("calamares-python",
-                        localedir=libcalamares.utils.gettext_path(),
+                        localedir=libcalamares.utils.gettext_path(), 
                         languages=libcalamares.utils.gettext_languages(),
                         fallback=True).gettext
 
 
 def pretty_name():
-    return _("Creating initramfs based on archiso with mkinitcpio.")
+    return _("Creating initramfs based with mkinitcpio.")
 
 def run():
     """ Calls routine to create kernel initramfs image.
 
     :return:
     """
- #   from subprocess import CalledProcessError
+    print("image_source=", configuration["image_source"])
 
-    print("image_source=", libcalamares.job.configuration['image_source'])
+    check_call(["cp",
+                "/run/archiso/bootmnt/arch/boot/x86_64/vmlinuz",
+                value("rootMoountPoint") + "/boot/vmlinuz-linux"])
 
-    root_mount_point = libcalamares.globalstorage.value("rootMountPoint")
-    subprocess.check_call(["cp", "/run/archiso/bootmnt/arch/boot/x86_64/vmlinuz", root_mount_point + "/boot/vmlinuz-linux"])
-
-    kernel = libcalamares.job.configuration['kernel']
     try:
-        check_target_env_call(['mkinitcpio', '-p', kernel])
+        check_target_env_call(["mkinitcpio",
+                               "-p",
+                               configuration["kernel"]])
     except CalledProcessError as e:
         libcalamares.utils.warning(str(e))
         return ( _( "Process Failed" ),

--- a/src/modules/initcpio/main.py
+++ b/src/modules/initcpio/main.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # === This file is part of Calamares - <https://github.com/calamares> ===

--- a/src/modules/initcpio/main.py
+++ b/src/modules/initcpio/main.py
@@ -32,7 +32,7 @@ _ = gettext.translation("calamares-python",
                         fallback=True).gettext
 
 def pretty_name():
-    return _("Creating initramfs based with mkinitcpio.")
+    return _("Creating initramfs with mkinitcpio.")
 
 def run():
     """ Calls routine to create kernel initramfs image.

--- a/src/modules/initcpio/main.py
+++ b/src/modules/initcpio/main.py
@@ -31,7 +31,6 @@ _ = gettext.translation("calamares-python",
                         languages=libcalamares.utils.gettext_languages(),
                         fallback=True).gettext
 
-
 def pretty_name():
     return _("Creating initramfs based with mkinitcpio.")
 
@@ -40,11 +39,13 @@ def run():
 
     :return:
     """
-    print("image_source=", libcalamares.job.configuration["image_source"])
 
-    check_call(["cp",
-                "/run/archiso/bootmnt/arch/boot/x86_64/vmlinuz",
-                libcalamares.globalstorage.value("rootMountPoint") + "/boot/vmlinuz-linux"])
+    if (libcalamares.job.configuration and "image_source" in libcalamares.job.configuration):
+        check_call(["cp",
+                    libcalamares.job.configuration["image_source",
+                    libcalamares.globalstorage.value("rootMountPoint")
+                    + "/boot/vmlinuz-"
+                    + llibcalamares.job.configuration["kernel"]]])
 
     try:
         check_target_env_call(["mkinitcpio",

--- a/src/modules/initcpio/main.py
+++ b/src/modules/initcpio/main.py
@@ -22,6 +22,7 @@
 
 import gettext
 import libcalamares
+from libcalamares.utils import check_target_env_call
 from subprocess import CalledProcessError
 from subprocess import check_call
 

--- a/src/modules/initcpio/main.py
+++ b/src/modules/initcpio/main.py
@@ -43,7 +43,7 @@ def run():
 
     check_call(["cp",
                 "/run/archiso/bootmnt/arch/boot/x86_64/vmlinuz",
-                libcalamares.globalstorage.value("rootMoountPoint") + "/boot/vmlinuz-linux"])
+                libcalamares.globalstorage.value("rootMountPoint") + "/boot/vmlinuz-linux"])
 
     try:
         check_target_env_call(["mkinitcpio",

--- a/src/modules/initcpio/main.py
+++ b/src/modules/initcpio/main.py
@@ -42,10 +42,10 @@ def run():
 
     if (libcalamares.job.configuration and "image_source" in libcalamares.job.configuration):
         check_call(["cp",
-                    libcalamares.job.configuration["image_source",
+                    libcalamares.job.configuration["image_source"],
                     libcalamares.globalstorage.value("rootMountPoint")
                     + "/boot/vmlinuz-"
-                    + libcalamares.job.configuration["kernel"]]])
+                    + libcalamares.job.configuration["kernel"]])
 
     try:
         check_target_env_call(["mkinitcpio",

--- a/src/modules/initcpio/main.py
+++ b/src/modules/initcpio/main.py
@@ -41,11 +41,14 @@ def run():
     """
 
     if (libcalamares.job.configuration and "image_source" in libcalamares.job.configuration):
+        if ("image_target" in libcalamares.job.configuration):
+            target = libcalamares.job.configuration["image_target"]
+        else
+            target = "/boot/vmlinuz-linux"
         check_call(["cp",
                     libcalamares.job.configuration["image_source"],
                     libcalamares.globalstorage.value("rootMountPoint")
-                    + "/boot/vmlinuz-"
-                    + libcalamares.job.configuration["kernel"]])
+                    + target)
 
     try:
         check_target_env_call(["mkinitcpio",

--- a/src/modules/initcpio/main.py
+++ b/src/modules/initcpio/main.py
@@ -1,10 +1,11 @@
-#!/usr/bin/env python3
+/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # === This file is part of Calamares - <https://github.com/calamares> ===
 #
 #   Copyright 2014, Philip Müller <philm@manjaro.org>
 #   Copyright 2019, Adriaan de Groot <groot@kde.org>
+#   Copyright 2019, Michael Picht <mipi@fsfe.org> 
 #
 #   Calamares is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -19,10 +20,15 @@
 #   You should have received a copy of the GNU General Public License
 #   along with Calamares. If not, see <http://www.gnu.org/licenses/>.
 
-import libcalamares
-from libcalamares.utils import check_target_env_call
-
 import gettext
+import libcalamares
+import subprocess
+
+
+#from libcalamares.utils import check_target_env_call
+#from libcalamares.utils import *
+
+#import gettext
 _ = gettext.translation("calamares-python",
                         localedir=libcalamares.utils.gettext_path(),
                         languages=libcalamares.utils.gettext_languages(),
@@ -30,14 +36,19 @@ _ = gettext.translation("calamares-python",
 
 
 def pretty_name():
-    return _("Creating initramfs with mkinitcpio.")
+    return _("Creating initramfs based on archiso with mkinitcpio.")
 
 def run():
     """ Calls routine to create kernel initramfs image.
 
     :return:
     """
-    from subprocess import CalledProcessError
+ #   from subprocess import CalledProcessError
+
+    print("image_source=", libcalamares.job.configuration['image_source'])
+
+    root_mount_point = libcalamares.globalstorage.value("rootMountPoint")
+    subprocess.check_call(["cp", "/run/archiso/bootmnt/arch/boot/x86_64/vmlinuz", root_mount_point + "/boot/vmlinuz-linux"])
 
     kernel = libcalamares.job.configuration['kernel']
     try:
@@ -48,3 +59,4 @@ def run():
                  _( "Process <pre>mkinitcpio</pre> failed with error code {!s}. The command was <pre>{!s}</pre>." ).format( e.returncode, e.cmd ) )
 
     return None
+

--- a/src/modules/initcpio/main.py
+++ b/src/modules/initcpio/main.py
@@ -45,7 +45,7 @@ def run():
                     libcalamares.job.configuration["image_source",
                     libcalamares.globalstorage.value("rootMountPoint")
                     + "/boot/vmlinuz-"
-                    + llibcalamares.job.configuration["kernel"]]])
+                    + libcalamares.job.configuration["kernel"]]])
 
     try:
         check_target_env_call(["mkinitcpio",


### PR DESCRIPTION
Hi,
the initcpio module doesn't work for ISO's where the squashfs image doesn't contain a kernel image (that's the case, for example, for archiso).
I propose to enhance the module by some new  optional config parameters (and the corresponding logic in the main.py). With that, the module also works for the ISO's mentioned above. Since the added config is completely optional, users don't have to change their existing config.
With the new config, users can set a source and a target for the kernel image. The image is then copied from the source to the target.
mipi