### PR TITLE
Network manager internet checking fix

### DIFF
--- a/src/libcalamares/network/Manager.cpp
+++ b/src/libcalamares/network/Manager.cpp
@@ -144,7 +144,7 @@ Manager::Manager()
 {
 }
 
-Manager::~Manager() {}
+Manager::~Manager() { }
 
 Manager&
 Manager::instance()
@@ -164,7 +164,7 @@ Manager::checkHasInternet()
 {
     d->m_hasInternet = synchronousPing( d->m_hasInternetUrl );
     emit hasInternetChanged( d->m_hasInternet );
-    return hasInternet;
+    return d->m_hasInternet;
 }
 
 void

--- a/src/libcalamares/network/Manager.cpp
+++ b/src/libcalamares/network/Manager.cpp
@@ -163,7 +163,7 @@ bool
 Manager::checkHasInternet()
 {
     d->m_hasInternet = synchronousPing( d->m_hasInternetUrl );
-    emit hasInternetChanged( hasInternet );
+    emit hasInternetChanged( d->m_hasInternet );
     return hasInternet;
 }
 

--- a/src/libcalamares/network/Manager.cpp
+++ b/src/libcalamares/network/Manager.cpp
@@ -162,17 +162,8 @@ Manager::hasInternet()
 bool
 Manager::checkHasInternet()
 {
-    bool hasInternet = d->nam()->networkAccessible() == QNetworkAccessManager::Accessible;
-
-    if ( !hasInternet && ( d->nam()->networkAccessible() == QNetworkAccessManager::UnknownAccessibility ) )
-    {
-        hasInternet = synchronousPing( d->m_hasInternetUrl );
-    }
-    if ( hasInternet != d->m_hasInternet )
-    {
-        d->m_hasInternet = hasInternet;
-        emit hasInternetChanged( hasInternet );
-    }
+    d->m_hasInternet = synchronousPing( d->m_hasInternetUrl );
+    emit hasInternetChanged( hasInternet );
     return hasInternet;
 }
 


### PR DESCRIPTION
Qt's `QNetworkAccessManager::networkAccessible` is obsolete from version 5.15. I have checked with latest qt 5.15.0. the problem is this method now returns `true` even if the network/internet is not accessible. so using that to determine internet availability fails with newer versions of qt and probably will be removed from later versions of qt. it is still safe to use the `synchronousPing` method and i think it will be safe to use it for foreseeable future.