### PR TITLE
pre-select default item in packagechooser

### DIFF
--- a/src/modules/packagechooser/PackageChooserPage.cpp
+++ b/src/modules/packagechooser/PackageChooserPage.cpp
@@ -140,6 +140,16 @@ PackageChooserPage::setModel( QAbstractItemModel* model )
              &PackageChooserPage::updateLabels );
 }
 
+void
+PackageChooserPage::setSelection( const QModelIndex& index )
+{
+    if ( index.isValid() )
+    {
+        ui->products->selectionModel()->select( index, QItemSelectionModel::Select );
+        currentChanged( index );
+    }
+}
+
 bool
 PackageChooserPage::hasSelection() const
 {

--- a/src/modules/packagechooser/PackageChooserPage.h
+++ b/src/modules/packagechooser/PackageChooserPage.h
@@ -35,10 +35,13 @@ class PackageChooserPage : public QWidget
 public:
     explicit PackageChooserPage( PackageChooserMode mode, QWidget* parent = nullptr );
 
+    /// @brief Sets the data model for the listview
     void setModel( QAbstractItemModel* model );
 
     /// @brief Sets the introductory (no-package-selected) texts
     void setIntroduction( const PackageItem& item );
+    /// @brief Selects a listview item
+    void setSelection( const QModelIndex& index );
     /// @brief Is anything selected?
     bool hasSelection() const;
     /** @brief Get the list of selected ids

--- a/src/modules/packagechooser/PackageChooserViewStep.cpp
+++ b/src/modules/packagechooser/PackageChooserViewStep.cpp
@@ -144,6 +144,12 @@ PackageChooserViewStep::isAtEnd() const
     return true;
 }
 
+void
+PackageChooserViewStep::onActivate()
+{
+    if ( !m_widget->hasSelection() )
+        m_widget->setSelection( m_defaultIdx );
+}
 
 void
 PackageChooserViewStep::onLeave()
@@ -198,6 +204,9 @@ PackageChooserViewStep::setConfigurationMap( const QVariantMap& configurationMap
         }
     }
 
+    QString default_item_id = CalamaresUtils::getString( configurationMap, "default" );
+    m_defaultIdx = QModelIndex();
+
     bool first_time = !m_model;
     if ( configurationMap.contains( "items" ) )
     {
@@ -207,6 +216,22 @@ PackageChooserViewStep::setConfigurationMap( const QVariantMap& configurationMap
     if ( first_time && m_widget && m_model )
     {
         hookupModel();
+    }
+
+    // find default item
+    if ( first_time && m_model && !default_item_id.isEmpty() )
+    {
+        for (int item_n = 0; item_n < m_model->packageCount(); ++item_n)
+        {
+            QModelIndex item_idx = m_model->index( item_n, 0 );
+            QVariant item_id = m_model->data( item_idx, PackageListModel::IdRole );
+
+            if ( item_id.toString() == default_item_id )
+            {
+                m_defaultIdx = item_idx;
+                break;
+            }
+        }
     }
 }
 

--- a/src/modules/packagechooser/PackageChooserViewStep.h
+++ b/src/modules/packagechooser/PackageChooserViewStep.h
@@ -50,6 +50,7 @@ public:
     bool isAtBeginning() const override;
     bool isAtEnd() const override;
 
+    void onActivate() override;
     void onLeave() override;
 
     Calamares::JobList jobs() const override;
@@ -67,6 +68,7 @@ private:
     PackageChooserMode m_mode;
     QString m_id;
     CalamaresUtils::Locale::TranslatedString* m_stepName;  // As it appears in the sidebar
+    QModelIndex m_defaultIdx;
 };
 
 CALAMARES_PLUGIN_FACTORY_DECLARATION( PackageChooserViewStepFactory )

--- a/src/modules/packagechooser/packagechooser.conf
+++ b/src/modules/packagechooser/packagechooser.conf
@@ -33,6 +33,10 @@ labels:
     step: "Packages"
     step[nl]: "Pakketten"
 
+# (Optional) 'id' of pre-selected list-view item.
+# Pre-selects one of the items below.
+# default: kde
+
 # Items to display in the chooser. In general, this should be a
 # pretty short list to avoid overwhelming the UI. This is a list
 # of objects, and the items are displayed in list order.


### PR DESCRIPTION
while evaluating the 'packagechooser' module, i noted some things that i did not like - one of them being that there was no way to have a static description/explanation of the module - the other more importanlty thing was that there is no way to pre-select a default list item - that would be quite useful, especially in "required" modes -

this MR accomplishes both of those features, while retaining the original behavior, if desired; by adding two new config keys to over-ride the existing null item method, if desired

the documentation for the 'item['id]' indicates that it is not intended to be used in 'required' modes

> Only include this if the mode allows selecting none.

for that reason, this MR also removes the null item if present and in one of the 'required' modes, regardless of the new over-rides
