### PR TITLE
eliminate magic number in src/modules/welcome/WelcomePage.cpp

### DIFF
--- a/src/modules/welcome/WelcomePage.cpp
+++ b/src/modules/welcome/WelcomePage.cpp
@@ -124,7 +124,8 @@ WelcomePage::WelcomePage( QWidget* parent )
         mb.exec();
     } );
 
-    ui->verticalLayout->insertWidget( 3, m_checkingWidget );
+    int welcome_text_idx = ui->verticalLayout->indexOf( ui->mainText );
+    ui->verticalLayout->insertWidget( welcome_text_idx + 1, m_checkingWidget );
 }
 
 


### PR DESCRIPTION
this is a patch i am carrying - the hard-coded index is problematic if any custom elements are added to the page - for instance, i added a banner image above the welcome message - i could append that patch too if others want it - the banner image element is added only if it is defined in the branding config
