### PR TITLE
[mount] Ignore unformatted filesystems only

### DIFF
--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -56,7 +56,7 @@ def mount_partition(root_mount_point, partition, partitions):
         raise
 
     fstype = partition.get("fs", "").lower()
-    if not fstype or fstype == "unformatted":
+    if fstype == "unformatted":
         return
 
     if fstype == "fat16" or fstype == "fat32":

--- a/src/modules/mount/mount.conf
+++ b/src/modules/mount/mount.conf
@@ -12,9 +12,12 @@
 # Extra filesystems to mount. The key's value is a list of entries; each
 # entry has four keys:
 #   - device    The device node to mount
-#   - fs        The filesystem type to use
+#   - fs (optional) The filesystem type to use
 #   - mountPoint Where to mount the filesystem
 #   - options (optional) Extra options to pass to mount(8)
+#
+# The device is not mounted if the mountPoint is unset or if the fs is
+# set to unformatted.
 #
 extraMounts:
     - device: proc


### PR DESCRIPTION
Mount guesses the filesystem if it is unset or if it is set to `auto`, thanks to `blkid` (for example bind mountpoints like `/dev` or `/run/udev` in mount.conf). See `mount(8)` for more details.

This fixes 163351a.