### PR TITLE
Don't use a keyfile for encrypted partitions if /boot in unecrypted

### DIFF
--- a/src/modules/grubcfg/main.py
+++ b/src/modules/grubcfg/main.py
@@ -90,9 +90,7 @@ def modify_grub_default(partitions, root_mount_point, distributor):
     swap_outer_uuid = ""
     swap_outer_mappername = None
     no_save_default = False
-    unencrypted_separate_boot = False
-    if any(partition["mountPoint"] == "/boot" and "luksMapperName" not in partition for partition in partitions):
-        unencrypted_separate_boot = True
+    unencrypted_separate_boot = any(p["mountPoint"] == "/boot" and "luksMapperName" not in p for p in partitions):
 
     for partition in partitions:
         if partition["mountPoint"] in ("/", "/boot") and partition["fs"] in ("btrfs", "f2fs"):

--- a/src/modules/grubcfg/main.py
+++ b/src/modules/grubcfg/main.py
@@ -90,7 +90,7 @@ def modify_grub_default(partitions, root_mount_point, distributor):
     swap_outer_uuid = ""
     swap_outer_mappername = None
     no_save_default = False
-    unencrypted_separate_boot = any(p["mountPoint"] == "/boot" and "luksMapperName" not in p for p in partitions):
+    unencrypted_separate_boot = any(p["mountPoint"] == "/boot" and "luksMapperName" not in p for p in partitions)
 
     for partition in partitions:
         if partition["mountPoint"] in ("/", "/boot") and partition["fs"] in ("btrfs", "f2fs"):

--- a/src/modules/grubcfg/main.py
+++ b/src/modules/grubcfg/main.py
@@ -90,6 +90,12 @@ def modify_grub_default(partitions, root_mount_point, distributor):
     swap_outer_uuid = ""
     swap_outer_mappername = None
     no_save_default = False
+    unencrypted_separate_boot = False
+
+    for partition in partitions:
+        if (partition["mountPoint"] == "/boot"
+                and "luksMapperName" not in partition):
+            unencrypted_separate_boot = True
 
     for partition in partitions:
         if partition["mountPoint"] in ("/", "/boot") and partition["fs"] in ("btrfs", "f2fs"):
@@ -239,7 +245,7 @@ def modify_grub_default(partitions, root_mount_point, distributor):
     if not have_distributor_line:
         lines.append(distributor_line)
 
-    if cryptdevice_params:
+    if cryptdevice_params and not unencrypted_separate_boot:
         lines.append("GRUB_ENABLE_CRYPTODISK=y")
 
     with open(default_grub, 'w') as grub_file:

--- a/src/modules/grubcfg/main.py
+++ b/src/modules/grubcfg/main.py
@@ -91,11 +91,8 @@ def modify_grub_default(partitions, root_mount_point, distributor):
     swap_outer_mappername = None
     no_save_default = False
     unencrypted_separate_boot = False
-
-    for partition in partitions:
-        if (partition["mountPoint"] == "/boot"
-                and "luksMapperName" not in partition):
-            unencrypted_separate_boot = True
+    if any(partition["mountPoint"] == "/boot" and "luksMapperName" not in partition for partition in partitions):
+        unencrypted_separate_boot = True
 
     for partition in partitions:
         if partition["mountPoint"] in ("/", "/boot") and partition["fs"] in ("btrfs", "f2fs"):

--- a/src/modules/initcpiocfg/main.py
+++ b/src/modules/initcpiocfg/main.py
@@ -146,8 +146,7 @@ def modify_mkinitcpio_conf(partitions, root_mount_point):
         if partition["mountPoint"] == "/" and "luksMapperName" in partition:
             encrypt_hook = True
 
-        if (partition["mountPoint"] == "/boot"
-                and "luksMapperName" not in partition):
+        if (partition["mountPoint"] == "/boot" and "luksMapperName" not in partition):
             unencrypted_separate_boot = True
 
         if partition["mountPoint"] == "/usr":

