### PR TITLE
[partition] Fix message user if no option available

### DIFF
--- a/src/modules/partition/gui/ChoicePage.cpp
+++ b/src/modules/partition/gui/ChoicePage.cpp
@@ -1464,7 +1464,7 @@ ChoicePage::setupActions()
     }
 
     if ( m_somethingElseButton->isHidden() && m_alongsideButton->isHidden() && m_replaceButton->isHidden()
-         && m_somethingElseButton->isHidden() )
+         && m_eraseButton->isHidden() )
     {
         if ( atLeastOneIsMounted )
         {


### PR DESCRIPTION
Hello,

The button `m_eraseButton` is not tested while the button `m_somethingElseButton` is tested twice.

This happened due to a bad resolve of a conflict :facepalm:.