### PR TITLE
Do not allow 'root' as username

### DIFF
--- a/src/modules/users/UsersPage.cpp
+++ b/src/modules/users/UsersPage.cpp
@@ -409,6 +409,13 @@ UsersPage::validateUsernameText( const QString& textRef )
                     tr( "Only lowercase letters, numbers, underscore and hyphen are allowed." ) );
         m_readyUsername = false;
     }
+    else if ( 0 == QString::compare("root", text, Qt::CaseSensitive ) )
+    {
+        labelError( ui->labelUsername,
+                    ui->labelUsernameError,
+                    tr( "'root' is not allowed as user name." ) );
+        m_readyUsername = false;
+    }
     else
     {
         labelOk( ui->labelUsername, ui->labelUsernameError );


### PR DESCRIPTION
On the "Users" tab, the user can choose a username. It was possible to
use 'root' as username, which led to an installation error, because
'root' exists already.

Added a new check to the username validation.

Fixes #1462.