### PR TITLE
[libcalamares] Handle integers prefixed with 0 or 0x

### DIFF
--- a/src/libcalamares/utils/Variant.cpp
+++ b/src/libcalamares/utils/Variant.cpp
@@ -72,14 +72,7 @@ getInteger( const QVariantMap& map, const QString& key, qint64 d )
     if ( map.contains( key ) )
     {
         auto v = map.value( key );
-        if ( v.type() == QVariant::Int )
-        {
-            result = v.toInt();
-        }
-        else if ( v.type() == QVariant::LongLong )
-        {
-            result = v.toLongLong();
-        }
+        result = v.toString().toLongLong(nullptr, 0);
     }
 
     return result;


### PR DESCRIPTION
- QString to-integer members detect if an integer string begins with
  "0x" (base 16) or "0", base 8; but QVariant members do not.
- QString: the C language convention is used is base is set to 0.
- Convert to QString and use its member toLongLong() and set base to 0
  to detect integer strings begin with a prefix.