### PR TITLE
add checkbox to disable password validations

### DIFF
--- a/src/modules/users/UsersPage.h
+++ b/src/modules/users/UsersPage.h
@@ -48,6 +48,8 @@ public:
     void onActivate();
 
     void setWriteRootPassword( bool show );
+    void setPasswordCheckboxVisible( bool visible );
+    void setValidatePasswordDefault( bool checked );
     void setAutologinDefault( bool checked );
     void setReusePasswordDefault( bool checked );
 

--- a/src/modules/users/UsersViewStep.cpp
+++ b/src/modules/users/UsersViewStep.cpp
@@ -173,6 +173,18 @@ UsersViewStep::setConfigurationMap( const QVariantMap& configurationMap )
         }
     }
 
+    if ( configurationMap.contains( "allowWeakPasswords" ) &&
+        configurationMap.value( "allowWeakPasswords" ).type() == QVariant::Bool )
+    {
+        m_widget->setPasswordCheckboxVisible( configurationMap.value( "allowWeakPasswords" ).toBool() );
+    }
+
+    if ( configurationMap.contains( "doPasswordChecks" ) &&
+        configurationMap.value( "doPasswordChecks" ).type() == QVariant::Bool )
+    {
+        m_widget->setValidatePasswordDefault( configurationMap.value( "doPasswordChecks" ).toBool() );
+    }
+
     QString shell( QLatin1Literal( "/bin/bash" ) );  // as if it's not set at all
     if ( configurationMap.contains( "userShell" ) )
         shell = CalamaresUtils::getString( configurationMap, "userShell" );

--- a/src/modules/users/page_usersetup.ui
+++ b/src/modules/users/page_usersetup.ui
@@ -461,6 +461,13 @@
     </spacer>
    </item>
    <item>
+    <widget class="QCheckBox" name="checkBoxValidatePassword">
+     <property name="text">
+      <string>Require strong passwords.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="checkBoxAutoLogin">
      <property name="text">
       <string>Log in automatically without asking for the password.</string>

--- a/src/modules/users/users.conf
+++ b/src/modules/users/users.conf
@@ -28,7 +28,7 @@ defaultGroups:
 # Disable when your Distribution does not require such a group.
 autologinGroup:  autologin
 # You can control the initial state for the 'autologin checkbox' in UsersViewStep here.
-# Possible values are: true to enable or false to disable the checkbox by default
+# Possible values are: true to enable or false to disable the checkbox by default.
 doAutologin:     true
 
 # When set to a non-empty string, Calamares creates a sudoers file for the user.
@@ -68,12 +68,23 @@ doReusePassword: true
 #
 # (additional checks may be implemented in CheckPWQuality.cpp and
 # wired into UsersPage.cpp)
+#
+# To disable specific password validations,
+# comment out the relevant 'passwordRequirements' keys below.
+# To disable all password validations,
+# set both 'allowWeakPasswords' and 'doPasswordChecks' to false.
 passwordRequirements:
     minLength: -1  # Password at least this many characters
     maxLength: -1  # Password at most this many characters
     libpwquality:
         - minlen=0
         - minclass=0
+# You can control the visibility of the 'strong passwords' checkbox in UsersViewStep here.
+# Possible values are: true to show or false to hide the checkbox.
+allowWeakPasswords: true
+# You can control the initial state for the 'strong passwords' checkbox in UsersViewStep here.
+# Possible values are: true to enable or false to disable the checkbox by default.
+doPasswordChecks: true
 
 # Shell to be used for the regular user of the target system.
 # There are three possible kinds of settings:


### PR DESCRIPTION
this is useful for grown-up users (and devs) to be able to use weak passwords if they so choose, while keeping the constraints enabled by default - it currently only guards the libpwquality checks; and is hidden when libpwquality is not linked in