### PR TITLE
[bootloader] Set the EFI Boot Next

### DIFF
--- a/src/modules/bootloader/main.py
+++ b/src/modules/bootloader/main.py
@@ -403,6 +403,21 @@ def install_secureboot(efi_directory):
         "-p", efi_partition_number,
         "-l", install_efi_directory + "/" + install_efi_bin])
 
+    boot_entry = None
+    efi_bootvars = subprocess.check_output(
+        [libcalamares.job.configuration["efiBootMgr"]], text=True)
+    for line in efi_bootvars.split('\n'):
+        if not line:
+            continue
+        words = line.split()
+        if len(words) >= 2 and words[0] == "BootOrder:":
+            boot_entry = words[1].split(',')[0] 
+            break
+    if boot_entry:
+        subprocess.call([
+            libcalamares.job.configuration["efiBootMgr"],
+            "-n", boot_entry])
+
     # The input file /etc/default/grub should already be filled out by the
     # grubcfg job module.
     check_target_env_call([libcalamares.job.configuration["grubMkconfig"],


### PR DESCRIPTION
 - This forces the EFI firmware to boot the loader that was just
   created, whatever the boot order set in the firmware setup (USB,
   CD/DVD, HD...).
 - It is safe to use the first Boot Entry listed in BootOrder as the
   previous command creates the new entry and adds it to the first place
   of the BootOrder.