### PR TITLE
[umount] Fix list of mount-points to unmount

### DIFF
--- a/src/modules/umount/main.py
+++ b/src/modules/umount/main.py
@@ -39,10 +39,11 @@ def list_mounts(root_mount_point):
     """
     lst = []
 
+    root_mount_point = os.path.normpath(root_mount_point)
     for line in open("/etc/mtab").readlines():
         device, mount_point, _ = line.split(" ", 2)
 
-        if mount_point.startswith(root_mount_point):
+        if os.path.commonprefix([root_mount_point, mount_point]) == root_mount_point:
             lst.append((device, mount_point))
 
     return lst


### PR DESCRIPTION
The root mount-point can end with a / while the mount-point read from
the file /etc/mtab does not end with a /.

This leads to skip the unmounting of the root mount-point and causes the
removal of the root mountpoint directory to fail with EBUSY because it
is still mounted.

This uses the python functions os.path.normpath() to normalize the root
mount-point (i.e. to drop the trailing /) and os.path.commonprefix() to
determine the longest common prefix between the two mount-points. If the
returned prefix is identical to the normalized root mount-point then the
mount-point must be added to the list of the mount-points to unmount.

More generally, the python modules should rely on the os.path functions
to compare for paths instead of using strings. It covers this way lots
of corner cases (path with "//", "/../", "/./", ...).