### PR TITLE
fix typos in src/modules/packagechooser/packagechooser.conf

### DIFF
--- a/src/modules/packagechooser/packagechooser.conf
+++ b/src/modules/packagechooser/packagechooser.conf
@@ -24,7 +24,7 @@ mode: required
 # The following translated keys are used:
 #  - *step*, used in the overall progress view (left-hand pane)
 #
-# Each key kan have a [locale] added to it, which is used as
+# Each key can have a [locale] added to it, which is used as
 # the translated string for that locale. For the strings
 # associated with the "no-selection" item, see *items*, below
 # with the explicit id "".
@@ -42,7 +42,7 @@ labels:
 # as a source for the data.
 #
 # For data provided by the list: the item has an id, which is used in
-# setting the value of *packagechooser_<module-id>*). The following fields
+# setting the value of *packagechooser_<module-id>*. The following fields
 # are mandatory:
 #
 #  - *id* ID for the product. The ID "" is special, and is used for

--- a/src/modules/packagechooser/packagechooser.conf
+++ b/src/modules/packagechooser/packagechooser.conf
@@ -45,19 +45,21 @@ labels:
 # setting the value of *packagechooser_<module-id>*. The following fields
 # are mandatory:
 #
-#  - *id* ID for the product. The ID "" is special, and is used for
-#    "no package selected". Only include this if the mode allows
-#    selecting none.
-#  - *package* Package name for the product. While mandatory, this is
-#       not actually used anywhere.
-#  - *name* Human-readable name of the product. To provide translations,
-#       add a *[lang]* decoration as part of the key name, e.g. `name[nl]`
-#       for Dutch. The list of usable languages can be found in
-#       `CMakeLists.txt` or as part of the debug output of Calamares.
-#  - *description* Human-readable description. These can be translated
-#       as well.
-#  - *screenshot* Path to a single screenshot of the product. May be
-#       a filesystem path or a QRC path (e.g. ":/images/no-selection.png").
+#  - *id* : ID for the product. The ID "" is special, and is used for
+#           "no package selected". Only include this if the mode allows
+#           selecting none.
+#  - *package* : Package name for the product. While mandatory, this is
+#                not actually used anywhere.
+#  - *name* : Human-readable name of the product. To provide translations,
+#             add a *[lang]* decoration as part of the key name,
+#               e.g. `name[nl]` for Dutch.
+#             The list of usable languages can be found in
+#             `CMakeLists.txt` or as part of the debug output of Calamares.
+#  - *description* : Human-readable description. These can be translated
+#                    as well.
+#  - *screenshot* : Path to a single screenshot of the product. May be
+#                   a filesystem path or a QRC path,
+#                     e.g. ":/images/no-selection.png".
 #
 # Use the empty string "" as ID / key for the "no selection" item if
 # you want to customize the display of that item as well.
@@ -66,7 +68,7 @@ labels:
 # key which points to an AppData XML file in the local filesystem.
 # This file is parsed to provide the id (from AppData id), name
 # (from AppData name), description (from AppData description paragraphs
-# or the summary entries), and a screenshot (the defautl screenshot
+# or the summary entries), and a screenshot (the default screenshot
 # from AppData). No package is set (but that is unused anyway).
 #
 # AppData may contain IDs that are not useful inside Calamares,


### PR DESCRIPTION
the second commit only changes white-space for readability