### PR TITLE
Update main.py

### DIFF
--- a/src/modules/grubcfg/main.py
+++ b/src/modules/grubcfg/main.py
@@ -72,6 +72,12 @@ def modify_grub_default(partitions, root_mount_point, distributor):
     swap_uuid = ""
     swap_outer_uuid = ""
     swap_outer_mappername = None
+    no_save_default = False
+
+    for partition in partitions:
+        if partition["mountPoint"] in ("/", "/boot") and partition["fs"] in ("btrfs", "f2fs"):
+            no_save_default = True
+            break
 
     if have_plymouth:
         use_splash = "splash"
@@ -191,6 +197,9 @@ def modify_grub_default(partitions, root_mount_point, distributor):
                     # We're not updating because of *keepDistributor*, but if
                     # this was a comment line, then it's still not been set.
                     have_distributor_line = have_distributor_line or not lines[i].startswith("#")
+            # If btrfs or f2fs is used, don't save default
+            if no_save_default and lines[i].startswith("GRUB_SAVEDEFAULT="):
+                lines[i] = "#GRUB_SAVEDEFAULT=\"true\""
     else:
         lines = []
 


### PR DESCRIPTION
Unset GRUB_SAVEDEFAULT if / or /boot is in btrfs or f2fs partition. This avoids the error "sparse file not allowed" at boot time. Btrfs and f2fs do not support saving default entry in grub.