### PR TITLE
[users] Full name transliteration support for user creation

### DIFF
--- a/src/modules/users/CMakeLists.txt
+++ b/src/modules/users/CMakeLists.txt
@@ -21,6 +21,18 @@ if( LibPWQuality_FOUND )
     add_definitions( -DCHECK_PWQUALITY -DHAVE_LIBPWQUALITY )
 endif()
 
+find_package( ICU COMPONENTS uc i18n )
+set_package_properties(
+    ICU PROPERTIES
+    PURPOSE "Transliteration support for full name to username conversion"
+)
+
+if( ICU_FOUND )
+    list( APPEND USER_EXTRA_LIB ICU::uc ICU::i18n )
+    include_directories( ${ICU_INCLUDE_DIRS} )
+    add_definitions( -DHAVE_ICU )
+endif()
+
 include_directories( ${PROJECT_BINARY_DIR}/src/libcalamaresui )
 
 set( JOB_SRC

--- a/src/modules/users/Config.cpp
+++ b/src/modules/users/Config.cpp
@@ -307,12 +307,15 @@ transliterate( const QString& input )
         return input;
     }
 
-    auto transliterable = icu::UnicodeString( input.utf16() );
-
+    icu::UnicodeString transliterable( input.utf16() );
     transliterator->transliterate( transliterable );
-
     return QString::fromUtf16( transliterable.getTerminatedBuffer() );
-
+}
+#else
+static QString
+transliterate( const QString& input )
+{
+    return input;
 }
 #endif
 
@@ -374,13 +377,8 @@ Config::setFullName( const QString& name )
 
         // Build login and hostname, if needed
         static QRegExp rx( "[^a-zA-Z0-9 ]", Qt::CaseInsensitive );
-#ifdef HAVE_ICU
-        QString cleanName = transliterate(name);
-        cleanName.replace("'", "");
-#else
-        QString cleanName = name;
-#endif
-        cleanName = CalamaresUtils::removeDiacritics( cleanName ).replace( rx, " " ).toLower().simplified();
+
+        QString cleanName = CalamaresUtils::removeDiacritics( transliterate( name ) ).replace( QRegExp( "[-']" ), "").replace( rx, " " ).toLower().simplified();
 
 
         QStringList cleanParts = cleanName.split( ' ' );

--- a/src/modules/users/Config.cpp
+++ b/src/modules/users/Config.cpp
@@ -97,7 +97,7 @@ Config::Config( QObject* parent )
     connect( this, &Config::requireStrongPasswordsChanged, this, &Config::checkReady );
 }
 
-Config::~Config() {}
+Config::~Config() { }
 
 void
 Config::setUserShell( const QString& shell )
@@ -297,10 +297,10 @@ transliterate( const QString& input )
 {
     static auto ue = UErrorCode::U_ZERO_ERROR;
     static auto transliterator = std::unique_ptr< icu::Transliterator >(
-                icu::Transliterator::createInstance( TRANSLITERATOR_ID, UTRANS_FORWARD, ue )
-                );
+        icu::Transliterator::createInstance( TRANSLITERATOR_ID, UTRANS_FORWARD, ue ) );
 
