### PR TITLE
[partition] Strip extra file after the at sign

### DIFF
--- a/src/modules/partition/core/OsproberEntry.h
+++ b/src/modules/partition/core/OsproberEntry.h
@@ -41,6 +41,7 @@ struct OsproberEntry
 {
     QString prettyName;
     QString path;
+    QString file;
     QString uuid;
     bool canBeResized;
     QStringList line;

--- a/src/modules/partition/core/PartUtils.cpp
+++ b/src/modules/partition/core/PartUtils.cpp
@@ -393,17 +393,25 @@ runOsprober( DeviceModel* dm )
                 prettyName = lineColumns.value( 2 ).simplified();
             }
 
-            QString path = lineColumns.value( 0 ).simplified();
+            QString file, path = lineColumns.value( 0 ).simplified();
             if ( !path.startsWith( "/dev/" ) )  //basic sanity check
             {
                 continue;
+            }
+
+            // strip extra file after device: /dev/name@/path/to/file
+            int index = path.indexOf( '@' );
+            if ( index != -1 )
+            {
+                file = path.right( path.length() - index - 1 );
+                path = path.left( index );
             }
 
             FstabEntryList fstabEntries = lookForFstabEntries( path );
             QString homePath = findPartitionPathForMountPoint( fstabEntries, "/home" );
 
             osproberEntries.append(
-                { prettyName, path, QString(), canBeResized( dm, path ), lineColumns, fstabEntries, homePath } );
+                { prettyName, path, file, QString(), canBeResized( dm, path ), lineColumns, fstabEntries, homePath } );
             osproberCleanLines.append( line );
         }
     }

--- a/src/modules/partition/gui/ReplaceWidget.cpp
+++ b/src/modules/partition/gui/ReplaceWidget.cpp
@@ -177,7 +177,7 @@ ReplaceWidget::onPartitionSelected()
 
         QString fsNameForUser = userVisibleFS( partition->fileSystem() );
         QString prettyName = tr( "Data partition (%1)" ).arg( fsNameForUser );
-        for ( const QString& line : osproberLines )
+        for ( const auto& line : osproberLines )
         {
             QStringList lineColumns = line.split( ':' );
 


### PR DESCRIPTION
- os-proper may return an extra file after the device:
  /dev/sda1:Ubuntu 19.10 (19.10):Ubuntu:linux
  /dev/sdb1@/EFI/Microsoft/Boot/bootmgfw.efi:Windows Boot Manager:Windows:efi