### PR TITLE
[bootloader] Remove unused variable root_mount_point

### DIFF
--- a/src/modules/bootloader/main.py
+++ b/src/modules/bootloader/main.py
@@ -57,7 +57,6 @@ def get_uuid():
 
     :return:
     """
-    root_mount_point = libcalamares.globalstorage.value("rootMountPoint")
     partitions = libcalamares.globalstorage.value("partitions")
 
     for partition in partitions:


### PR DESCRIPTION
- root_mount_point was used initially for logging c1a139995 (adding new
  bootloader job options are to use grub for BIOS, gummiboot for efi set
  extra mountpoint when efi is found)
- the trace was removed since 533031b3c ([bootloader] print() does not
  log)