### PR TITLE
Partition Attributes

### DIFF
--- a/src/libcalamares/utils/Variant.cpp
+++ b/src/libcalamares/utils/Variant.cpp
@@ -85,6 +85,19 @@ getInteger( const QVariantMap& map, const QString& key, qint64 d )
     return result;
 }
 
+quint64
+getUnsignedInteger( const QVariantMap& map, const QString& key, quint64 u )
+{
+    quint64 result = u;
+    if ( map.contains( key ) )
+    {
+        auto v = map.value( key );
+        result = v.toString().toULongLong(nullptr, 0);
+    }
+
+    return result;
+}
+
 double
 getDouble( const QVariantMap& map, const QString& key, double d )
 {

--- a/src/libcalamares/utils/Variant.h
+++ b/src/libcalamares/utils/Variant.h
@@ -49,6 +49,11 @@ DLLEXPORT QString getString( const QVariantMap& map, const QString& key );
 DLLEXPORT qint64 getInteger( const QVariantMap& map, const QString& key, qint64 d );
 
 /**
+ * Get an unsigned integer value from a mapping; returns @p u if no value.
+ */
+DLLEXPORT quint64 getUnsignedInteger( const QVariantMap& map, const QString& key, quint64 u );
+
+/**
  * Get a double value from a mapping (integers are converted); returns @p d if no value.
  */
 DLLEXPORT double getDouble( const QVariantMap& map, const QString& key, double d );

--- a/src/modules/partition/core/PartitionCoreModule.cpp
+++ b/src/modules/partition/core/PartitionCoreModule.cpp
@@ -884,6 +884,7 @@ PartitionCoreModule::initLayout( const QVariantList& config )
 
         if ( !m_partLayout->addEntry( CalamaresUtils::getString( pentry, "name" ),
                                       CalamaresUtils::getString( pentry, "type" ),
+                                      CalamaresUtils::getUnsignedInteger( pentry, "attributes", 0 ),
                                       CalamaresUtils::getString( pentry, "mountPoint" ),
                                       CalamaresUtils::getString( pentry, "filesystem" ),
                                       CalamaresUtils::getSubMap( pentry, "features", ok ),

--- a/src/modules/partition/core/PartitionLayout.cpp
+++ b/src/modules/partition/core/PartitionLayout.cpp
@@ -119,6 +119,7 @@ PartitionLayout::addEntry( const QString& mountPoint, const QString& size, const
 bool
 PartitionLayout::addEntry( const QString& label,
                            const QString& type,
+                           quint64 attributes,
                            const QString& mountPoint,
                            const QString& fs,
                            const QVariantMap& features,
@@ -141,6 +142,7 @@ PartitionLayout::addEntry( const QString& label,
 
     entry.partLabel = label;
     entry.partType = type;
+    entry.partAttributes = attributes;
     entry.partMountPoint = mountPoint;
     PartUtils::findFS( fs, &entry.partFileSystem );
     if ( entry.partFileSystem == FileSystem::Unknown )
@@ -250,6 +252,14 @@ PartitionLayout::execute( Device* dev,
             currentPartition->setType( part.partType );
 #else
             cWarning() << "Ignoring type; requires KPMcore >= 4.2.0.";
+#endif
+        }
+        if ( part.partAttributes )
+        {
+#if defined( WITH_KPMCORE42API )
+            currentPartition->setAttributes( part.partAttributes );
+#else
+            cWarning() << "Ignoring attributes; requires KPMcore >= 4.2.0.";
 #endif
         }
         if ( !part.partFeatures.isEmpty() )

--- a/src/modules/partition/core/PartitionLayout.h
+++ b/src/modules/partition/core/PartitionLayout.h
@@ -42,6 +42,7 @@ public:
     {
         QString partLabel;
         QString partType;
+        quint64 partAttributes;
         QString partMountPoint;
         FileSystem::Type partFileSystem = FileSystem::Unknown;
         QVariantMap partFeatures;
@@ -77,6 +78,7 @@ public:
                    const QString& max = QString() );
     bool addEntry( const QString& label,
                    const QString& type,
+                   quint64 attributes,
                    const QString& mountPoint,
                    const QString& fs,
                    const QVariantMap& features,

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -106,6 +106,7 @@ defaultFileSystemType:  "ext4"
 #       size: 20%
 #       minSize: 500M
 #       maxSize: 10G
+#       attributes: 0xffff000000000003
 #     - name: "home"
 #       type = "933ac7e1-2eb4-4f13-b844-0e14e2aef915"
 #       filesystem: "ext4"
@@ -128,6 +129,7 @@ defaultFileSystemType:  "ext4"
 #           and
 #           partition name (gpt only; since KPMCore 4.2.0)
 #   - type: partition type (optional parameter; gpt only; requires KPMCore >= 4.2.0)
+#   - attributes: partition attributes (optional parameter; gpt only; requires KPMCore >= 4.2.0)
 #   - filesystem: filesystem type
 #   - mountPoint: partition mount point
 #   - size: partition size in bytes (append 'K', 'M' or 'G' for KiB, MiB or GiB)


### PR DESCRIPTION
Hello,

This PR adds the attribute `attributes` that sets the GPT attributes to the GPT partition.

This PR requires the [MR](https://invent.kde.org/system/kpmcore/-/merge_requests/9) to be merged in KPMCore. Merged.

This PR is similar to #1409 for GPT partition UUID (`PARTUUID`).

Regards,
Gaël