### PR TITLE
i18n: Replace Kiev with Kyiv. Kiev is incorrect spelling

### DIFF
--- a/lang/tz_en.ts
+++ b/lang/tz_en.ts
@@ -1283,7 +1283,7 @@
     </message>
     <message>
         <location filename="../src/libcalamares/locale/ZoneData_p.cxxtr" line="253"/>
-        <source>Kiev</source>
+        <source>Kyiv</source>
         <comment>tz_names</comment>
         <translation type="unfinished"></translation>
     </message>

--- a/lang/tz_nl.ts
+++ b/lang/tz_nl.ts
@@ -1283,7 +1283,7 @@
     </message>
     <message>
         <location filename="../src/libcalamares/locale/ZoneData_p.cxxtr" line="253"/>
-        <source>Kiev</source>
+        <source>Kyiv</source>
         <comment>tz_names</comment>
         <translation type="unfinished"></translation>
     </message>

--- a/src/libcalamares/locale/ZoneData_p.cxxtr
+++ b/src/libcalamares/locale/ZoneData_p.cxxtr
@@ -250,7 +250,7 @@ static const QStringList& tz_names_table()
 		QObject::tr("Kerguelen", "tz_names"),
 		QObject::tr("Khandyga", "tz_names"),
 		QObject::tr("Khartoum", "tz_names"),
-		QObject::tr("Kiev", "tz_names"),
+		QObject::tr("Kyiv", "tz_names"),
 		QObject::tr("Kigali", "tz_names"),
 		QObject::tr("Kinshasa", "tz_names"),
 		QObject::tr("Kiritimati", "tz_names"),


### PR DESCRIPTION
Official statement of the Ministry of Foreign Affairs of Ukraine
https://mfa.gov.ua/en/page/open/id/5418