### PR TITLE
[unpackfs] Enable to use "/" as a source

### DIFF
--- a/src/modules/unpackfs/main.py
+++ b/src/modules/unpackfs/main.py
@@ -208,7 +208,7 @@ class UnpackOperation:
                 imgbasename = os.path.splitext(
                     os.path.basename(entry.source))[0]
                 imgmountdir = os.path.join(source_mount_path, imgbasename)
-                os.mkdir(imgmountdir)
+                os.makedirs(imgmountdir, exist_ok=True)
 
                 self.mount_image(entry, imgmountdir)
 


### PR DESCRIPTION
If we don't have/need an image for the rootfs, we might want to
configure the `/` directory as a source for unpackfs. Unfortunately,
this raises an error:
  - unpackfs first creates a temporary directory
  - it then creates a subdirectory for each source, using the source
path's basename
  - when the source is `/`, the basename is an empty string, therefore
the module tries to create an already existing directory

In order to prevent this error, we use the `os.makedirs` function with
parameter `exist_ok=True` instead of `os.mkdir`.