### PR TITLE
[Fix] Welcome Page links

### DIFF
--- a/src/branding/default/branding.desc
+++ b/src/branding/default/branding.desc
@@ -129,9 +129,9 @@ strings:
     shortVersionedName:  FancyGL 2020.2
     bootloaderEntryName: FancyGL
     productUrl:          https://calamares.io/
-    supportUrl:          https://github.com/calamares/calamares/issues
-    knownIssuesUrl:      https://calamares.io/about/
-    releaseNotesUrl:     https://calamares.io/about/
+    supportUrl:          https://github.com/calamares/calamares/wiki
+    knownIssuesUrl:      https://github.com/calamares/calamares/issues
+    releaseNotesUrl:     http://calamares.io/news/
     donateUrl:           https://kde.org/community/donations/index.php
 
 # These images are loaded from the branding module directory.


### PR DESCRIPTION
"Generic support" and "Known Issues" links fixed + "releaseNotesURL" changed appropriately.

Referencing issue #1588  