--- a/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
+++ b/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
@@ -141,7 +141,7 @@ partitions()
 bool
 hasUnencryptedSeparateBoot()
 {
-    const QVariantList partitions = partitions();
+    const QVariantList partitions = ::partitions();
     for ( const QVariant& partition : partitions )
     {
         QVariantMap partitionMap = partition.toMap();

--- a/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
+++ b/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
@@ -201,7 +201,7 @@ LuksBootKeyFileJob::exec()
     // /boot partition is not encrypted, keyfile must not be used
     if ( hasUnencryptedSeparateBoot() )
     {
-        cDebug() << Logger::SubEntry << "/boot partition is not encryptepted, skipping keyfile creation.";
+        cDebug() << Logger::SubEntry << "/boot partition is not encrypted, skipping keyfile creation.";
         return Calamares::JobResult::ok();
     }
 

--- a/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
+++ b/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
@@ -137,7 +137,8 @@ LuksBootKeyFileJob::partitions()
     return globalStorage->value( QStringLiteral( "partitions" ) ).toList();
 }
 
-static bool
+// static
+bool
 LuksBootKeyFileJob::hasUnencryptedSeparateBoot()
 {
     const QVariantList partitions = LuksBootKeyFileJob::partitions();

--- a/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
+++ b/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
@@ -129,6 +129,30 @@ setupLuks( const LuksDevice& d )
     return true;
 }
 
+// static
+QVariantList
+LuksBootKeyFileJob::partitions()
+{
+    Calamares::GlobalStorage* globalStorage = Calamares::JobQueue::instance()->globalStorage();
+    return globalStorage->value( QStringLiteral( "partitions" ) ).toList();
+}
+
+static bool
+LuksBootKeyFileJob::hasUnencryptedSeparateBoot()
+{
+    const QVariantList partitions = LuksBootKeyFileJob::partitions();
+    for ( const QVariant& partition : partitions )
+    {
+        QVariantMap partitionMap = partition.toMap();
+        QString mountPoint = partitionMap.value( QStringLiteral( "mountPoint" ) ).toString();
+        if ( mountPoint == QStringLiteral( "/boot" ) )
+        {
+            return !partitionMap.contains( QStringLiteral( "luksMapperName" ) );
+        }
+    }
+    return false;
+}
+
 Calamares::JobResult
 LuksBootKeyFileJob::exec()
 {
@@ -171,6 +195,13 @@ LuksBootKeyFileJob::exec()
     {
         // Then there was no root partition
         cDebug() << Logger::SubEntry << "No root partition.";
+        return Calamares::JobResult::ok();
+    }
+
+    // /boot partition is not encrypted, keyfile must not be used
+    if ( hasUnencryptedSeparateBoot() )
+    {
+        cDebug() << Logger::SubEntry << "/boot partition is not encryptepted, skipping keyfile creation.";
         return Calamares::JobResult::ok();
     }
 

--- a/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
+++ b/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
@@ -131,7 +131,7 @@ setupLuks( const LuksDevice& d )
 
 // static
 QVariantList
-LuksBootKeyFileJob::partitions()
+partitions()
 {
     Calamares::GlobalStorage* globalStorage = Calamares::JobQueue::instance()->globalStorage();
     return globalStorage->value( QStringLiteral( "partitions" ) ).toList();
@@ -139,9 +139,9 @@ LuksBootKeyFileJob::partitions()
 
 // static
 bool
-LuksBootKeyFileJob::hasUnencryptedSeparateBoot()
+hasUnencryptedSeparateBoot()
 {
-    const QVariantList partitions = LuksBootKeyFileJob::partitions();
+    const QVariantList partitions = partitions();
     for ( const QVariant& partition : partitions )
     {
         QVariantMap partitionMap = partition.toMap();

--- a/src/modules/luksbootkeyfile/LuksBootKeyFileJob.h
+++ b/src/modules/luksbootkeyfile/LuksBootKeyFileJob.h
@@ -30,6 +30,9 @@ public:
     QString prettyName() const override;
 
     Calamares::JobResult exec() override;
+private:
+    static QVariantList partitions();
+    static bool hasUnencryptedSeparateBoot();
 };
 
 CALAMARES_PLUGIN_FACTORY_DECLARATION( LuksBootKeyFileJobFactory )

--- a/src/modules/luksbootkeyfile/LuksBootKeyFileJob.h
+++ b/src/modules/luksbootkeyfile/LuksBootKeyFileJob.h
@@ -30,9 +30,6 @@ public:
     QString prettyName() const override;
 
     Calamares::JobResult exec() override;
-private:
-    static QVariantList partitions();
-    static bool hasUnencryptedSeparateBoot();
 };
 
 CALAMARES_PLUGIN_FACTORY_DECLARATION( LuksBootKeyFileJobFactory )

--- a/src/modules/openrcdmcryptcfg/main.py
+++ b/src/modules/openrcdmcryptcfg/main.py
@@ -21,10 +21,6 @@ _ = gettext.translation("calamares-python",
                         fallback=True).gettext
 
 
-for partition in partitions:
-        if (partition["mountPoint"] == "/boot"
-                and "luksMapperName" not in partition):
-            unencrypted_separate_boot = True
 
 def pretty_name():
     return _("Configuring OpenRC dmcrypt service.")
@@ -34,6 +30,8 @@ def write_dmcrypt_conf(partitions, root_mount_point, dmcrypt_conf_path):
     crypto_target = ""
     crypto_source = ""
     unencrypted_separate_boot = False
+    if any(partition["mountPoint"] == "/boot" and "luksMapperName" not in partition for partition in partitions):
+        unencrypted_separate_boot = True
 
     for partition in partitions:
         has_luks = "luksMapperName" in partition

--- a/src/modules/openrcdmcryptcfg/main.py
+++ b/src/modules/openrcdmcryptcfg/main.py
@@ -29,9 +29,7 @@ def pretty_name():
 def write_dmcrypt_conf(partitions, root_mount_point, dmcrypt_conf_path):
     crypto_target = ""
     crypto_source = ""
-    unencrypted_separate_boot = False
-    if any(partition["mountPoint"] == "/boot" and "luksMapperName" not in partition for partition in partitions):
-        unencrypted_separate_boot = True
+    unencrypted_separate_boot = any(p["mountPoint"] == "/boot" and "luksMapperName" not in p for p in partitions):
 
     for partition in partitions:
         has_luks = "luksMapperName" in partition

--- a/src/modules/openrcdmcryptcfg/main.py
+++ b/src/modules/openrcdmcryptcfg/main.py
@@ -29,7 +29,7 @@ def pretty_name():
 def write_dmcrypt_conf(partitions, root_mount_point, dmcrypt_conf_path):
     crypto_target = ""
     crypto_source = ""
-    unencrypted_separate_boot = any(p["mountPoint"] == "/boot" and "luksMapperName" not in p for p in partitions):
+    unencrypted_separate_boot = any(p["mountPoint"] == "/boot" and "luksMapperName" not in p for p in partitions)
 
     for partition in partitions:
         has_luks = "luksMapperName" in partition

--- a/src/modules/openrcdmcryptcfg/main.py
+++ b/src/modules/openrcdmcryptcfg/main.py
@@ -49,7 +49,7 @@ def write_dmcrypt_conf(partitions, root_mount_point, dmcrypt_conf_path):
             with open(os.path.join(root_mount_point, dmcrypt_conf_path), 'a+') as dmcrypt_file:
                 dmcrypt_file.write("\ntarget=" + crypto_target)
                 dmcrypt_file.write("\nsource=" + crypto_source)
-                # Don't use keyfile if boot is unecrypted, keys must not be stored on unencrypted partitions
+                # Don't use keyfile if boot is unencrypted, keys must not be stored on unencrypted partitions
                 if not unencrypted_separate_boot:
                     dmcrypt_file.write("\nkey=/crypto_keyfile.bin")
                 dmcrypt_file.write("\n")

--- a/src/modules/openrcdmcryptcfg/main.py
+++ b/src/modules/openrcdmcryptcfg/main.py
@@ -20,7 +20,6 @@ _ = gettext.translation("calamares-python",
                         languages=libcalamares.utils.gettext_languages(),
                         fallback=True).gettext
 
-unencrypted_separate_boot = False
 
 for partition in partitions:
         if (partition["mountPoint"] == "/boot"
@@ -34,6 +33,7 @@ def pretty_name():
 def write_dmcrypt_conf(partitions, root_mount_point, dmcrypt_conf_path):
     crypto_target = ""
     crypto_source = ""
+    unencrypted_separate_boot = False
 
     for partition in partitions:
         has_luks = "luksMapperName" in partition

--- a/src/modules/openrcdmcryptcfg/main.py
+++ b/src/modules/openrcdmcryptcfg/main.py
@@ -42,8 +42,7 @@ def write_dmcrypt_conf(partitions, root_mount_point, dmcrypt_conf_path):
         if not has_luks and not skip_partitions:
             libcalamares.utils.debug(
                 "Skip writing OpenRC LUKS configuration for partition {!s}".format(partition["mountPoint"]))
-        # Don't use keyfile if boot is unecrypted, keys must not be stored on unencrypted partitions
-        if has_luks and not skip_partitions and not unencrypted_separate_boot:
+        if has_luks and not skip_partitions:
             crypto_target = partition["luksMapperName"]
             crypto_source = "/dev/disk/by-uuid/{!s}".format(partition["uuid"])
             libcalamares.utils.debug(
@@ -52,7 +51,9 @@ def write_dmcrypt_conf(partitions, root_mount_point, dmcrypt_conf_path):
             with open(os.path.join(root_mount_point, dmcrypt_conf_path), 'a+') as dmcrypt_file:
                 dmcrypt_file.write("\ntarget=" + crypto_target)
                 dmcrypt_file.write("\nsource=" + crypto_source)
-                dmcrypt_file.write("\nkey=/crypto_keyfile.bin")
+                # Don't use keyfile if boot is unecrypted, keys must not be stored on unencrypted partitions
+                if not unencrypted_separate_boot:
+                    dmcrypt_file.write("\nkey=/crypto_keyfile.bin")
                 dmcrypt_file.write("\n")
 
         if has_luks and skip_partitions:

--- a/src/modules/openrcdmcryptcfg/main.py
+++ b/src/modules/openrcdmcryptcfg/main.py
@@ -20,6 +20,12 @@ _ = gettext.translation("calamares-python",
                         languages=libcalamares.utils.gettext_languages(),
                         fallback=True).gettext
 
+unencrypted_separate_boot = False
+
+for partition in partitions:
+        if (partition["mountPoint"] == "/boot"
+                and "luksMapperName" not in partition):
+            unencrypted_separate_boot = True
 
 def pretty_name():
     return _("Configuring OpenRC dmcrypt service.")
@@ -36,8 +42,8 @@ def write_dmcrypt_conf(partitions, root_mount_point, dmcrypt_conf_path):
         if not has_luks and not skip_partitions:
             libcalamares.utils.debug(
                 "Skip writing OpenRC LUKS configuration for partition {!s}".format(partition["mountPoint"]))
-
-        if has_luks and not skip_partitions:
+        # Don't use keyfile if boot is unecrypted, keys must not be stored on unencrypted partitions
+        if has_luks and not skip_partitions and not unencrypted_separate_boot:
             crypto_target = partition["luksMapperName"]
             crypto_source = "/dev/disk/by-uuid/{!s}".format(partition["uuid"])
             libcalamares.utils.debug(


### PR DESCRIPTION
Needed changes for supporting unencrypted /boot partition. It still needs
1) Handling for dracut
2) Skipping writing and adding the keyfile in the first place
I can't do those parts because I don't know C.

But this pull request should still be useful, and avoid
1) Automatic decryption at boot time without password
2) unbootable system due to the misconfigured grub.