### PR TITLE
[partition] Partition table type settings

### DIFF
--- a/src/modules/partition/core/Config.cpp
+++ b/src/modules/partition/core/Config.cpp
@@ -239,6 +239,20 @@ Config::setConfigurationMap( const QVariantMap& configurationMap )
     Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
     gs->insert( "allowManualPartitioning",
                 CalamaresUtils::getBool( configurationMap, "allowManualPartitioning", true ) );
+
+    if ( configurationMap.contains( "requiredPartitionTableType" ) &&
+        configurationMap.value( "requiredPartitionTableType" ).type() == QVariant::List )
+    {
+        m_requiredPartitionTableType.clear();
+        m_requiredPartitionTableType.append( configurationMap.value( "requiredPartitionTableType" ).toStringList() );
+    }
+    else if ( configurationMap.contains( "requiredPartitionTableType" ) &&
+        configurationMap.value( "requiredPartitionTableType" ).type() == QVariant::String )
+    {
+        m_requiredPartitionTableType.clear();
+        m_requiredPartitionTableType.append( configurationMap.value( "requiredPartitionTableType" ).toString() );
+    }
+    gs->insert( "requiredPartitionTableType", m_requiredPartitionTableType);
 }
 
 void

--- a/src/modules/partition/core/Config.h
+++ b/src/modules/partition/core/Config.h
@@ -114,6 +114,7 @@ private:
     InstallChoice m_initialInstallChoice = NoChoice;
     InstallChoice m_installChoice = NoChoice;
     qreal m_requiredStorageGiB = 0.0;  // May duplicate setting in the welcome module
