### PR TITLE
add esperanto branding translations, fix mis-configured ones

### DIFF
--- a/src/branding/default/lang/calamares-default_ar.ts
+++ b/src/branding/default/lang/calamares-default_ar.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="nl">
+<TS version="2.1" language="ar">
 <context>
     <name>show</name>
     <message>
@@ -11,7 +11,7 @@
     <message>
         <location filename="../show.qml" line="68"/>
         <source>This is a third Slide element.</source>
-	<translation>عرض الثالث</translation>
+        <translation>عرض الثالث</translation>
     </message>
 </context>
 </TS>

--- a/src/branding/default/lang/calamares-default_en.ts
+++ b/src/branding/default/lang/calamares-default_en.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="en_US">
+<TS version="2.1" language="en">
 <context>
     <name>show</name>
     <message>

--- a/src/branding/default/lang/calamares-default_eo.ts
+++ b/src/branding/default/lang/calamares-default_eo.ts
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="nl">
+<TS version="2.1" language="eo">
 <context>
     <name>show</name>
     <message>
         <location filename="../show.qml" line="64"/>
         <source>This is a second Slide element.</source>
-        <translation>Dit is het tweede Dia element.</translation>
+        <translation>Ĉi tio estas la dua gliteja.</translation>
     </message>
     <message>
         <location filename="../show.qml" line="68"/>
         <source>This is a third Slide element.</source>
-        <translation>Dit is het derde Dia element.</translation>
+        <translation>Ĉi tio estas la tria gliteja.</translation>
     </message>
 </context>
 </TS>

--- a/src/branding/default/lang/calamares-default_fr.ts
+++ b/src/branding/default/lang/calamares-default_fr.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="nl">
+<TS version="2.1" language="fr">
 <context>
     <name>show</name>
     <message>
@@ -11,7 +11,7 @@
     <message>
         <location filename="../show.qml" line="68"/>
         <source>This is a third Slide element.</source>
-	<translation>La troisième affice ce trouve ici.</translation>
+        <translation>La troisième affice ce trouve ici.</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
all of these translations other than english were declared as 'nl'
