### PR TITLE
[localeq] Repeater with zonesModel crashes cala

### DIFF
--- a/src/modules/localeq/localeq.qml
+++ b/src/modules/localeq/localeq.qml
@@ -27,9 +27,9 @@ RowLayout
         Layout.fillWidth: true
         ColumnLayout {
             id: zones
-            Repeater {
+            ListView {
                 model: config.zonesModel
-                Text {
+                delegate: Text { 
                     text: label
                 }
             }


### PR DESCRIPTION
probably due to dynamically loading items
regionModel now lists, zonesModel only lists one delegate, but
working on QML modules can now continue without crashing cala