### PR TITLE
[partition] Name partition using filesystem label

### DIFF
--- a/src/modules/partition/core/PartitionLayout.cpp
+++ b/src/modules/partition/core/PartitionLayout.cpp
@@ -237,6 +237,7 @@ PartitionLayout::execute( Device* dev,
         PartitionInfo::setMountPoint( currentPartition, part.partMountPoint );
         if ( !part.partLabel.isEmpty() )
         {
+            currentPartition->setLabel( part.partLabel );
             currentPartition->fileSystem().setLabel( part.partLabel );
         }
         // Some buggy (legacy) BIOSes test if the bootflag of at least one partition is set.

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -112,7 +112,9 @@ defaultFileSystemType:  "ext4"
 #       size: 100%
 #
 # There can be any number of partitions, each entry having the following attributes:
-#   - name: partition label
+#   - name: filesystem label
+#           and
+#           partition name (gpt only; since KPMCore 4.2.0)
 #   - filesystem: filesystem type
 #   - mountPoint: partition mount point
 #   - size: partition size in bytes (append 'K', 'M' or 'G' for KiB, MiB or GiB)


### PR DESCRIPTION
Hello,

This PR reuses the attribute `name` to name the GTP partition; the `name` is used already to set the filesystem label.

``` yaml
partitionLayout:
  - name: "efi" # set the filesystem label to "efi" AND the gpt partition name to "efi" as well
    filesystem: "fat32"
    # (...)
  - name: "rootfs" # ditto with "rootfs"
    filesystem: "ext4"
    # (...)
```

The example above creates the following GPT disk:

```
label: gpt
label-id: X
device: /dev/sda
unit: sectors
first-lba: X
last-lba: X
sector-size: 512

/dev/sda1 : start=X, size=X, type=X, uuid=X, name="efi"
/dev/sda2 : start=X, size=X, type=X, uuid=X, name="rootfs"
#                                                                      ^- the GPT partition name is set
```

This MR needs the [MR](https://invent.kde.org/kde/kpmcore/-/merge_requests/4) to be merged in KPMCore to be functional, but it does not require it to compile.

Regards,
Gaël