### PR TITLE
cross-reference/clarify geoip documentation

### DIFF
--- a/src/modules/locale/LocaleViewStep.cpp
+++ b/src/modules/locale/LocaleViewStep.cpp
@@ -235,7 +235,7 @@ LocaleViewStep::setConfigurationMap( const QVariantMap& configurationMap )
     }
     else
     {
-        // Optional
+        // Accommodate deprecated geoip configuration
         m_geoipUrl = CalamaresUtils::getString( configurationMap, "geoipUrl" );
         m_geoipStyle = CalamaresUtils::getString( configurationMap, "geoipStyle" );
         m_geoipSelector = CalamaresUtils::getString( configurationMap, "geoipSelector" );

--- a/src/modules/locale/locale.conf
+++ b/src/modules/locale/locale.conf
@@ -23,6 +23,7 @@ zone:                       "New_York"
 #
 # Enable only when your Distribution is using an
 # custom path for locale.gen
+#
 #localeGenPath:             "PATH_TO/locale.gen"
 
 # GeoIP based Language settings: Leave commented out to disable GeoIP.
@@ -78,14 +79,19 @@ zone:                       "New_York"
 #    <Response><TimeZone>Europe/Brussels</TimeZone></Response>
 # ```
 #
-# To accomodate providers of GeoIP timezone data with peculiar timezone
+# To accommodate providers of GeoIP timezone data with peculiar timezone
 # naming conventions, the following cleanups are performed automatically:
 #  - backslashes are removed
 #  - spaces are replaced with _
 #
 # Legacy settings "geoipStyle", "geoipUrl" and "geoipSelector"
 # in the top-level are still supported, but I'd advise against.
+#
+# To disable GeoIP checking, either comment-out the entire geoip section,
+# or set the *style* key to an unsupported format (e.g. `none`).
+# Also, note the analogous feature in src/modules/welcome/welcome.conf.
+#
 geoip:
-    style:  "json"
-    url:    "https://geoip.kde.org/v1/calamares"
+    style:    "json"
+    url:      "https://geoip.kde.org/v1/calamares"
     selector: ""  # leave blank for the default

--- a/src/modules/welcome/welcome.conf
+++ b/src/modules/welcome/welcome.conf
@@ -69,13 +69,13 @@ requirements:
 # but remember to use a URL that returns full data **and** to
 # use a selector that will pick the country, not the timezone.
 #
-# To disable, either comment-out the entire section, or set
-# the *style* key to an unsupported format (e.g. `none`, as is
-# done here).
-
+# To disable GeoIP checking, either comment-out the entire geoip section,
+# or set the *style* key to an unsupported format (e.g. `none`).
+# Also, note the analogous feature in src/modules/locale/locale.conf.
+#
 geoip:
-    style:  "none"
-    url:    "https://geoip.kde.org/v1/ubiquity"  # extended XML format
+    style:    "none"
+    url:      "https://geoip.kde.org/v1/ubiquity"  # extended XML format
     selector: "CountryCode"  # blank uses default, which is wrong
 
 # User interface


### PR DESCRIPTION
mainly to clarify that geoip requests can originate from two different modules for those who wish to disable it
