### PR TITLE
[partition] output more things in overiew

### DIFF
--- a/src/libcalamares/partition/PartitionQuery.cpp
+++ b/src/libcalamares/partition/PartitionQuery.cpp
@@ -16,6 +16,7 @@
 
 #include <kpmcore/core/device.h>
 #include <kpmcore/core/partition.h>
+#include <kpmcore/core/partitiontable.h>
 
 namespace CalamaresUtils
 {
@@ -25,6 +26,19 @@ namespace Partition
 // Types from KPMCore
 using ::Device;
 using ::Partition;
+
+const PartitionTable*
+getPartitionTable( const Partition* partition )
+{
+    const PartitionNode* root = partition;
+    while ( root && !root->isRoot() )
+    {
+        root = root->parent();
+    }
+
+    return dynamic_cast< const PartitionTable* >( root );
+}
+
 
 bool
 isPartitionFreeSpace( const Partition* partition )

--- a/src/libcalamares/partition/PartitionQuery.h
+++ b/src/libcalamares/partition/PartitionQuery.h
@@ -24,6 +24,7 @@
 
 class Device;
 class Partition;
+class PartitionTable;
 
 namespace CalamaresUtils
 {
@@ -32,6 +33,10 @@ namespace Partition
 
 using ::Device;
 using ::Partition;
+using ::PartitionTable;
+
+/** @brief Get partition table */
+const PartitionTable* getPartitionTable( const Partition* partition );
 
 /** @brief Is this a free-space area? */
 bool isPartitionFreeSpace( const Partition* );

--- a/src/modules/partition/core/PartUtils.cpp
+++ b/src/modules/partition/core/PartUtils.cpp
@@ -454,20 +454,7 @@ isEfiBootable( const Partition* candidate )
     }
 
     /* Otherwise, if it's a GPT table, Boot (bit 0) is the same as Esp */
-    const PartitionNode* root = candidate;
-    while ( root && !root->isRoot() )
-    {
-        root = root->parent();
-    }
-
-    // Strange case: no root found, no partition table node?
-    if ( !root )
-    {
-        cWarning() << "No root of partition table found.";
-        return false;
-    }
-
-    const PartitionTable* table = dynamic_cast< const PartitionTable* >( root );
+    const PartitionTable* table = CalamaresUtils::Partition::getPartitionTable( candidate );
     if ( !table )
     {
         cWarning() << "Root of partition table is not a PartitionTable object";

--- a/src/modules/partition/jobs/CreatePartitionJob.cpp
+++ b/src/modules/partition/jobs/CreatePartitionJob.cpp
@@ -12,6 +12,7 @@
 #include "CreatePartitionJob.h"
 
 #include "partition/FileSystem.h"
+#include "partition/PartitionQuery.h"
 #include "utils/Logger.h"
 #include "utils/Units.h"
 
@@ -32,9 +33,92 @@ CreatePartitionJob::CreatePartitionJob( Device* device, Partition* partition )
 {
 }
 
+static const QMap < QString, QString > gptTypePrettyStrings = {
+    { "44479540-f297-41b2-9af7-d131d5f0458a", "Linux Root Partition (x86)" },
+    { "4f68bce3-e8cd-4db1-96e7-fbcaf984b709", "Linux Root Partition (x86-64)" },
+    { "69dad710-2ce4-4e3c-b16c-21a1d49abed3", "Linux Root Partition (32-bit ARM)" },
+    { "b921b045-1df0-41c3-af44-4c6f280d3fae", "Linux Root Partition (64-bit ARM)" },
+    { "993d8d3d-f80e-4225-855a-9daf8ed7ea97", "Linux Root Partition (Itanium/IA-64)" },
+    { "d13c5d3b-b5d1-422a-b29f-9454fdc89d76", "Linux Root Verity Partition (x86)" },
+    { "2c7357ed-ebd2-46d9-aec1-23d437ec2bf5", "Linux Root Verity Partition (x86-64)" },
+    { "7386cdf2-203c-47a9-a498-f2ecce45a2d6", "Linux Root Verity Partition (32-bit ARM)" },
+    { "df3300ce-d69f-4c92-978c-9bfb0f38d820", "Linux Root Verity Partition (64-bit ARM/AArch64)" },
+    { "86ed10d5-b607-45bb-8957-d350f23d0571", "Linux Root Verity Partition (Itanium/IA-64)" },
+    { "75250d76-8cc6-458e-bd66-bd47cc81a812", "Linux /usr Partition (x86)" },
+    { "8484680c-9521-48c6-9c11-b0720656f69e", "Linux /usr Partition (x86-64)" },
+    { "7d0359a3-02b3-4f0a-865c-654403e70625", "Linux /usr Partition (32-bit ARM)" },
+    { "b0e01050-ee5f-4390-949a-9101b17104e9", "Linux /usr Partition (64-bit ARM/AArch64)" },
+    { "4301d2a6-4e3b-4b2a-bb94-9e0b2c4225ea", "Linux /usr Partition (Itanium/IA-64)" },
+    { "8f461b0d-14ee-4e81-9aa9-049b6fb97abd", "Linux /usr Verity Partition (x86)" },
+    { "77ff5f63-e7b6-4633-acf4-1565b864c0e6", "Linux /usr Verity Partition (x86-64)" },
+    { "c215d751-7bcd-4649-be90-6627490a4c05", "Linux /usr Verity Partition (32-bit ARM)" },
+    { "6e11a4e7-fbca-4ded-b9e9-e1a512bb664e", "Linux /usr Verity Partition (64-bit ARM/AArch64)" },
+    { "6a491e03-3be7-4545-8e38-83320e0ea880", "Linux /usr Verity Partition (Itanium/IA-64)" },
+    { "933ac7e1-2eb4-4f13-b844-0e14e2aef915", "Linux Home Partition" },
+    { "3b8f8425-20e0-4f3b-907f-1a25a76f98e8", "Linux Server Data Partition" },
+    { "4d21b016-b534-45c2-a9fb-5c16e091fd2d", "Linux Variable Data Partition" },
+    { "7ec6f557-3bc5-4aca-b293-16ef5df639d1", "Linux Temporary Data Partition" },
+    { "0657fd6d-a4ab-43c4-84e5-0933c84b4f4f", "Linux Swap" },
+    { "c12a7328-f81f-11d2-ba4b-00a0c93ec93b", "EFI System Partition" },
+    { "bc13c2ff-59e6-4262-a352-b275fd6f7172", "Extended Boot Loader Partition" },
+    { "0fc63daf-8483-4772-8e79-3d69d8477de4", "Other Data Partitions" },
+    { "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7", "Microsoft basic data" },
+};
+
+static QString
+prettyGptType( const QString& type )
+{
+    return gptTypePrettyStrings.value( type.toLower(), type );
+}
+
+static QString
+prettyGptEntries( const Partition* partition )
+{
+    if ( !partition )
+    {
+        return QString();
+    }
+
+    QStringList list;
+
+    if ( !partition->label().isEmpty() )
+    {
+        list += partition->label();
+    }
+
+    QString type = prettyGptType( partition->type() );
+    if ( !type.isEmpty() )
+    {
+        list += type;
+    }
+
+    return list.join( QStringLiteral( ", " ) );
+}
+
 QString
 CreatePartitionJob::prettyName() const
 {
+    const PartitionTable* table = CalamaresUtils::Partition::getPartitionTable( m_partition );
+    if ( table && table->type() == PartitionTable::TableType::gpt )
+    {
+        QString entries = prettyGptEntries( m_partition );
+        if ( !entries.isEmpty() )
+        {
+            return tr( "Create new %1MiB partition on %3 (%2) with entries %4." )
+                       .arg( CalamaresUtils::BytesToMiB( m_partition->capacity() ) )
+                       .arg( m_device->name() )
+                       .arg( m_device->deviceNode() )
+                       .arg( entries );
+        }
+        else
+        {
+            return tr( "Create new %1MiB partition on %3 (%2)." )
+                       .arg( CalamaresUtils::BytesToMiB( m_partition->capacity() ) )
+                       .arg( m_device->name() )
+                       .arg( m_device->deviceNode() );
+        }
+    }
+
     return tr( "Create new %2MiB partition on %4 (%3) with file system %1." )
         .arg( userVisibleFS( m_partition->fileSystem() ) )
         .arg( CalamaresUtils::BytesToMiB( m_partition->capacity() ) )
@@ -46,6 +130,27 @@ CreatePartitionJob::prettyName() const
 QString
 CreatePartitionJob::prettyDescription() const
 {
+    const PartitionTable* table = CalamaresUtils::Partition::getPartitionTable( m_partition );
+    if ( table && table->type() == PartitionTable::TableType::gpt )
+    {
+        QString entries = prettyGptEntries( m_partition );
+        if ( !entries.isEmpty() )
+        {
+            return tr( "Create new <strong>%1MiB</strong> partition on <strong>%3</strong> (%2) with entries <em>%4</em>." )
+                       .arg( CalamaresUtils::BytesToMiB( m_partition->capacity() ) )
+                       .arg( m_device->name() )
+                       .arg( m_device->deviceNode() )
+                       .arg( entries );
+        }
+        else
+        {
+            return tr( "Create new <strong>%1MiB</strong> partition on <strong>%3</strong> (%2)." )
+                       .arg( CalamaresUtils::BytesToMiB( m_partition->capacity() ) )
+                       .arg( m_device->name() )
+                       .arg( m_device->deviceNode() );
+        }
+    }
+
     return tr( "Create new <strong>%2MiB</strong> partition on <strong>%4</strong> "
                "(%3) with file system <strong>%1</strong>." )
         .arg( userVisibleFS( m_partition->fileSystem() ) )
@@ -58,6 +163,24 @@ CreatePartitionJob::prettyDescription() const
 QString
 CreatePartitionJob::prettyStatusMessage() const
 {
+    const PartitionTable* table = CalamaresUtils::Partition::getPartitionTable( m_partition );
+    if ( table && table->type() == PartitionTable::TableType::gpt )
+    {
+        QString type = prettyGptType( m_partition->type() );
+        if ( type.isEmpty() )
+        {
+            type = m_partition->label();
+        }
+        if ( type.isEmpty() )
+        {
+            type = userVisibleFS( m_partition->fileSystem() );
+        }
+
+        return tr( "Creating new %1 partition on %2." )
+                   .arg( type )
+                   .arg( m_device->deviceNode() );
+    }
+
     return tr( "Creating new %1 partition on %2." )
         .arg( userVisibleFS( m_partition->fileSystem() ) )
         .arg( m_device->deviceNode() );

--- a/src/modules/partition/jobs/FillGlobalStorageJob.cpp
+++ b/src/modules/partition/jobs/FillGlobalStorageJob.cpp
@@ -91,6 +91,7 @@ mapForPartition( Partition* partition, const QString& uuid )
     map[ "mountPoint" ] = PartitionInfo::mountPoint( partition );
     map[ "fsName" ] = userVisibleFS( partition->fileSystem() );
     map[ "fs" ] = untranslatedFS( partition->fileSystem() );
+    map[ "features" ] = partition->fileSystem().features();
     if ( partition->fileSystem().type() == FileSystem::Luks
          && dynamic_cast< FS::luks& >( partition->fileSystem() ).innerFS() )
     {
@@ -126,6 +127,33 @@ mapForPartition( Partition* partition, const QString& uuid )
     return map;
 }
 
+static QString
+prettyFileSystemFeatures( const QVariantMap& features )
+{
+    QStringList list;
+    for ( const auto& key : features.keys() )
+    {
+        const auto& value = features.value( key );
+        if ( value.type() == QVariant::Bool )
+        {
+            if ( value.toBool() )
+            {
+                list += key;
+            }
+            else
+            {
+                list += QString( "not " ) + key;
+            }
+        }
+        else
+        {
+            list += key + QString( "=" ) + value.toString();
+        }
+    }
+
+    return list.join( QStringLiteral( ", " ) );
+}
+
 FillGlobalStorageJob::FillGlobalStorageJob( const Config*, QList< Device* > devices, const QString& bootLoaderPath )
     : m_devices( devices )
     , m_bootLoaderPath( bootLoaderPath )
@@ -153,6 +181,7 @@ FillGlobalStorageJob::prettyDescription() const
             QString path = partitionMap.value( "device" ).toString();
             QString mountPoint = partitionMap.value( "mountPoint" ).toString();
             QString fsType = partitionMap.value( "fs" ).toString();
+            QString features = prettyFileSystemFeatures( partitionMap.value( "features" ).toMap() );
             if ( mountPoint.isEmpty() || fsType.isEmpty() || fsType == QString( "unformatted" ) )
             {
                 continue;
@@ -161,34 +190,81 @@ FillGlobalStorageJob::prettyDescription() const
             {
                 if ( mountPoint == "/" )
                 {
-                    lines.append( tr( "Install %1 on <strong>new</strong> %2 system partition." )
-                                      .arg( Calamares::Branding::instance()->shortProductName() )
-                                      .arg( fsType ) );
+                    if ( !features.isEmpty() )
+                    {
+                        lines.append( tr( "Install %1 on <strong>new</strong> %2 system partition "
+                                          "with features <em>%3</em>" )
+                                          .arg( Calamares::Branding::instance()->shortProductName() )
+                                          .arg( fsType )
+                                          .arg( features ) );
+                    }
+                    else
+                    {
+                        lines.append( tr( "Install %1 on <strong>new</strong> %2 system partition." )
+                                          .arg( Calamares::Branding::instance()->shortProductName() )
+                                          .arg( fsType ) );
+                    }
                 }
                 else
                 {
-                    lines.append( tr( "Set up <strong>new</strong> %2 partition with mount point "
-                                      "<strong>%1</strong>." )
-                                      .arg( mountPoint )
-                                      .arg( fsType ) );
+                    if ( !features.isEmpty() )
+                    {
+                        lines.append( tr( "Set up <strong>new</strong> %2 partition with mount point "
+                                          "<strong>%1</strong> and features <em>%3</em>." )
+                                          .arg( mountPoint )
+                                          .arg( fsType )
+                                          .arg( features ) );
+                    }
+                    else
+                    {
+                        lines.append( tr( "Set up <strong>new</strong> %2 partition with mount point "
+                                          "<strong>%1</strong>%3." )
+                                          .arg( mountPoint )
+                                          .arg( fsType )
+                                          .arg( features ) );
+                    }
                 }
             }
             else
             {
                 if ( mountPoint == "/" )
                 {
-                    lines.append( tr( "Install %2 on %3 system partition <strong>%1</strong>." )
-                                      .arg( path )
-                                      .arg( Calamares::Branding::instance()->shortProductName() )
-                                      .arg( fsType ) );
+                    if ( !features.isEmpty() )
+                    {
+                        lines.append( tr( "Install %2 on %3 system partition <strong>%1</strong>"
+                                          " with features <em>%4</em>." )
+                                          .arg( path )
+                                          .arg( Calamares::Branding::instance()->shortProductName() )
+                                          .arg( fsType )
+                                          .arg( features ) );
+                    }
+                    else
+                    {
+                        lines.append( tr( "Install %2 on %3 system partition <strong>%1</strong>." )
+                                          .arg( path )
+                                          .arg( Calamares::Branding::instance()->shortProductName() )
+                                          .arg( fsType ) );
+                    }
                 }
                 else
                 {
-                    lines.append( tr( "Set up %3 partition <strong>%1</strong> with mount point "
-                                      "<strong>%2</strong>." )
-                                      .arg( path )
-                                      .arg( mountPoint )
-                                      .arg( fsType ) );
+                    if ( !features.isEmpty() )
+                    {
+                        lines.append( tr( "Set up %3 partition <strong>%1</strong> with mount point "
+                                          "<strong>%2</strong> and features <em>%4</em>." )
+                                          .arg( path )
+                                          .arg( mountPoint )
+                                          .arg( fsType )
+                                          .arg( features ) );
+                    }
+                    else
+                    {
+                        lines.append( tr( "Set up %3 partition <strong>%1</strong> with mount point "
+                                          "<strong>%2</strong>%4." )
+                                          .arg( path )
+                                          .arg( mountPoint )
+                                          .arg( fsType ) );
+                    }
                 }
             }
         }


### PR DESCRIPTION
Hello,

This RFC intends to output more things in the overview, such as the file-system features or the GPT entries (name, UUID, attributes, type).

It adds the new helper `CalamaresUtils::getPartitionTable()`.

It adds the filesystem `features` to the global storage.

It introduces a mapping between the GPT types and a more human-friendly string (it may go to kpmcore?).

What do you think?

Regards,
Gaël