### PR TITLE
[mkinitfs] New module

### DIFF
--- a/src/modules/mkinitfs/main.py
+++ b/src/modules/mkinitfs/main.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# === This file is part of Calamares - <https://github.com/calamares> ===
+#
+#   Copyright 2014-2015, Philip Müller <philm@manjaro.org>
+#   Copyright 2014, Teo Mrnjavac <teo@kde.org>
+#   Copyright 2017, Alf Gaida <agaid@siduction.org>
+#   Copyright 2019, Adriaan de Groot <groot@kde.org>
+#
+#   Calamares is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Calamares is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with Calamares. If not, see <http://www.gnu.org/licenses/>.
+
+import libcalamares
+from libcalamares.utils import target_env_call
+
+
+import gettext
+_ = gettext.translation("calamares-python",
+                        localedir=libcalamares.utils.gettext_path(),
+                        languages=libcalamares.utils.gettext_languages(),
+                        fallback=True).gettext
+
+
+def pretty_name():
+    return _("Creating initramfs with mkinitfs.")
+
+
+def run_mkinitfs():
+    """
+    Creates initramfs, even when initramfs already exists.
+
+    :return:
+    """
+    return target_env_call(['mkinitfs'])
+
+
+def run():
+    """
+    Starts routine to create initramfs. It passes back the exit code
+    if it fails.
+
+    :return:
+    """
+    return_code = run_mkinitfs()
+
+    if return_code != 0:
+        return ( _("Failed to run mkinitfs on the target"),
+                 _("The exit code was {}").format(return_code) )

--- a/src/modules/mkinitfs/module.desc
+++ b/src/modules/mkinitfs/module.desc
@@ -1,0 +1,5 @@
+---
+type:		"job"
+name:		"mkinitfs"
+interface:	"python"
+script:		"main.py"


### PR DESCRIPTION
This module allows the generation of the initramfs in Alpine Linux based
systems (excluding postmarketOS). Very bare bones, but then again it
doesn't need much. It uses the Alpine Linux tool "mkinitfs" to do the
job.