### PR TITLE
implement definable job weights

### DIFF
--- a/src/libcalamares/Job.cpp
+++ b/src/libcalamares/Job.cpp
@@ -97,6 +97,13 @@ Job::~Job()
 {}
 
 
+qreal
+Job::getJobWeight() const
+{
+    return qreal( 1.0 );
+}
+
+
 QString
 Job::prettyDescription() const
 {

--- a/src/libcalamares/Job.h
+++ b/src/libcalamares/Job.h
@@ -83,6 +83,7 @@ public:
     explicit Job( QObject* parent = nullptr );
     virtual ~Job();
 
+    virtual qreal getJobWeight() const;
     virtual QString prettyName() const = 0;
     virtual QString prettyDescription() const;
     virtual QString prettyStatusMessage() const;


### PR DESCRIPTION
this addresses feature request #1176 

this commit adds a getter method to the Job class,
allowing each sub-class to define a weighted share of
the total 100% progress, and an instance var to the
JobThread class that caches them

the jobPercent as passed into the JobThread::emitProgress()
handler is compared to the defined weight f the current job,
and added to all previous job weights, rather than the current linear
calculation (m_jobIndex / jobPercent)

for any Job sub-class not implementing the getter, the
default value will reproduce the original current behavior as
1/n_jobs

the caveat for the implementer, is that it requires the long
running command to be run in its own thread; so that 'emit
progress' can be pumped in fine grained intervals - and of
course there needs to be some way to determine what is the
current progress from the parent thread, while waiting for
the long-running thread to exit
