### PR TITLE
[partition] Add the GPT type and attributes to global storage

### DIFF
--- a/src/modules/partition/jobs/FillGlobalStorageJob.cpp
+++ b/src/modules/partition/jobs/FillGlobalStorageJob.cpp
@@ -93,6 +93,8 @@ mapForPartition( Partition* partition, const QString& uuid )
     map[ "device" ] = partition->partitionPath();
     map[ "partlabel" ] = partition->label();
     map[ "partuuid" ] = partition->uuid();
+    map[ "parttype" ] = partition->type();
+    map[ "partattrs" ] = partition->attributes();
     map[ "mountPoint" ] = PartitionInfo::mountPoint( partition );
     map[ "fsName" ] = userVisibleFS( partition->fileSystem() );
     map[ "fs" ] = untranslatedFS( partition->fileSystem() );
@@ -110,6 +112,7 @@ mapForPartition( Partition* partition, const QString& uuid )
     using TR = Logger::DebugRow< const char* const, const QString& >;
     deb << Logger::SubEntry << "mapping for" << partition->partitionPath() << partition->deviceNode()
         << TR( "partlabel", map[ "partlabel" ].toString() ) << TR( "partuuid", map[ "partuuid" ].toString() )
+        << TR( "parttype", map[ "partype" ].toString() ) << TR( "partattrs", map[ "partattrs" ].toString() )
         << TR( "mountPoint:", PartitionInfo::mountPoint( partition ) ) << TR( "fs:", map[ "fs" ].toString() )
         << TR( "fsName", map[ "fsName" ].toString() ) << TR( "uuid", uuid )
         << TR( "claimed", map[ "claimed" ].toString() );


### PR DESCRIPTION
Hello,

This PR adds the GPT partition type `parttype` and `partattrs` to the global storage (as for `partlabel` and `partuuid` since commit 3d2b9053b08b41ee9dab70c61a9542324442b35a).

I have no opinion on with format to use to serialize the attributes to the global storage as is a 64bit integer, and should be expressed in hexadecimal as it is flags. String is fine? Any idea?

Regards,
Gaël