### PR TITLE
Revert Manual Partition instructions

### DIFF
--- a/src/modules/partition/gui/ChoicePage.cpp
+++ b/src/modules/partition/gui/ChoicePage.cpp
@@ -332,9 +332,7 @@ ChoicePage::setupChoices()
 
     CALAMARES_RETRANSLATE(
         m_somethingElseButton->setText( tr( "<strong>Manual partitioning</strong><br/>"
-                                            "You can create or resize partitions yourself."
-                                            " Having a GPT partition table and <strong>fat32 512Mb /boot partition "
-                                            "is a must for UEFI installs</strong>, either use an existing without formatting or create one." ) );
+                                            "You can create or resize partitions yourself." ) );
         updateSwapChoicesTr( m_eraseSwapChoiceComboBox );
     )
 }


### PR DESCRIPTION
With PR calamares/calamares#1357 the label of the "Manual partitioning" option
was changed, which introduced several downsides:
  * The label is shown for UEFI and for BIOS installations.
  * The mountpoint of the ESP is and should be distro specific.
  * The label always mentioned GPT, which is irrelevant.
  * The label should explain, what the option does, and not, what
    problems can occur under certain circumstances.