### PR TITLE
[initcpiocfg] add usr hook if partition is separate

### DIFF
--- a/src/modules/initcpiocfg/main.py
+++ b/src/modules/initcpiocfg/main.py
@@ -144,6 +144,9 @@ def modify_mkinitcpio_conf(partitions, root_mount_point):
                 and "luksMapperName" not in partition):
             unencrypted_separate_boot = True
 
+        if partition["mountPoint"] == "/usr":
+            hooks.append("usr")
+
     if encrypt_hook:
         hooks.append("encrypt")
         if not unencrypted_separate_boot and \


### PR DESCRIPTION

The hook **usr** adds support for `/usr `on a separate partition when using **mkinicpio**. See [#/usr as a separate partition](https://wiki.archlinux.org/index.php/Mkinitcpio#/usr_as_a_separate_partition) for details. Function: Mounts the `/usr `partition after the real root has been mounted.



