### PR TITLE
[rawfs] Fix crash if bogus is unset

### DIFF
--- a/src/modules/rawfs/main.py
+++ b/src/modules/rawfs/main.py
@@ -96,7 +96,7 @@ class RawFSItem:
         count = 0
 
         libcalamares.utils.debug("Copying {} to {}".format(self.source, self.destination))
-        if libcalamares.job.configuration["bogus"]:
+        if libcalamares.job.configuration.get("bogus", False):
             return
 
         srcsize, srcblksize = get_device_size(self.source)


### PR DESCRIPTION
Hello,

I found a crash with the module `rawfs`.

This happens since 74fb88f9ac674ccbe2aacf2e6a9e1298b692c50c if the new property `bogus` is unset, that is the case with the files `rawfs.conf` written before calamares version 3.2.24.

This fixes

```
	12:44:25 [6]: Python Error:
	 <class 'TypeError'>
	 'builtin_function_or_method' object is not subscriptable
	 File "/usr/lib/calamares/modules/rawfs/main.py", line 188, in run
	    item.copy(filesystems.index(item), len(filesystems))

	  File "/usr/lib/calamares/modules/rawfs/main.py", line 99, in copy
	    if libcalamares.job.configuration["bogus"]:
```

Best Regards,
Gaël