### PR TITLE
[partition,mount] Make mountPoint and filesystem optionals

### DIFF
--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -39,6 +39,9 @@ def mount_partition(root_mount_point, partition, partitions):
     # Create mount point with `+` rather than `os.path.join()` because
     # `partition["mountPoint"]` starts with a '/'.
     raw_mount_point = partition["mountPoint"]
+    if not raw_mount_point:
+        return
+
     mount_point = root_mount_point + raw_mount_point
 
     # Ensure that the created directory has the correct SELinux context on

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -56,6 +56,8 @@ def mount_partition(root_mount_point, partition, partitions):
         raise
 
     fstype = partition.get("fs", "").lower()
+    if not fstype or fstype == "unformatted":
+        return
 
     if fstype == "fat16" or fstype == "fat32":
         fstype = "vfat"

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -7,6 +7,7 @@
 #   SPDX-FileCopyrightText: 2017 Alf Gaida <agaida@siduction.org>
 #   SPDX-FileCopyrightText: 2019 Adriaan de Groot <groot@kde.org>
 #   SPDX-FileCopyrightText: 2019 Kevin Kofler <kevin.kofler@chello.at>
+#   SPDX-FileCopyrightText: 2019-2020 Collabora Ltd
 #   SPDX-License-Identifier: GPL-3.0-or-later
 #
 #   Calamares is Free Software: see the License-Identifier above.
@@ -56,22 +57,16 @@ def mount_partition(root_mount_point, partition, partitions):
     if fstype == "fat16" or fstype == "fat32":
         fstype = "vfat"
 
-    if "luksMapperName" in partition:
-        libcalamares.utils.debug(
-            "about to mount {!s}".format(partition["luksMapperName"]))
-        libcalamares.utils.mount(
-            "/dev/mapper/{!s}".format(partition["luksMapperName"]),
-            mount_point,
-            fstype,
-            partition.get("options", ""),
-            )
+    device = partition["device"]
 
-    else:
-        libcalamares.utils.mount(partition["device"],
-                                 mount_point,
-                                 fstype,
-                                 partition.get("options", ""),
-                                 )
+    if "luksMapperName" in partition:
+        device = os.path.join("/dev/mapper", partition["luksMapperName"])
+
+    if libcalamares.utils.mount(device,
+                                mount_point,
+                                fstype,
+                                partition.get("options", "")) != 0:
+        libcalamares.utils.warning("Cannot mount {}".format(device))
 
     # If the root partition is btrfs, we create a subvolume "@"
     # for the root mount point.
@@ -96,37 +91,23 @@ def mount_partition(root_mount_point, partition, partitions):
 
         subprocess.check_call(["umount", "-v", root_mount_point])
 
+        device = partition["device"]
+
         if "luksMapperName" in partition:
-            libcalamares.utils.mount(
-                "/dev/mapper/{!s}".format(partition["luksMapperName"]),
-                mount_point,
-                fstype,
-                ",".join(
-                    ["subvol=@", partition.get("options", "")]),
-                )
-            if not has_home_mount_point:
-                libcalamares.utils.mount(
-                    "/dev/mapper/{!s}".format(partition["luksMapperName"]),
-                    root_mount_point + "/home",
-                    fstype,
-                    ",".join(
-                        ["subvol=@home", partition.get("options", "")]),
-                    )
-        else:
-            libcalamares.utils.mount(
-                partition["device"],
-                mount_point,
-                fstype,
-                ",".join(["subvol=@", partition.get("options", "")]),
-                )
-            if not has_home_mount_point:
-                libcalamares.utils.mount(
-                    partition["device"],
-                    root_mount_point + "/home",
-                    fstype,
-                    ",".join(
-                        ["subvol=@home", partition.get("options", "")]),
-                    )
+            device = os.path.join("/dev/mapper", partition["luksMapperName"])
+
+        if libcalamares.utils.mount(device,
+                                    mount_point,
+                                    fstype,
+                                    ",".join(["subvol=@", partition.get("options", "")])) != 0:
+            libcalamares.utils.warning("Cannot mount {}".format(device))
+
+        if not has_home_mount_point:
+            if libcalamares.utils.mount(device,
+                                        root_mount_point + "/home",
+                                        fstype,
+                                        ",".join(["subvol=@home", partition.get("options", "")])) != 0:
+                libcalamares.utils.warning("Cannot mount {}".format(device))
 
 
 def run():

