### PR TITLE
replace hard-coded bg color of requirements failure notice with relative tint

### DIFF
--- a/src/modules/welcome/checker/ResultsListWidget.cpp
+++ b/src/modules/welcome/checker/ResultsListWidget.cpp
@@ -71,11 +71,14 @@ ResultsListWidget::init( const Calamares::RequirementsList& checkEntries )
             allChecked = false;
             if ( entry.mandatory )
                 requirementsSatisfied = false;
+
             ciw->setAutoFillBackground( true );
             QPalette pal( ciw->palette() );
-            pal.setColor( QPalette::Background, Qt::white );
+            QColor bgColor = pal.window().color().value();
+            int bgHue = ( entry.satisfied ) ? bgColor.hue() : ( entry.mandatory ) ? 0 : 60;
+            bgColor.setHsv( bgHue, 64, bgColor.value() );
+            pal.setColor( QPalette::Window, bgColor );
             ciw->setPalette( pal );
-
         }
     }
 
@@ -196,7 +199,10 @@ ResultsListWidget::showDetailsDialog( const Calamares::RequirementsList& checkEn
 
         ciw->setAutoFillBackground( true );
         QPalette pal( ciw->palette() );
-        pal.setColor( QPalette::Background, Qt::white );
+        QColor bgColor = pal.window().color().value();
+        int bgHue = ( entry.satisfied ) ? bgColor.hue() : ( entry.mandatory ) ? 0 : 60;
+        bgColor.setHsv( bgHue, 64, bgColor.value() );
+        pal.setColor( QPalette::Window, bgColor );
         ciw->setPalette( pal );
     }
 


### PR DESCRIPTION
with dark themes, the failed requirement notice and pop-out message-box have un-readable white-on-white text - this is due to the hard-coded text color Qt::white

this MR applies a red-ish tint to whatever is the current background color beneath the warning text for failed mandatory checks, and a yellow-ish tint for failed optional checks - i made the change from 'QPalette::Background' to 'QPalette::Window' due to the deprecation notice on the QT docs website

this code could use to be dried out - i have more commits which do that if you want to see them - in fact, this ResultsListWidget is the only client of ResultWidget; so all of the configuration which is duplicated for both instances, could be moved into the ResultWidget constructor