### PR TITLE
Prevent integer overflow when parsing configuration

### DIFF
--- a/src/libcalamares/PythonHelper.cpp
+++ b/src/libcalamares/PythonHelper.cpp
@@ -52,6 +52,9 @@ variantToPyObject( const QVariant& variant )
     case QVariant::Int:
         return bp::object( variant.toInt() );
 
+    case QVariant::LongLong:
+        return bp::object( variant.toLongLong() );
+
     case QVariant::Double:
         return bp::object( variant.toDouble() );
 

--- a/src/libcalamares/partition/PartitionSize.cpp
+++ b/src/libcalamares/partition/PartitionSize.cpp
@@ -50,7 +50,7 @@ PartitionSize::PartitionSize( const QString& s )
 
     if ( m_unit == SizeUnit::None )
     {
-        m_value = s.toInt();
+        m_value = s.toLongLong();
         if ( m_value > 0 )
         {
             m_unit = SizeUnit::Byte;

--- a/src/libcalamares/utils/NamedSuffix.h
+++ b/src/libcalamares/utils/NamedSuffix.h
@@ -58,7 +58,7 @@ public:
     }
 
     /** @brief Specific value and unit. */
-    NamedSuffix( int value, unit_t unit )
+    NamedSuffix( qint64 value, unit_t unit )
         : m_value( value )
         , m_unit( unit )
     {
@@ -75,7 +75,7 @@ public:
         for ( const auto& suffix : table.table )
             if ( s.endsWith( suffix.first ) )
             {
-                m_value = s.left( s.length() - suffix.first.length() ).toInt();
+                m_value = s.left( s.length() - suffix.first.length() ).toLongLong();
                 m_unit = suffix.second;
                 break;
             }
@@ -89,7 +89,7 @@ public:
      */
     NamedSuffix( const QString& s );
 
-    int value() const { return m_value; }
+    qint64 value() const { return m_value; }
     unit_t unit() const { return m_unit; }
 
     /** @brief Check that a value-unit combination is valid.
@@ -100,7 +100,7 @@ public:
     bool isValid() const;
 
 protected:
-    int m_value;
+    qint64 m_value;
     unit_t m_unit;
 };
 

--- a/src/libcalamares/utils/Variant.cpp
+++ b/src/libcalamares/utils/Variant.cpp
@@ -61,16 +61,20 @@ getString( const QVariantMap& map, const QString& key )
     return QString();
 }
 
-int
-getInteger( const QVariantMap& map, const QString& key, int d )
+qint64
+getInteger( const QVariantMap& map, const QString& key, qint64 d )
 {
-    int result = d;
+    qint64 result = d;
     if ( map.contains( key ) )
     {
         auto v = map.value( key );
         if ( v.type() == QVariant::Int )
         {
             result = v.toInt();
+        }
+        else if ( v.type() == QVariant::LongLong )
+        {
+            result = v.toLongLong();
         }
     }
 

--- a/src/libcalamares/utils/Variant.h
+++ b/src/libcalamares/utils/Variant.h
@@ -41,7 +41,7 @@ DLLEXPORT QString getString( const QVariantMap& map, const QString& key );
 /**
  * Get an integer value from a mapping; returns @p d if no value.
  */
-DLLEXPORT int getInteger( const QVariantMap& map, const QString& key, int d );
+DLLEXPORT qint64 getInteger( const QVariantMap& map, const QString& key, qint64 d );
 
 /**
  * Get a double value from a mapping (integers are converted); returns @p d if no value.

--- a/src/libcalamares/utils/Yaml.cpp
+++ b/src/libcalamares/utils/Yaml.cpp
@@ -79,7 +79,7 @@ yamlScalarToVariant( const YAML::Node& scalarNode )
     }
     if ( QRegExp( "[-+]?\\d+" ).exactMatch( scalarString ) )
     {
-        return QVariant( scalarString.toInt() );
+        return QVariant( scalarString.toLongLong() );
     }
     if ( QRegExp( "[-+]?\\d*\\.?\\d+" ).exactMatch( scalarString ) )
     {

--- a/src/modules/welcome/checker/GeneralRequirements.cpp
+++ b/src/modules/welcome/checker/GeneralRequirements.cpp
@@ -206,7 +206,7 @@ GeneralRequirements::setConfigurationMap( const QVariantMap& configurationMap )
 
     if ( configurationMap.contains( "requiredStorage" ) &&
          ( configurationMap.value( "requiredStorage" ).type() == QVariant::Double ||
-           configurationMap.value( "requiredStorage" ).type() == QVariant::Int ) )
+           configurationMap.value( "requiredStorage" ).type() == QVariant::LongLong ) )
     {
         bool ok = false;
         m_requiredStorageGiB = configurationMap.value( "requiredStorage" ).toDouble( &ok );
@@ -227,7 +227,7 @@ GeneralRequirements::setConfigurationMap( const QVariantMap& configurationMap )
 
     if ( configurationMap.contains( "requiredRam" ) &&
          ( configurationMap.value( "requiredRam" ).type() == QVariant::Double ||
-           configurationMap.value( "requiredRam" ).type() == QVariant::Int ) )
+           configurationMap.value( "requiredRam" ).type() == QVariant::LongLong ) )
     {
         bool ok = false;
         m_requiredRamGiB = configurationMap.value( "requiredRam" ).toDouble( &ok );


### PR DESCRIPTION
For the `partition` module, we might need to parse extremely large numbers (such as a multi-GiB sizes expressed in bytes), resulting in an overflow for 32-bit integers.
In order to solve this, this patch modifies `CalamaresUtils::getInteger()` in order to return a `qint64`.