### PR TITLE
Fix error in unpackfs

### DIFF
--- a/src/modules/unpackfs/main.py
+++ b/src/modules/unpackfs/main.py
@@ -103,6 +103,7 @@ def file_copy(source, dest, progress_cb):
     if not source.endswith("/"):
         source += "/"
 
+    num_files_total_local = 0
     num_files_copied = 0  # Gets updated through rsync output
 
     args = ['rsync', '-aHAXr']


### PR DESCRIPTION
In some (rare) cases, `num_files_total_local` might not be declared when reporting progress. This patch initializes this variable in order to prevent any python error in this case.