-    if( ue != UErrorCode::U_ZERO_ERROR ){
+    if ( ue != UErrorCode::U_ZERO_ERROR )
+    {
         cWarning() << "Can't create transliterator";
 
         //it'll be checked later for non-ASCII characters
@@ -378,7 +378,11 @@ Config::setFullName( const QString& name )
         // Build login and hostname, if needed
         static QRegExp rx( "[^a-zA-Z0-9 ]", Qt::CaseInsensitive );
 
-        QString cleanName = CalamaresUtils::removeDiacritics( transliterate( name ) ).replace( QRegExp( "[-']" ), "").replace( rx, " " ).toLower().simplified();
+        QString cleanName = CalamaresUtils::removeDiacritics( transliterate( name ) )
+                                .replace( QRegExp( "[-']" ), "" )
+                                .replace( rx, " " )
+                                .toLower()
+                                .simplified();
 
 
         QStringList cleanParts = cleanName.split( ' ' );

--- a/src/modules/users/Config.cpp
+++ b/src/modules/users/Config.cpp
@@ -300,7 +300,7 @@ transliterate( const QString& input )
         return input;
     }
 
-    auto transliterable = icu::UnicodeString( input.toUtf8().data() );
+    auto transliterable = icu::UnicodeString( input.utf16() );
 
     transliterator->transliterate( transliterable );
 

--- a/src/modules/users/Config.cpp
+++ b/src/modules/users/Config.cpp
@@ -26,6 +26,12 @@
 #ifdef HAVE_ICU
 #include <unicode/translit.h>
 #include <unicode/unistr.h>
+
+//Did my best choosing compound ID
+static const char* TRANSLITERATOR_ID = "Russian-Latin/BGN;"
+                                       "Greek-Latin/UNGEGN;"
+                                       "Any-Latin;"
+                                       "Latin-ASCII";
 #endif
 
 static const QRegExp USERNAME_RX( "^[a-z_][a-z0-9_-]*[$]?$" );
@@ -290,7 +296,7 @@ transliterate( const QString& input )
 {
     static auto ue = UErrorCode::U_ZERO_ERROR;
     static auto transliterator = std::unique_ptr< icu::Transliterator >(
-                icu::Transliterator::createInstance( "Any-Latin; Latin-ASCII", UTRANS_FORWARD, ue )
+                icu::Transliterator::createInstance( TRANSLITERATOR_ID, UTRANS_FORWARD, ue )
                 );
 
     if( ue != UErrorCode::U_ZERO_ERROR ){

--- a/src/modules/users/Config.cpp
+++ b/src/modules/users/Config.cpp
@@ -27,11 +27,12 @@
 #include <unicode/translit.h>
 #include <unicode/unistr.h>
 
-//Did my best choosing compound ID
+//Needed for ICU to apply some transliteration ruleset.
+//Still needs to be adjusted to fit the needs of the most of users
 static const char TRANSLITERATOR_ID[] = "Russian-Latin/BGN;"
-                                       "Greek-Latin/UNGEGN;"
-                                       "Any-Latin;"
-                                       "Latin-ASCII";
+                                        "Greek-Latin/UNGEGN;"
+                                        "Any-Latin;"
+                                        "Latin-ASCII";
 #endif
 
 static const QRegExp USERNAME_RX( "^[a-z_][a-z0-9_-]*[$]?$" );

--- a/src/modules/users/Config.cpp
+++ b/src/modules/users/Config.cpp
@@ -375,6 +375,7 @@ Config::setFullName( const QString& name )
         static QRegExp rx( "[^a-zA-Z0-9 ]", Qt::CaseInsensitive );
 #ifdef HAVE_ICU
         QString cleanName = transliterate(name);
+        cleanName.replace("'", "");
 #else
         QString cleanName = name;
 #endif

--- a/src/modules/users/Config.cpp
+++ b/src/modules/users/Config.cpp
@@ -288,12 +288,12 @@ guessProductName()
 static QString
 transliterate( const QString& input )
 {
-    static UErrorCode ue = UErrorCode::U_ZERO_ERROR;
+    static auto ue = UErrorCode::U_ZERO_ERROR;
     static auto transliterator = std::unique_ptr< icu::Transliterator >(
                 icu::Transliterator::createInstance( "Any-Latin; Latin-ASCII", UTRANS_FORWARD, ue )
                 );
 
-    if(ue!=0){
+    if( ue != UErrorCode::U_ZERO_ERROR ){
         cWarning() << "Can't create transliterator";
 
         //it'll be checked later for non-ASCII characters

--- a/src/modules/users/Config.cpp
+++ b/src/modules/users/Config.cpp
@@ -28,7 +28,7 @@
 #include <unicode/unistr.h>
 
 //Did my best choosing compound ID
-static const char* TRANSLITERATOR_ID = "Russian-Latin/BGN;"
+static const char TRANSLITERATOR_ID[] = "Russian-Latin/BGN;"
                                        "Greek-Latin/UNGEGN;"
                                        "Any-Latin;"
                                        "Latin-ASCII";

--- a/src/modules/users/Config.cpp
+++ b/src/modules/users/Config.cpp
@@ -372,14 +372,13 @@ Config::setFullName( const QString& name )
         emit fullNameChanged( name );
 
         // Build login and hostname, if needed
-        QString cleanName = CalamaresUtils::removeDiacritics( name ).toLower().simplified();
-
+        static QRegExp rx( "[^a-zA-Z0-9 ]", Qt::CaseInsensitive );
 #ifdef HAVE_ICU
-        cleanName = transliterate(cleanName);
+        QString cleanName = transliterate(name);
 #else
-        QRegExp rx( "[^a-zA-Z0-9 ]", Qt::CaseInsensitive );
-        cleanName.replace( rx, " " );
+        QString cleanName = name;
 #endif
+        cleanName = CalamaresUtils::removeDiacritics( cleanName ).replace( rx, " " ).toLower().simplified();
 
 
         QStringList cleanParts = cleanName.split( ' ' );

--- a/src/modules/usersq/CMakeLists.txt
+++ b/src/modules/usersq/CMakeLists.txt
@@ -29,6 +29,18 @@ if( LibPWQuality_FOUND )
     add_definitions( -DCHECK_PWQUALITY -DHAVE_LIBPWQUALITY )
 endif()
 
+find_package( ICU COMPONENTS uc i18n )
+set_package_properties(
+    ICU PROPERTIES
+    PURPOSE "Transliteration support for full name to username conversion"
+)
+
+if( ICU_FOUND )
+    list( APPEND USER_EXTRA_LIB ICU::uc ICU::i18n )
+    include_directories( ${ICU_INCLUDE_DIRS} )
+    add_definitions( -DHAVE_ICU )
+endif()
+
 calamares_add_plugin( usersq
     TYPE viewmodule
     EXPORT_MACRO PLUGINDLLEXPORT_PRO

--- a/src/modules/usersq/CMakeLists.txt
+++ b/src/modules/usersq/CMakeLists.txt
@@ -29,6 +29,7 @@ if( LibPWQuality_FOUND )
     add_definitions( -DCHECK_PWQUALITY -DHAVE_LIBPWQUALITY )
 endif()
 
+#needed for ${_users}/Config.cpp
 find_package( ICU COMPONENTS uc i18n )
 set_package_properties(
     ICU PROPERTIES


### PR DESCRIPTION
Use the International Components for Unicode if available to automatically convert unicode full name to unix user name.
![screenshot](https://user-images.githubusercontent.com/7955026/97819710-5acd7680-1c78-11eb-92eb-94df34161d3e.png)
