### PR TITLE
[libcalamares] Add default value to variant helpers

### DIFF
--- a/src/libcalamares/utils/Variant.cpp
+++ b/src/libcalamares/utils/Variant.cpp
@@ -38,21 +38,19 @@ namespace CalamaresUtils
 bool
 getBool( const QVariantMap& map, const QString& key, bool d )
 {
-    bool result = d;
     if ( map.contains( key ) )
     {
         auto v = map.value( key );
         if ( v.type() == QVariant::Bool )
         {
-            result = v.toBool();
+            return v.toBool();
         }
     }
-
-    return result;
+    return d;
 }
 
 QString
-getString( const QVariantMap& map, const QString& key )
+getString( const QVariantMap& map, const QString& key, const QString& d )
 {
     if ( map.contains( key ) )
     {
@@ -62,11 +60,11 @@ getString( const QVariantMap& map, const QString& key )
             return v.toString();
         }
     }
-    return QString();
+    return d;
 }
 
 QStringList
-getStringList( const QVariantMap& map, const QString& key )
+getStringList( const QVariantMap& map, const QString& key, const QStringList& d )
 {
     if ( map.contains( key ) )
     {
@@ -76,60 +74,53 @@ getStringList( const QVariantMap& map, const QString& key )
             return v.toStringList();
         }
     }
-    return QStringList();
+    return d;
 }
 
 qint64
 getInteger( const QVariantMap& map, const QString& key, qint64 d )
 {
-    qint64 result = d;
     if ( map.contains( key ) )
     {
         auto v = map.value( key );
-        result = v.toString().toLongLong(nullptr, 0);
+        return v.toString().toLongLong(nullptr, 0);
     }
-
-    return result;
+    return d;
 }
 
 quint64
-getUnsignedInteger( const QVariantMap& map, const QString& key, quint64 u )
+getUnsignedInteger( const QVariantMap& map, const QString& key, quint64 d )
 {
-    quint64 result = u;
     if ( map.contains( key ) )
     {
         auto v = map.value( key );
-        result = v.toString().toULongLong(nullptr, 0);
+        return v.toString().toULongLong(nullptr, 0);
     }
-
-    return result;
+    return d;
 }
 
 double
 getDouble( const QVariantMap& map, const QString& key, double d )
 {
-    double result = d;
     if ( map.contains( key ) )
     {
         auto v = map.value( key );
         if ( v.type() == QVariant::Int )
         {
-            result = v.toInt();
+            return v.toInt();
         }
         else if ( v.type() == QVariant::Double )
         {
-            result = v.toDouble();
+            return v.toDouble();
         }
     }
-
-    return result;
+    return d;
 }
 
 QVariantMap
-getSubMap( const QVariantMap& map, const QString& key, bool& success )
+getSubMap( const QVariantMap& map, const QString& key, bool& success, const QVariantMap& d )
 {
     success = false;
-
     if ( map.contains( key ) )
     {
         auto v = map.value( key );
@@ -139,7 +130,7 @@ getSubMap( const QVariantMap& map, const QString& key, bool& success )
             return v.toMap();
         }
     }
-    return QVariantMap();
+    return d;
 }
 
 }  // namespace CalamaresUtils

--- a/src/libcalamares/utils/Variant.h
+++ b/src/libcalamares/utils/Variant.h
@@ -33,45 +33,44 @@
 namespace CalamaresUtils
 {
 /**
- * Get a bool value from a mapping with a given key; returns the default
- * if no value is stored in the map.
+ * Get a bool value from a mapping with a given key; returns @p d if no value.
  */
-DLLEXPORT bool getBool( const QVariantMap& map, const QString& key, bool d );
+DLLEXPORT bool getBool( const QVariantMap& map, const QString& key, bool d = false );
 
 /**
- * Get a string value from a mapping; returns empty QString if no value.
+ * Get a string value from a mapping with a given key; returns @p d if no value.
  */
-DLLEXPORT QString getString( const QVariantMap& map, const QString& key );
+DLLEXPORT QString getString( const QVariantMap& map, const QString& key, const QString& d = QString() );
 
 /**
- * Get a string list from a mapping; returns empty list if no value.
+ * Get a string list from a mapping with a given key; returns @p d if no value.
  */
-DLLEXPORT QStringList getStringList( const QVariantMap& map, const QString& key );
+DLLEXPORT QStringList getStringList( const QVariantMap& map, const QString& key, const QStringList& d = QStringList() );
 
 /**
- * Get an integer value from a mapping; returns @p d if no value.
+ * Get an integer value from a mapping with a given key; returns @p d if no value.
  */
-DLLEXPORT qint64 getInteger( const QVariantMap& map, const QString& key, qint64 d );
+DLLEXPORT qint64 getInteger( const QVariantMap& map, const QString& key, qint64 d = 0);
 
 /**
- * Get an unsigned integer value from a mapping; returns @p u if no value.
+ * Get an unsigned integer value from a mapping with a given key; returns @p d if no value.
  */
-DLLEXPORT quint64 getUnsignedInteger( const QVariantMap& map, const QString& key, quint64 u );
+DLLEXPORT quint64 getUnsignedInteger( const QVariantMap& map, const QString& key, quint64 d = 0 );
 
 /**
- * Get a double value from a mapping (integers are converted); returns @p d if no value.
+ * Get a double value from a mapping with a given key (integers are converted); returns @p d if no value.
  */
-DLLEXPORT double getDouble( const QVariantMap& map, const QString& key, double d );
+DLLEXPORT double getDouble( const QVariantMap& map, const QString& key, double d = 0.0 );
 
 /**
- * Returns a sub-map (i.e. a nested map) from the given mapping with the
+ * Returns a sub-map (i.e. a nested map) from a given mapping with a 
  * given key. @p success is set to true if the @p key exists
  * in @p map and converts to a map, false otherwise.
  *
- * Returns an empty map if there is no such key or it is not a map-value.
+ * Returns @p d if there is no such key or it is not a map-value.
  * (e.g. if @p success is false).
  */
-DLLEXPORT QVariantMap getSubMap( const QVariantMap& map, const QString& key, bool& success );
+DLLEXPORT QVariantMap getSubMap( const QVariantMap& map, const QString& key, bool& success, const QVariantMap& d = QVariantMap() );
 }  // namespace CalamaresUtils
 
 #endif


### PR DESCRIPTION
- Some variant helpers take a default parameter if the map does not
  contains the given key or if the type mismatches. Make all helpers
  behave the same.