### PR TITLE
[unpackfs] Skip overlay extended attributes

### DIFF
--- a/src/modules/unpackfs/main.py
+++ b/src/modules/unpackfs/main.py
@@ -181,7 +181,7 @@ def file_copy(source, entry, progress_cb):
     num_files_total_local = 0
     num_files_copied = 0  # Gets updated through rsync output
 
-    args = ['rsync', '-aHAXr']
+    args = ['rsync', '-aHAXr', '--filter=-x trusted.overlay.*']
     args.extend(global_excludes())
     if entry.excludeFile:
         args.extend(["--exclude-from=" + entry.excludeFile])


### PR DESCRIPTION
Hello,

This PR intends to fix mount issues if using an overlay filesystem, after rebooting the target.

The module `unpackfs` preserves the extended attributes at `rsync` and the overlay filesystem stores extended attributes by inodes.

The overlay filesystem keeps traces of the lower directory by encoding and storing its `UUID` to the attribute `trusted.overlay.origin`.

If the index feature is on, that attribute is compared to the `UUID` of the __lower directory__ at every subsequent mount and causes `mount` to fail with **ESTATE** if it does not match.

This filters the namespace `trusted.overlay.*` by using the `rsync` option `'--filter=-x trusted.overlay.*'` to make sure the overlays extended attributes are not preserved.

Fixes:

```
# mount -t overlay -o lowerdir=...,upperdir,...,workdir= overlay /mnt/etc
mount: /var/mnt/etc: mount(2) system call failed: Stale file handle.
```

```
# dmesg
(...)
overlayfs: "xino" feature enabled using 32 upper inode bits.
overlayfs: failed to verify origin (/etc, ino=524292, err=-116)
overlayfs: failed to verify upper root origin
```