### PR TITLE
[partition] Fix missing initialization of the attribute partAttributes

### DIFF
--- a/src/modules/partition/core/PartitionLayout.cpp
+++ b/src/modules/partition/core/PartitionLayout.cpp
@@ -85,10 +85,16 @@ PartitionLayout::addEntry( PartitionLayout::PartitionEntry entry )
     return true;
 }
 
+PartitionLayout::PartitionEntry::PartitionEntry()
+    : partAttributes( 0 )
+{
+}
+
 PartitionLayout::PartitionEntry::PartitionEntry( const QString& size, const QString& min, const QString& max )
     : partSize( size )
     , partMinSize( min )
     , partMaxSize( max )
+    , partAttributes( 0 )
 {
 }
 

--- a/src/modules/partition/core/PartitionLayout.h
+++ b/src/modules/partition/core/PartitionLayout.h
@@ -52,7 +52,7 @@ public:
         CalamaresUtils::Partition::PartitionSize partMaxSize;
 
         /// @brief All-zeroes PartitionEntry
-        PartitionEntry() {}
+        PartitionEntry();
         /// @brief Parse @p size, @p min and @p max to their respective member variables
         PartitionEntry( const QString& size, const QString& min, const QString& max );
 


### PR DESCRIPTION
Hello,

I forgot to initialize the attribute `partAttributes` in the default constructor and in the constructor with sizes. See #1435.

My bad.

Regards