### PR TITLE
Add 'base 10' partition size multiples

### DIFF
--- a/src/libcalamares/partition/PartitionSize.cpp
+++ b/src/libcalamares/partition/PartitionSize.cpp
@@ -33,7 +33,8 @@ unitSuffixes()
         { QStringLiteral( "%" ), SizeUnit::Percent }, { QStringLiteral( "K" ), SizeUnit::KiB },
         { QStringLiteral( "KiB" ), SizeUnit::KiB },   { QStringLiteral( "M" ), SizeUnit::MiB },
         { QStringLiteral( "MiB" ), SizeUnit::MiB },   { QStringLiteral( "G" ), SizeUnit::GiB },
-        { QStringLiteral( "GiB" ), SizeUnit::GiB }
+        { QStringLiteral( "GiB" ), SizeUnit::GiB },   { QStringLiteral( "KB" ), SizeUnit::KB },
+        { QStringLiteral( "MB" ), SizeUnit::MB },     { QStringLiteral( "GB" ), SizeUnit::GB }
     };
 
     return names;
@@ -90,8 +91,11 @@ PartitionSize::toSectors( qint64 totalSectors, qint64 sectorSize ) const
             return totalSectors * value() / 100;
         }
     case SizeUnit::Byte:
+    case SizeUnit::KB:
     case SizeUnit::KiB:
+    case SizeUnit::MB:
     case SizeUnit::MiB:
+    case SizeUnit::GB:
     case SizeUnit::GiB:
         return CalamaresUtils::bytesToSectors( toBytes(), sectorSize );
     }
@@ -125,8 +129,11 @@ PartitionSize::toBytes( qint64 totalSectors, qint64 sectorSize ) const
             return totalSectors * value() / 100;
         }
     case SizeUnit::Byte:
+    case SizeUnit::KB:
     case SizeUnit::KiB:
+    case SizeUnit::MB:
     case SizeUnit::MiB:
+    case SizeUnit::GB:
     case SizeUnit::GiB:
         return toBytes();
     }
@@ -161,8 +168,11 @@ PartitionSize::toBytes( qint64 totalBytes ) const
             return totalBytes * value() / 100;
         }
     case SizeUnit::Byte:
+    case SizeUnit::KB:
     case SizeUnit::KiB:
+    case SizeUnit::MB:
     case SizeUnit::MiB:
+    case SizeUnit::GB:
     case SizeUnit::GiB:
         return toBytes();
     }
@@ -186,10 +196,16 @@ PartitionSize::toBytes() const
         return -1;
     case SizeUnit::Byte:
         return value();
+    case SizeUnit::KB:
+        return CalamaresUtils::KBtoBytes( static_cast< unsigned long long >( value() ) );
     case SizeUnit::KiB:
         return CalamaresUtils::KiBtoBytes( static_cast< unsigned long long >( value() ) );
+    case SizeUnit::MB:
+        return CalamaresUtils::MBtoBytes( static_cast< unsigned long long >( value() ) );
     case SizeUnit::MiB:
         return CalamaresUtils::MiBtoBytes( static_cast< unsigned long long >( value() ) );
+    case SizeUnit::GB:
+        return CalamaresUtils::GBtoBytes( static_cast< unsigned long long >( value() ) );
     case SizeUnit::GiB:
         return CalamaresUtils::GiBtoBytes( static_cast< unsigned long long >( value() ) );
     }
@@ -211,8 +227,11 @@ PartitionSize::operator<( const PartitionSize& other ) const
     case SizeUnit::Percent:
         return ( m_value < other.m_value );
     case SizeUnit::Byte:
+    case SizeUnit::KB:
     case SizeUnit::KiB:
+    case SizeUnit::MB:
     case SizeUnit::MiB:
+    case SizeUnit::GB:
     case SizeUnit::GiB:
         return ( toBytes() < other.toBytes() );
     }
@@ -234,8 +253,11 @@ PartitionSize::operator>( const PartitionSize& other ) const
     case SizeUnit::Percent:
         return ( m_value > other.m_value );
     case SizeUnit::Byte:
+    case SizeUnit::KB:
     case SizeUnit::KiB:
+    case SizeUnit::MB:
     case SizeUnit::MiB:
+    case SizeUnit::GB:
     case SizeUnit::GiB:
         return ( toBytes() > other.toBytes() );
     }
@@ -257,8 +279,11 @@ PartitionSize::operator==( const PartitionSize& other ) const
     case SizeUnit::Percent:
         return ( m_value == other.m_value );
     case SizeUnit::Byte:
+    case SizeUnit::KB:
     case SizeUnit::KiB:
+    case SizeUnit::MB:
     case SizeUnit::MiB:
+    case SizeUnit::GB:
     case SizeUnit::GiB:
         return ( toBytes() == other.toBytes() );
     }

