### PR TITLE
Fix issue 1286

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,7 @@ if( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
 
     set( CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined" )
 
-    set( CALAMARES_AUTOMOC_OPTIONS "-butils/moc-warnings.h" )
+    set( CALAMARES_AUTOMOC_OPTIONS --include utils/moc-warnings.h )
     set( CALAMARES_AUTOUIC_OPTIONS --include utils/moc-warnings.h )
 else()
     set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-undefined" )


### PR DESCRIPTION
automoc in cmake 3.16.1 adds "-p subdirectory" to moc commands run for
files in a subdirectory, breaking inclusion of utils/moc-warnings.h the
way calamares currently does it for clang users.