### PR TITLE
retrieving string list fix

### DIFF
--- a/src/libcalamares/utils/Variant.cpp
+++ b/src/libcalamares/utils/Variant.cpp
@@ -67,7 +67,7 @@ getStringList( const QVariantMap& map, const QString& key, const QStringList& d 
     if ( map.contains( key ) )
     {
         auto v = map.value( key );
-        if ( v.type() == QVariant::StringList )
+        if ( v.canConvert( QMetaType::QStringList ) )
         {
             return v.toStringList();
         }
@@ -81,7 +81,7 @@ getInteger( const QVariantMap& map, const QString& key, qint64 d )
     if ( map.contains( key ) )
     {
         auto v = map.value( key );
-        return v.toString().toLongLong(nullptr, 0);
+        return v.toString().toLongLong( nullptr, 0 );
     }
     return d;
 }
@@ -92,7 +92,7 @@ getUnsignedInteger( const QVariantMap& map, const QString& key, quint64 d )
     if ( map.contains( key ) )
     {
         auto v = map.value( key );
-        return v.toString().toULongLong(nullptr, 0);
+        return v.toString().toULongLong( nullptr, 0 );
     }
     return d;
 }


### PR DESCRIPTION
previous implementation of type checking variable `v` was never true, as a string list in the map is actually of type `QVariantList`. its better to use the framework provided method `canConvert` to check if this can yield a string list and act on it. this may also fix the issue with `users` module's group bug. users module uses `getStringList` method to retrieve the config group list, which never returns the actual group list found in the config because of this bug.