### PR TITLE
[partition] Add support for filesystem-specific features

### DIFF
--- a/src/libcalamares/CMakeLists.txt
+++ b/src/libcalamares/CMakeLists.txt
@@ -128,7 +128,12 @@ if ( KPMcore_FOUND )
     find_package( Qt5 REQUIRED DBus )  # Needed for KPMCore
     find_package( KF5 REQUIRED I18n WidgetsAddons )  # Needed for KPMCore
 
-    if( KPMcore_VERSION VERSION_GREATER_EQUAL "4.0" )
+    if( KPMcore_VERSION VERSION_GREATER_EQUAL "4.2" )
+        add_definitions(
+            -DWITH_KPMCORE42API
+            -DWITH_KPMCORE4API
+        ) # kpmcore 4.2 with new API
+    elseif( KPMcore_VERSION VERSION_GREATER_EQUAL "4.0" )
         add_definitions( -DWITH_KPMCORE4API ) # kpmcore 4 with new API
     elseif( KPMcore_VERSION VERSION_GREATER "3.3.70" )
         message( FATAL_ERROR "KPMCore beta versions ${KPMcore_VERSION} not supported" )

--- a/src/modules/fsresizer/CMakeLists.txt
+++ b/src/modules/fsresizer/CMakeLists.txt
@@ -8,7 +8,9 @@ set( _partition_defs "" )
 if ( KPMcore_FOUND AND Qt5DBus_FOUND AND KF5CoreAddons_FOUND AND KF5Config_FOUND )
     include_directories( ${KPMCORE_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/src/modules/partition )
 
-    if( KPMcore_VERSION VERSION_GREATER_EQUAL "4.0" )
+    if( KPMcore_VERSION VERSION_GREATER_EQUAL "4.2" )
+        list( APPEND _partition_defs WITH_KPMCORE42API WITH_KPMCORE4API ) # kpmcore 4.2 with new API
+    elseif( KPMcore_VERSION VERSION_GREATER_EQUAL "4.0" )
         list( APPEND _partition_defs WITH_KPMCORE4API ) # kpmcore 4 with new API
     elseif( KPMcore_VERSION VERSION_GREATER "3.3.70" )
         message( FATAL_ERROR "KPMCore beta versions ${KPMcore_VERSION} are not supported" )

--- a/src/modules/partition/CMakeLists.txt
+++ b/src/modules/partition/CMakeLists.txt
@@ -33,6 +33,9 @@ if ( KPMcore_FOUND AND Qt5DBus_FOUND AND KF5CoreAddons_FOUND AND KF5Config_FOUND
     if ( KPMcore_VERSION VERSION_GREATER "3.90")
         list( APPEND _partition_defs WITH_KPMCORE4API) # kpmcore 4 with new API
     endif()
+    if( KPMcore_VERSION VERSION_GREATER_EQUAL "4.2" )
+        list( APPEND _partition_defs WITH_KPMCORE42API) # kpmcore 4.2 with new API
+    endif()
 
     include_directories( ${KPMCORE_INCLUDE_DIR} )
     include_directories( ${PROJECT_BINARY_DIR}/src/libcalamaresui )

--- a/src/modules/partition/core/PartitionCoreModule.cpp
+++ b/src/modules/partition/core/PartitionCoreModule.cpp
@@ -834,6 +834,7 @@ PartitionCoreModule::initLayout()
 void
 PartitionCoreModule::initLayout( const QVariantList& config )
 {
+    bool ok;
     QString sizeString;
     QString minSizeString;
     QString maxSizeString;
@@ -884,6 +885,7 @@ PartitionCoreModule::initLayout( const QVariantList& config )
         if ( !m_partLayout->addEntry( CalamaresUtils::getString( pentry, "name" ),
                                       CalamaresUtils::getString( pentry, "mountPoint" ),
                                       CalamaresUtils::getString( pentry, "filesystem" ),
+                                      CalamaresUtils::getSubMap( pentry, "features", ok ),
                                       sizeString,
                                       minSizeString,
                                       maxSizeString ) )

--- a/src/modules/partition/core/PartitionLayout.cpp
+++ b/src/modules/partition/core/PartitionLayout.cpp
@@ -120,6 +120,7 @@ bool
 PartitionLayout::addEntry( const QString& label,
                            const QString& mountPoint,
                            const QString& fs,
+                           const QVariantMap& features,
                            const QString& size,
                            const QString& min,
                            const QString& max )
@@ -144,6 +145,7 @@ PartitionLayout::addEntry( const QString& label,
     {
         entry.partFileSystem = m_defaultFsType;
     }
+    entry.partFeatures = features;
 
     m_partLayout.append( entry );
 
@@ -238,6 +240,15 @@ PartitionLayout::execute( Device* dev,
         if ( !part.partLabel.isEmpty() )
         {
             currentPartition->fileSystem().setLabel( part.partLabel );
+        }
+        if ( !part.partFeatures.isEmpty() )
+        {
+#if defined( WITH_KPMCORE42API )
+            for ( const auto& k : part.partFeatures.keys() )
+                currentPartition->fileSystem().addFeature( k, part.partFeatures.value(k) );
+#else
+            cWarning() << "Ignoring features; requires KPMcore >= 4.2.0.";
+#endif
         }
         // Some buggy (legacy) BIOSes test if the bootflag of at least one partition is set.
         // Otherwise they ignore the device in boot-order, so add it here.

--- a/src/modules/partition/core/PartitionLayout.h
+++ b/src/modules/partition/core/PartitionLayout.h
@@ -31,6 +31,7 @@
 // Qt
 #include <QList>
 #include <QObject>
+#include <QVariantMap>
 
 class Partition;
 
@@ -42,6 +43,7 @@ public:
         QString partLabel;
         QString partMountPoint;
         FileSystem::Type partFileSystem = FileSystem::Unknown;
+        QVariantMap partFeatures;
         CalamaresUtils::Partition::PartitionSize partSize;
         CalamaresUtils::Partition::PartitionSize partMinSize;
         CalamaresUtils::Partition::PartitionSize partMaxSize;
@@ -75,6 +77,7 @@ public:
     bool addEntry( const QString& label,
                    const QString& mountPoint,
                    const QString& fs,
+                   const QVariantMap& features,
                    const QString& size,
                    const QString& min = QString(),
                    const QString& max = QString() );

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -106,9 +106,15 @@ defaultFileSystemType:  "ext4"
 #       mountPoint: "/home"
 #       size: 3G
 #       minSize: 1.5G
+#       features:
+#         64bit: false
+#         casefold: true
 #     - name: "data"
 #       filesystem: "fat32"
 #       mountPoint: "/data"
+#       features:
+#         sector-size: 4096
+#         sectors-per-cluster: 128
 #       size: 100%
 #
 # There can be any number of partitions, each entry having the following attributes:
@@ -120,6 +126,8 @@ defaultFileSystemType:  "ext4"
 #           % of the available drive space if a '%' is appended to the value
 #   - minSize: minimum partition size (optional parameter)
 #   - maxSize: maximum partition size (optional parameter)
+#   - features: filesystem features (optional parameter; requires KPMCore >= 4.2.0)
+#       name: boolean or integer or string
 
 # Checking for available storage
 #


### PR DESCRIPTION
_KPMcore_ is now supporting for filesystem-specific features since the version _4.1.0_.

The file-system __features__ can be set using the module partition by specifying the dictionary `features` for any partition in `partitionLayout`. The feature is specific to the filesystem; the feature as a name and a value that can be either a boolean flag or an integer value or a string.

The example below tests the boolean and integer values feature. It:

- sets the both _FAT32_ features `sector-size` and `sectors-per-cluster` that take an integer value to the partition _efi_, and
- sets the _ext4_ feature `casefold` and resets the _ext4_ feature `64bit` that are two boolean flags to the partition _rootfs_. 

``` yaml
$ cat partition.conf
(...)
partitionLayout:
  - name: "efi"
    filesystem: "fat32"
    mountPoint: "/efi"
    size: 128M
    minSize: 128M
    features:
      sector-size: 4096
      sectors-per-cluster: 128
  - name: "rootfs"
    filesystem: "ext4"hg
    mountPoint: "/"
    size: 1G
    minSize: 1G
    features:
      casefold: true
      64bit: false
```

KPMcore generates the following commands:

-  `/usr/bin/mkfs.vat -S4096 -s124 -F32 -I -v /dev/sda1`
- `/usr/sbin/mkfs.ext4 -O ^64bit,casefold -qF /dev/sda2`

This commit uses the changes in the [commit] to add that support in `calamares`.

I hope you will like that contribution.

[commit]: https://github.com/KDE/kpmcore/commit/d24191ebd8ee4a1792003e5bd280cb7679f5e834