+    QStringList m_requiredPartitionTableType;
 };
 
 /** @brief Given a set of swap choices, return a sensible value from it.

--- a/src/modules/partition/core/PartitionActions.cpp
+++ b/src/modules/partition/core/PartitionActions.cpp
@@ -118,6 +118,14 @@ doAutopartition( PartitionCoreModule* core, Device* dev, Choices::AutoPartitionO
     // before that one, numbered 0..2047).
     qint64 firstFreeSector = CalamaresUtils::bytesToSectors( empty_space_sizeB, dev->logicalSize() );
 
+    PartitionTable::TableType partType = PartitionTable::nameToTableType( o.defaultPartitionTableType );
+    if ( partType == PartitionTable::unknownTableType )
+    {
+        partType = isEfi ? PartitionTable::gpt : PartitionTable::msdos;
+    }
+
+    core->createPartitionTable( dev, partType );
+
     if ( isEfi )
     {
         qint64 efiSectorCount = CalamaresUtils::bytesToSectors( uefisys_part_sizeB, dev->logicalSize() );
@@ -127,7 +135,6 @@ doAutopartition( PartitionCoreModule* core, Device* dev, Choices::AutoPartitionO
         // at firstFreeSector, we need efiSectorCount sectors, numbered
         // firstFreeSector..firstFreeSector+efiSectorCount-1.
         qint64 lastSector = firstFreeSector + efiSectorCount - 1;
-        core->createPartitionTable( dev, PartitionTable::gpt );
         Partition* efiPartition = KPMHelpers::createNewPartition( dev->partitionTable(),
                                                                   *dev,
                                                                   PartitionRole( PartitionRole::Primary ),
@@ -143,10 +150,6 @@ doAutopartition( PartitionCoreModule* core, Device* dev, Choices::AutoPartitionO
         }
         core->createPartition( dev, efiPartition, KPM_PARTITION_FLAG_ESP );
         firstFreeSector = lastSector + 1;
-    }
-    else
-    {
-        core->createPartitionTable( dev, PartitionTable::msdos );
     }
 
     const bool mayCreateSwap

--- a/src/modules/partition/core/PartitionActions.h
+++ b/src/modules/partition/core/PartitionActions.h
@@ -29,11 +29,13 @@ namespace Choices
 {
 struct ReplacePartitionOptions
 {
+    QString defaultPartitionTableType; // e.g. "gpt" or "msdos"
     QString defaultFsType;  // e.g. "ext4" or "btrfs"
     QString luksPassphrase;  // optional
 
-    ReplacePartitionOptions( const QString& fs, const QString& luks )
-        : defaultFsType( fs )
+    ReplacePartitionOptions( const QString& pt, const QString& fs, const QString& luks )
+        : defaultPartitionTableType ( pt )
+        , defaultFsType( fs )
         , luksPassphrase( luks )
     {
     }
@@ -45,12 +47,13 @@ struct AutoPartitionOptions : ReplacePartitionOptions
     quint64 requiredSpaceB;  // estimated required space for root partition
     Config::SwapChoice swap;
 
-    AutoPartitionOptions( const QString& fs,
+    AutoPartitionOptions( const QString& pt,
+                          const QString& fs,
                           const QString& luks,
                           const QString& efi,
                           qint64 requiredBytes,
                           Config::SwapChoice s )
-        : ReplacePartitionOptions( fs, luks )
+        : ReplacePartitionOptions( pt, fs, luks )
         , efiPartitionMountPoint( efi )
         , requiredSpaceB( requiredBytes > 0 ? static_cast< quint64 >( requiredBytes ) : 0 )
         , swap( s )

--- a/src/modules/partition/gui/ChoicePage.cpp
+++ b/src/modules/partition/gui/ChoicePage.cpp
@@ -448,7 +448,8 @@ ChoicePage::applyActionChoice( InstallChoice choice )
     {
         auto gs = Calamares::JobQueue::instance()->globalStorage();
 
-        PartitionActions::Choices::AutoPartitionOptions options { gs->value( "defaultFileSystemType" ).toString(),
+        PartitionActions::Choices::AutoPartitionOptions options { gs->value( "defaultPartitionTableType" ).toString(),
+                                                                  gs->value( "defaultFileSystemType" ).toString(),
                                                                   m_encryptWidget->passphrase(),
                                                                   gs->value( "efiSystemPartition" ).toString(),
                                                                   CalamaresUtils::GiBtoBytes(
@@ -805,7 +806,9 @@ ChoicePage::doReplaceSelectedPartition( const QModelIndex& current )
                             m_core,
                             selectedDevice(),
                             selectedPartition,
-                            { gs->value( "defaultFileSystemType" ).toString(), m_encryptWidget->passphrase() } );
+                            { gs->value( "defaultPartitionType" ).toString(),
+                              gs->value( "defaultFileSystemType" ).toString(),
+                              m_encryptWidget->passphrase() } );
                         Partition* homePartition = findPartitionByPath( { selectedDevice() }, *homePartitionPath );
 
                         if ( homePartition && doReuseHomePartition )

--- a/src/modules/partition/gui/ChoicePage.h
+++ b/src/modules/partition/gui/ChoicePage.h
@@ -154,6 +154,7 @@ private:
     int m_lastSelectedDeviceIndex = -1;
     int m_lastSelectedActionIndex = -1;
 
+    QStringList m_requiredPartitionTableType;
     QString m_defaultFsType;
     bool m_enableEncryptionWidget;
 

--- a/src/modules/partition/gui/PartitionViewStep.cpp
+++ b/src/modules/partition/gui/PartitionViewStep.cpp
@@ -574,6 +574,13 @@ PartitionViewStep::setConfigurationMap( const QVariantMap& configurationMap )
     }
     gs->insert( "defaultFileSystemType", fsRealName );
 
+    QString partitionTableName = CalamaresUtils::getString( configurationMap, "defaultPartitionTableType" );
+    if ( partitionTableName.isEmpty() )
+    {
+        cWarning() << "Partition-module setting *defaultPartitionTableType* is unset, "
+                      "will use gpt for efi or msdos for bios";
+    }
+    gs->insert( "defaultPartitionTableType", partitionTableName );
 
     // Now that we have the config, we load the PartitionCoreModule in the background
     // because it could take a while. Then when it's done, we can set up the widgets

--- a/src/modules/partition/gui/ReplaceWidget.cpp
+++ b/src/modules/partition/gui/ReplaceWidget.cpp
@@ -85,7 +85,8 @@ ReplaceWidget::applyChanges()
             Device* dev = model->device();
 
             PartitionActions::doReplacePartition(
-                m_core, dev, partition, { gs->value( "defaultFileSystemType" ).toString(), QString() } );
+                m_core, dev, partition, { gs->value( "defaultPartitionTableType" ).toString(),
+                    gs->value( "defaultFileSystemType" ).toString(), QString() } );
 
             if ( m_isEfi )
             {

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -102,6 +102,21 @@ initialSwapChoice: none
 # Names are case-sensitive and defined by KPMCore.
 # defaultPartitionTableType: msdos
 
+# Requirement for partition table type
+#
+# Restrict the installation on disks that match the type of partition
+# tables that are specified.
+#
+# Suggested values: msdos, gpt
+# If nothing is specified, Calamares defaults to both "msdos" and "mbr".
+#
+# Names are case-sensitive and defined by KPMCore.
+# requiredPartitionTableType: gpt
+# or,
+# requiredPartitionTableType:
+#     - msdos
+#     - gpt
+
 # Default filesystem type, used when a "new" partition is made.
 #
 # When replacing a partition, the existing filesystem inside the

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -88,6 +88,20 @@ initialPartitioningChoice: none
 # one of the items from the options.
 initialSwapChoice: none
 
+# Default partition table type, used when a "erase" disk is made.
+#
+# When erasing a disk, a new partition table is created on disk.
+# In other cases, e.g. Replace and Alongside, as well as when using
+# manual partitioning, this partition table exists already on disk
+# and it is left unmodified.
+#
+# Suggested values: gpt, msdos
+# If nothing is specified, Calamares defaults to "gpt" if system is
+# efi or "msdos".
+#
+# Names are case-sensitive and defined by KPMCore.
+# defaultPartitionTableType: msdos
+
 # Default filesystem type, used when a "new" partition is made.
 #
 # When replacing a partition, the existing filesystem inside the


### PR DESCRIPTION
Hello,

This PR ~~is an _RFC_ to~~ restricts the installation on disks that use a specified partition table.

For example, since the `systemd` 211and the service [systemd-gpt-auto-generator](https://www.freedesktop.org/software/systemd/man/systemd-gpt-auto-generator.html), it is possible to discover and mount various partitions based on the _GPT_ [type](https://www.freedesktop.org/wiki/Specifications/DiscoverablePartitionsSpec/).

Therefore, we want to make sure the operating system is installed on a _GPT_ disk.

For now, the option **Erase disk** creates a new _GPT_ partition table if the booted system is _EFI_; otherwise, it creates an _MBR/MSDOS_ partition table (legacy _BIOS_).

The options **Replace a partition** and **Install alongside** left untouched the partition table type that exists on disk.

The option **Manual partitioning** may reuse the existing partition or let the user pick up the one he wants.

This PR introduces the two new settings in `partition.conf`:
- `defaultPartitionTableType` that forces the use of a partition table type, whatever if the firmware (_EFI_ or _BIOS_); see the first commit. That setting takes a string.
- `requiredPartitionTableType` that specifies the type of partition table on which the operating system can be installed. If the disk partition type does not match, the options **Replace a partition**, **Install alongside** and **Manual partitioning** are hidden; only the option **Erase disk** is made available to the user; see the second commit. That setting takes a string or a list of strings.

Example:

``` yaml
defaultPartitionTableType: gpt
requiredPartitionTableType:
  - msdos
  - gpt
```

This one forces the use of GPT:
``` yaml
defaultPartitionTableType: gpt
requiredPartitionTableType: gpt
```

Both commits are independent.

This is out of scope, but I have noticed that the UI label message is hidden since 48d0de2e08d66d5c9f38b87fed66512f241f79bb. I have reused it in case of the partition table type mismatch.

But if that element is not used anymore, we can remove it entirely that will simplify the [code](https://github.com/calamares/calamares/blob/69c2d089f29338b0d48724a092c82149721bd091/src/modules/partition/gui/ChoicePage.cpp#L1266-L1370).