### PR TITLE
Fix #1471 on more CPU's

### DIFF
--- a/src/modules/hostinfo/HostInfoJob.cpp
+++ b/src/modules/hostinfo/HostInfoJob.cpp
@@ -117,7 +117,7 @@ static QString
 hostCPUmatchARM( const QString& s )
 {
     // Both Rock64 and Raspberry pi mention 0x41
-    if ( s.contains( ": 0x41" ) )
+    if ( s.contains( ": 0x41" ) || s.contains( ": 0x50" ) )
     {
         return QStringLiteral( "ARM" );
     }


### PR DESCRIPTION
https://github.com/calamares/calamares/commit/5066624a8ebaac6c3ab3dc2cfb111e3c7e3cf40d fixed the `testHostOS` test on AMD and arm machines. However, at least the Alpine Linux aarch64 CI builder returns "CPU implementer: 0x50" rather than 0x41 like some other arm CPU's seem to do. Let's make sure it passes there as well, and it could possibly fix it for more distributions building it for arm.

(I should probably add some comment for which kind of device reports 0x50, but I don't know a proper message to put there)