--- a/src/libcalamares/partition/PartitionSize.h
+++ b/src/libcalamares/partition/PartitionSize.h
@@ -36,8 +36,11 @@ enum class SizeUnit
     None,
     Percent,
     Byte,
+    KB,
     KiB,
+    MB,
     MiB,
+    GB,
     GiB
 };
 

--- a/src/libcalamares/utils/Units.h
+++ b/src/libcalamares/utils/Units.h
@@ -25,16 +25,34 @@
 namespace CalamaresUtils
 {
 
+/** User defined literals, 1_KB is 1 KiloByte (= 10^3 bytes) */
+constexpr qint64 operator""_KB( unsigned long long m )
+{
+    return qint64( m ) * 1000;
+}
+
 /** User defined literals, 1_KiB is 1 KibiByte (= 2^10 bytes) */
 constexpr qint64 operator""_KiB( unsigned long long m )
 {
     return qint64( m ) * 1024;
 }
 
+/** User defined literals, 1_MB is 1 MegaByte (= 10^6 bytes) */
+constexpr qint64 operator""_MB( unsigned long long m )
+{
+    return operator""_KB(m)*1000;
+}
+
 /** User defined literals, 1_MiB is 1 MibiByte (= 2^20 bytes) */
 constexpr qint64 operator""_MiB( unsigned long long m )
 {
     return operator""_KiB(m)*1024;
+}
+
+/** User defined literals, 1_GB is 1 GigaByte (= 10^9 bytes) */
+constexpr qint64 operator""_GB( unsigned long long m )
+{
+    return operator""_MB(m)*1000;
 }
 
 /** User defined literals, 1_GiB is 1 GibiByte (= 2^30 bytes) */
@@ -44,9 +62,21 @@ constexpr qint64 operator""_GiB( unsigned long long m )
 }
 
 constexpr qint64
+KBtoBytes( unsigned long long m )
+{
+    return operator""_KB( m );
+}
+
+constexpr qint64
 KiBtoBytes( unsigned long long m )
 {
     return operator""_KiB( m );
+}
+
+constexpr qint64
+MBtoBytes( unsigned long long m )
+{
+    return operator""_MB( m );
 }
 
 constexpr qint64
@@ -56,9 +86,21 @@ MiBtoBytes( unsigned long long m )
 }
 
 constexpr qint64
+GBtoBytes( unsigned long long m )
+{
+    return operator""_GB( m );
+}
+
+constexpr qint64
 GiBtoBytes( unsigned long long m )
 {
     return operator""_GiB( m );
+}
+
+constexpr qint64
+KBtoBytes( double m )
+{
+    return qint64( m * 1000 );
 }
 
 constexpr qint64
@@ -68,9 +110,21 @@ KiBtoBytes( double m )
 }
 
 constexpr qint64
+MBtoBytes( double m )
+{
+    return qint64( m * 1000 * 1000 );
+}
+
+constexpr qint64
 MiBtoBytes( double m )
 {
     return qint64( m * 1024 * 1024 );
+}
+
+constexpr qint64
+GBtoBytes( double m )
+{
+    return qint64( m * 1000 * 1000 * 1000 );
 }
 
 constexpr qint64

--- a/src/libcalamares/utils/Units.h
+++ b/src/libcalamares/utils/Units.h
@@ -160,7 +160,7 @@ alignBytesToBlockSize( qint64 bytes, qint64 blocksize )
 constexpr qint64
 bytesToSectors( qint64 bytes, qint64 blocksize )
 {
-    return alignBytesToBlockSize( alignBytesToBlockSize( bytes, blocksize ), MiBtoBytes( 1ULL ) ) / blocksize;
+    return alignBytesToBlockSize( bytes, blocksize ) / blocksize;
 }
 
 }  // namespace CalamaresUtils

--- a/src/libcalamares/utils/Units.h
+++ b/src/libcalamares/utils/Units.h
@@ -160,7 +160,7 @@ alignBytesToBlockSize( qint64 bytes, qint64 blocksize )
 constexpr qint64
 bytesToSectors( qint64 bytes, qint64 blocksize )
 {
-    return alignBytesToBlockSize( bytes, blocksize ) / blocksize;
+    return alignBytesToBlockSize( alignBytesToBlockSize( bytes, blocksize ), MiBtoBytes( 1ULL ) ) / blocksize;
 }
 
 }  // namespace CalamaresUtils


### PR DESCRIPTION
In order to improve compatibility with third-party software, we could use a way to define partition sizes in 'base 10' multiples, namely kilo-, mega- & giga- (only 'base 2' multiples kibi-, mibi- & gibi- are supported for now).

Additionally, this PR modifies the `bytesToSectors()` function, so that partitions get aligned on sector boundaries, not necessarily on 1MiB blocks.