### PR TITLE
Partition UUID

### DIFF
--- a/src/modules/partition/core/PartitionCoreModule.cpp
+++ b/src/modules/partition/core/PartitionCoreModule.cpp
@@ -883,6 +883,7 @@ PartitionCoreModule::initLayout( const QVariantList& config )
         }
 
         if ( !m_partLayout->addEntry( CalamaresUtils::getString( pentry, "name" ),
+                                      CalamaresUtils::getString( pentry, "uuid" ),
                                       CalamaresUtils::getString( pentry, "type" ),
                                       CalamaresUtils::getString( pentry, "mountPoint" ),
                                       CalamaresUtils::getString( pentry, "filesystem" ),

--- a/src/modules/partition/core/PartitionLayout.cpp
+++ b/src/modules/partition/core/PartitionLayout.cpp
@@ -118,6 +118,7 @@ PartitionLayout::addEntry( const QString& mountPoint, const QString& size, const
 
 bool
 PartitionLayout::addEntry( const QString& label,
+                           const QString& uuid,
                            const QString& type,
                            const QString& mountPoint,
                            const QString& fs,
@@ -140,6 +141,7 @@ PartitionLayout::addEntry( const QString& label,
     }
 
     entry.partLabel = label;
+    entry.partUUID = uuid;
     entry.partType = type;
     entry.partMountPoint = mountPoint;
     PartUtils::findFS( fs, &entry.partFileSystem );
@@ -243,6 +245,10 @@ PartitionLayout::execute( Device* dev,
         {
             currentPartition->setLabel( part.partLabel );
             currentPartition->fileSystem().setLabel( part.partLabel );
+        }
+        if ( !part.partUUID.isEmpty() )
+        {
+            currentPartition->setUUID( part.partUUID );
         }
         if ( !part.partType.isEmpty() )
         {

--- a/src/modules/partition/core/PartitionLayout.h
+++ b/src/modules/partition/core/PartitionLayout.h
@@ -41,6 +41,7 @@ public:
     struct PartitionEntry
     {
         QString partLabel;
+        QString partUUID;
         QString partType;
         QString partMountPoint;
         FileSystem::Type partFileSystem = FileSystem::Unknown;
@@ -76,6 +77,7 @@ public:
                    const QString& min = QString(),
                    const QString& max = QString() );
     bool addEntry( const QString& label,
+                   const QString& uuid,
                    const QString& type,
                    const QString& mountPoint,
                    const QString& fs,

--- a/src/modules/partition/jobs/FillGlobalStorageJob.cpp
+++ b/src/modules/partition/jobs/FillGlobalStorageJob.cpp
@@ -91,6 +91,8 @@ mapForPartition( Partition* partition, const QString& uuid )
 {
     QVariantMap map;
     map[ "device" ] = partition->partitionPath();
+    map[ "partlabel" ] = partition->label();
+    map[ "partuuid" ] = partition->uuid();
     map[ "mountPoint" ] = PartitionInfo::mountPoint( partition );
     map[ "fsName" ] = userVisibleFS( partition->fileSystem() );
     map[ "fs" ] = untranslatedFS( partition->fileSystem() );
@@ -107,6 +109,7 @@ mapForPartition( Partition* partition, const QString& uuid )
     Logger::CDebug deb;
     using TR = Logger::DebugRow< const char* const, const QString& >;
     deb << Logger::SubEntry << "mapping for" << partition->partitionPath() << partition->deviceNode()
+        << TR( "partlabel", map[ "partlabel" ].toString() ) << TR( "partuuid", map[ "partuuid" ].toString() )
         << TR( "mountPoint:", PartitionInfo::mountPoint( partition ) ) << TR( "fs:", map[ "fs" ].toString() )
         << TR( "fsName", map[ "fsName" ].toString() ) << TR( "uuid", uuid )
         << TR( "claimed", map[ "claimed" ].toString() );

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -127,6 +127,7 @@ defaultFileSystemType:  "ext4"
 #   - name: filesystem label
 #           and
 #           partition name (gpt only; since KPMCore 4.2.0)
+#   - uuid: partition uuid (optional parameter; gpt only; requires KPMCore >= 4.2.0)
 #   - type: partition type (optional parameter; gpt only; requires KPMCore >= 4.2.0)
 #   - filesystem: filesystem type
 #   - mountPoint: partition mount point


### PR DESCRIPTION
Hello,

This PR adds the attribute `uuid` that sets the `PARTUUID` to the GPT partition (
b3400b7) and adds the GPT `partlabel` and `partuuid` to the global storage (5cb0024).

This PR requires the [MR](https://invent.kde.org/kde/kpmcore/-/merge_requests/8) to be merged in KPMCore. Merged.

Regards,
Gaël