--- a/src/modules/partition/core/PartitionLayout.cpp
+++ b/src/modules/partition/core/PartitionLayout.cpp
@@ -134,8 +134,7 @@ PartitionLayout::init( const QVariantList& config )
     {
         QVariantMap pentry = r.toMap();
 
-        if ( !pentry.contains( "name" ) || !pentry.contains( "mountPoint" ) || !pentry.contains( "filesystem" )
-             || !pentry.contains( "size" ) )
+        if ( !pentry.contains( "name" ) || !pentry.contains( "filesystem" ) || !pentry.contains( "size" ) )
         {
             cError() << "Partition layout entry #" << config.indexOf( r )
                      << "lacks mandatory attributes, switching to default layout.";

--- a/src/modules/partition/core/PartitionLayout.cpp
+++ b/src/modules/partition/core/PartitionLayout.cpp
@@ -134,7 +134,7 @@ PartitionLayout::init( const QVariantList& config )
     {
         QVariantMap pentry = r.toMap();
 
-        if ( !pentry.contains( "name" ) || !pentry.contains( "filesystem" ) || !pentry.contains( "size" ) )
+        if ( !pentry.contains( "name" ) || !pentry.contains( "size" ) )
         {
             cError() << "Partition layout entry #" << config.indexOf( r )
                      << "lacks mandatory attributes, switching to default layout.";
@@ -147,7 +147,7 @@ PartitionLayout::init( const QVariantList& config )
                           CalamaresUtils::getString( pentry, "type" ),
                           CalamaresUtils::getUnsignedInteger( pentry, "attributes", 0 ),
                           CalamaresUtils::getString( pentry, "mountPoint" ),
-                          CalamaresUtils::getString( pentry, "filesystem" ),
+                          CalamaresUtils::getString( pentry, "filesystem", "unformatted" ),
                           CalamaresUtils::getSubMap( pentry, "features", ok ),
                           CalamaresUtils::getString( pentry, "size", QStringLiteral( "0" ) ),
                           CalamaresUtils::getString( pentry, "minSize", QStringLiteral( "0" ) ),

--- a/src/modules/partition/jobs/FillGlobalStorageJob.cpp
+++ b/src/modules/partition/jobs/FillGlobalStorageJob.cpp
@@ -153,7 +153,7 @@ FillGlobalStorageJob::prettyDescription() const
             QString path = partitionMap.value( "device" ).toString();
             QString mountPoint = partitionMap.value( "mountPoint" ).toString();
             QString fsType = partitionMap.value( "fs" ).toString();
-            if ( mountPoint.isEmpty() || fsType.isEmpty() )
+            if ( mountPoint.isEmpty() || fsType.isEmpty() || fsType == QString( "unformatted" ) )
             {
                 continue;
             }

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -207,7 +207,7 @@ defaultFileSystemType:  "ext4"
 #   - uuid: partition uuid (optional parameter; gpt only; requires KPMCore >= 4.2.0)
 #   - type: partition type (optional parameter; gpt only; requires KPMCore >= 4.2.0)
 #   - attributes: partition attributes (optional parameter; gpt only; requires KPMCore >= 4.2.0)
-#   - filesystem: filesystem type
+#   - filesystem: filesystem type (optional parameter; fs not created if "unformatted" or unset)
 #   - mountPoint: partition mount point (optional parameter; not mounted if unset)
 #   - size: partition size in bytes (append 'K', 'M' or 'G' for KiB, MiB or GiB)
 #           or

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -208,7 +208,7 @@ defaultFileSystemType:  "ext4"
 #   - type: partition type (optional parameter; gpt only; requires KPMCore >= 4.2.0)
 #   - attributes: partition attributes (optional parameter; gpt only; requires KPMCore >= 4.2.0)
 #   - filesystem: filesystem type
-#   - mountPoint: partition mount point
+#   - mountPoint: partition mount point (optional parameter; not mounted if unset)
 #   - size: partition size in bytes (append 'K', 'M' or 'G' for KiB, MiB or GiB)
 #           or
 #           % of the available drive space if a '%' is appended to the value


### PR DESCRIPTION
Hello,

This PR intends to make both `partitionLayout` attributes `mountPoint` and `filesystem` optional.

In the case of creating a read-only system with `dm-verity`, the block device that contains the hash is not a file-system and cannot be mounted though.

This makes the `mountPoint` irrelevant (as well as `filesystem`).

Note: The "filesystem" type `DM_verityhash` is not supported (yet?) by kpmcore.

```
04:52:18 [0]: unknown file system type  "DM_verity_hash"  on  "/dev/sda3"
``` 

Note: In addition to that PR, the module `mount` fails silently if some partitions failed to be mounted. I have added a warning message to log the failure in a first stage, in order to not break the actual behavior. This behaviour was introduced a while ago with commit 9708669ac7be575beb91dfc0619e4595886bd370. We may want to fail instead in the future.

Regards,
Gaël