### PR TITLE
[packages] Add apk (Alpine Linux package manager) support

### DIFF
--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -364,6 +364,24 @@ class PMPisi(PackageManager):
         pass
 
 
+class PMApk(PackageManager):
+    backend = "apk"
+
+    def install(self, pkgs, from_local=False):
+        for pkg in pkgs:
+            check_target_env_call(["apk", "add", pkg])
+
+    def remove(self, pkgs):
+        for pkg in pkgs:
+            check_target_env_call(["apk", "del", pkg])
+
+    def update_db(self):
+        check_target_env_call(["apk", "update"])
+
+    def update_system(self):
+        check_target_env_call(["apk", "upgrade", "--available"])
+
+
 # Collect all the subclasses of PackageManager defined above,
 # and index them based on the backend property of each class.
 backend_managers = [

--- a/src/modules/packages/packages.conf
+++ b/src/modules/packages/packages.conf
@@ -10,6 +10,7 @@
 #  - pacman      - Pacman
 #  - portage     - Gentoo package manager
 #  - entropy     - Sabayon package manager
+#  - apk         = Alpine Linux package manager
 #  - dummy       - Dummy manager, only logs
 #
 backend: dummy


### PR DESCRIPTION
Yay for easy Python scripting!

Since we're looking into using Calamares as on-device installer for postmarketOS, let's add support for the Alpine Linux (which postmarketOS is based on) package manager.

Is this the only required bit as far as packages go, or is there some other things that need specific Alpine Linux support to work?