### PR TITLE
Implementing LogUpload functionality from branding

### DIFF
--- a/src/branding/default/branding.desc
+++ b/src/branding/default/branding.desc
@@ -220,17 +220,14 @@ slideshowAPI: 2
 
 
 # These options are to customize online uploading of logs to pastebins:
-#  - style  :  Defines the kind of pastebin service to be used. ie it can
-#              provide the functionality of controlling privacy of 
-#              paste (in future).Currently only "fiche" servers
-#              are supported. Takes string as input
+#  - type   :  Defines the kind of pastebin service to be used.Currently
+#              it accepts two values:
+#              - none    :    disables the pastebin functionality
+#              - fiche   :    use fiche pastebin server
 #  - url    :  Defines the address of pastebin service to be used.
 #              Takes string as input
 #  - port   :  Defines the port number to be used to send logs. Takes 
 #              integer as input
-#  - enable :  Defines if the functionality is to be used or not. Takes 
-#              bool as input
-logUpload.style   :    "fiche"
-logUpload.url     :    "termbin.com"
-logUpload.port    :    9999
-logUpload.enable  :    true
+uploadServer.type    :    "fiche"
+uploadServer.url     :    "termbin.com"
+uploadServer.port    :    9999

--- a/src/branding/default/branding.desc
+++ b/src/branding/default/branding.desc
@@ -219,3 +219,16 @@ slideshow:               "show.qml"
 slideshowAPI: 2
 
 
+# These options are to customize online uploading of logs to pastebins:
+#  - style  :  Defines the kind of pastebin service to be used. Takes
+#              string as input
+#  - url    :  Defines the address of pastebin service to be used.
+#              Takes string as input
+#  - port   :  Defines the port number to be used to send logs. Takes 
+#              integer as input
+#  - enable :  Defines if the functionality is to be used or not. Takes 
+#              bool as input
+logUpload.style   :    "fische"
+logUpload.url     :    "termbin.com"
+logUpload.port    :    9999
+logUpload.enable  :    true

--- a/src/branding/default/branding.desc
+++ b/src/branding/default/branding.desc
@@ -228,6 +228,7 @@ slideshowAPI: 2
 #              Takes string as input
 #  - port   :  Defines the port number to be used to send logs. Takes 
 #              integer as input
-uploadServer.type    :    "fiche"
-uploadServer.url     :    "termbin.com"
-uploadServer.port    :    9999
+uploadServer :
+    type :    "fiche"
+    url :      "termbin.com"
+    port :     9999

--- a/src/branding/default/branding.desc
+++ b/src/branding/default/branding.desc
@@ -220,15 +220,17 @@ slideshowAPI: 2
 
 
 # These options are to customize online uploading of logs to pastebins:
-#  - style  :  Defines the kind of pastebin service to be used. Takes
-#              string as input
+#  - style  :  Defines the kind of pastebin service to be used. ie it can
+#              provide the functionality of controlling privacy of 
+#              paste (in future).Currently only "fiche" servers
+#              are supported. Takes string as input
 #  - url    :  Defines the address of pastebin service to be used.
 #              Takes string as input
 #  - port   :  Defines the port number to be used to send logs. Takes 
 #              integer as input
 #  - enable :  Defines if the functionality is to be used or not. Takes 
 #              bool as input
-logUpload.style   :    "fische"
+logUpload.style   :    "fiche"
 logUpload.url     :    "termbin.com"
 logUpload.port    :    9999
 logUpload.enable  :    true

--- a/src/libcalamaresui/Branding.cpp
+++ b/src/libcalamaresui/Branding.cpp
@@ -86,6 +86,7 @@ const QStringList Branding::s_styleEntryStrings =
     "sidebarTextSelect",
     "sidebarTextHighlight"
 };
+
 // clang-format on
 // *INDENT-ON*
 
@@ -510,6 +511,11 @@ Branding::initSimpleSettings( const YAML::Node& doc )
     {
         m_windowHeight = WindowDimension( CalamaresUtils::windowPreferredHeight, WindowDimensionUnit::Pixies );
     }
+
+    m_logUploadEnable = doc[ "logUpload.enable" ].as< bool >( false );
+    m_logUploadURL = getString( doc, "logUpload.url") ;
+    m_logUploadPort = doc[ "logUpload.port" ].as< int >();
+    m_logUploadStyle= getString(doc, "logUpload.style" );
 }
 
 void

--- a/src/libcalamaresui/Branding.cpp
+++ b/src/libcalamaresui/Branding.cpp
@@ -87,6 +87,13 @@ const QStringList Branding::s_styleEntryStrings =
     "sidebarTextSelect",
     "sidebarTextHighlight"
 };
+
+const QStringList Branding::s_uploadServerStrings =
+{
+    "type",
+    "url",
+    "port"
+};
 // clang-format on
 // *INDENT-ON*
 
@@ -219,6 +226,12 @@ Branding::Branding( const QString& brandingFilePath, QObject* parent )
                 return imageFi.absoluteFilePath();
             } );
             loadStrings( m_style, doc, "style", []( const QString& s ) -> QString { return s; } );
+
+            const QVariantMap temp = CalamaresUtils::yamlMapToVariant( doc[ "uploadServer" ] );
+            for ( auto it = temp.constBegin(); it != temp.constEnd(); ++it )
+            {
+                m_uploadServer.insert( it.key(), it.value().toString() );
+            }
         }
         catch ( YAML::Exception& e )
         {
@@ -279,6 +292,11 @@ Branding::imagePath( Branding::ImageEntry imageEntry ) const
     return m_images.value( s_imageEntryStrings.value( imageEntry ) );
 }
 
+QString
+Branding::uploadServer( Branding::UploadServerEntry uploadServerEntry ) const
+{
+    return m_uploadServer.value( s_uploadServerStrings.value( uploadServerEntry ) );
+}
 
 QPixmap
 Branding::image( Branding::ImageEntry imageEntry, const QSize& size ) const
@@ -511,10 +529,6 @@ Branding::initSimpleSettings( const YAML::Node& doc )
     {
         m_windowHeight = WindowDimension( CalamaresUtils::windowPreferredHeight, WindowDimensionUnit::Pixies );
     }
-
-    m_uploadServerURL  = getString( doc, "uploadServer.url" );
-    m_uploadServerPort = doc[ "uploadServer.port" ].as< int >();
-    m_uploadServerType = getString( doc, "uploadServer.type" );
 }
 
 void

--- a/src/libcalamaresui/Branding.cpp
+++ b/src/libcalamaresui/Branding.cpp
@@ -87,7 +87,6 @@ const QStringList Branding::s_styleEntryStrings =
     "sidebarTextSelect",
     "sidebarTextHighlight"
 };
-
 // clang-format on
 // *INDENT-ON*
 
@@ -513,10 +512,9 @@ Branding::initSimpleSettings( const YAML::Node& doc )
         m_windowHeight = WindowDimension( CalamaresUtils::windowPreferredHeight, WindowDimensionUnit::Pixies );
     }
 
-    m_logUploadEnable = doc[ "logUpload.enable" ].as< bool >( false );
-    m_logUploadURL = getString( doc, "logUpload.url" );
-    m_logUploadPort = doc[ "logUpload.port" ].as< int >();
-    m_logUploadStyle = getString( doc, "logUpload.style" );
+    m_uploadServerURL  = getString( doc, "uploadServer.url" );
+    m_uploadServerPort = doc[ "uploadServer.port" ].as< int >();
+    m_uploadServerType = getString( doc, "uploadServer.type" );
 }
 
 void

--- a/src/libcalamaresui/Branding.cpp
+++ b/src/libcalamaresui/Branding.cpp
@@ -4,6 +4,7 @@
  *   SPDX-FileCopyrightText: 2017-2019 Adriaan de Groot <groot@kde.org>
  *   SPDX-FileCopyrightText: 2018 Raul Rodrigo Segura (raurodse)
  *   SPDX-FileCopyrightText: 2019 Camilo Higuita <milo.h@aol.com>
+ *   SPDX-FileCopyrightText: 2021 Anubhav Choudhary <ac.10edu@gmail.com>
  *   SPDX-License-Identifier: GPL-3.0-or-later
  *
  *   Calamares is Free Software: see the License-Identifier above.
@@ -513,9 +514,9 @@ Branding::initSimpleSettings( const YAML::Node& doc )
     }
 
     m_logUploadEnable = doc[ "logUpload.enable" ].as< bool >( false );
-    m_logUploadURL = getString( doc, "logUpload.url") ;
+    m_logUploadURL = getString( doc, "logUpload.url" );
     m_logUploadPort = doc[ "logUpload.port" ].as< int >();
-    m_logUploadStyle= getString(doc, "logUpload.style" );
+    m_logUploadStyle = getString( doc, "logUpload.style" );
 }
 
 void

--- a/src/libcalamaresui/Branding.h
+++ b/src/libcalamaresui/Branding.h
@@ -218,10 +218,9 @@ public:
 
 
     //Paste functionality related
-    bool logUploadEnable() { return m_logUploadEnable; };
-    QString logUploadURL() { return m_logUploadURL; };
-    int logUploadPort() { return m_logUploadPort; };
-    QString logUploadStyle() { return m_logUploadStyle; };
+    QString uploadServerType() { return m_uploadServerType; };
+    QString uploadServerURL() { return m_uploadServerURL; };
+    int uploadServerPort() { return m_uploadServerPort; };
 
 public slots:
     QString string( StringEntry stringEntry ) const;
@@ -270,10 +269,9 @@ private:
     bool m_welcomeStyleCalamares;
     bool m_welcomeExpandingLogo;
 
-    bool m_logUploadEnable;
-    QString m_logUploadURL;
-    int m_logUploadPort;
-    QString m_logUploadStyle;
+    QString m_uploadServerType;
+    QString m_uploadServerURL;
+    int m_uploadServerPort;
 
     WindowExpansion m_windowExpansion;
     WindowDimension m_windowHeight, m_windowWidth;

--- a/src/libcalamaresui/Branding.h
+++ b/src/libcalamaresui/Branding.h
@@ -23,6 +23,7 @@
 #include <QPixmap>
 #include <QSize>
 #include <QStringList>
+#include <QUrl>
 
 namespace YAML
 {
@@ -219,7 +220,7 @@ public:
 
     //Paste functionality related
     QString uploadServerType() { return m_uploadServerType; };
-    QString uploadServerURL() { return m_uploadServerURL; };
+    QUrl uploadServerURL() { return m_uploadServerURL; };
     int uploadServerPort() { return m_uploadServerPort; };
 
 public slots:
@@ -270,7 +271,7 @@ private:
     bool m_welcomeExpandingLogo;
 
     QString m_uploadServerType;
-    QString m_uploadServerURL;
+    QUrl m_uploadServerURL;
     int m_uploadServerPort;
 
     WindowExpansion m_windowExpansion;

--- a/src/libcalamaresui/Branding.h
+++ b/src/libcalamaresui/Branding.h
@@ -4,6 +4,7 @@
  *   SPDX-FileCopyrightText: 2017-2018 Adriaan de Groot <groot@kde.org>
  *   SPDX-FileCopyrightText: 2018 Raul Rodrigo Segura (raurodse)
  *   SPDX-FileCopyrightText: 2019 Camilo Higuita <milo.h@aol.com>
+ *   SPDX-FileCopyrightText: 2021 Anubhav Choudhary <ac.10edu@gmail.com>
  *   SPDX-License-Identifier: GPL-3.0-or-later
  *
  *   Calamares is Free Software: see the License-Identifier above.
@@ -216,11 +217,11 @@ public:
     void setGlobals( GlobalStorage* globalStorage ) const;
 
 
-     //Paste functionality related
-     bool logUploadEnable() { return m_logUploadEnable; };
-     QString logUploadURL() { return m_logUploadURL; };
-     int logUploadPort() { return m_logUploadPort; };
-     QString logUploadStyle() { return m_logUploadStyle; };
+    //Paste functionality related
+    bool logUploadEnable() { return m_logUploadEnable; };
+    QString logUploadURL() { return m_logUploadURL; };
+    int logUploadPort() { return m_logUploadPort; };
+    QString logUploadStyle() { return m_logUploadStyle; };
 
 public slots:
     QString string( StringEntry stringEntry ) const;

--- a/src/libcalamaresui/Branding.h
+++ b/src/libcalamaresui/Branding.h
@@ -83,6 +83,14 @@ public:
     };
     Q_ENUM( StyleEntry )
 
+    enum UploadServerEntry : short
+    {
+        Type,
+        URL,
+        Port
+    };
+    Q_ENUM( UploadServerEntry )
+
     /** @brief Setting for how much the main window may expand. */
     enum class WindowExpansion
     {
@@ -217,12 +225,6 @@ public:
      */
     void setGlobals( GlobalStorage* globalStorage ) const;
 
-
-    //Paste functionality related
-    QString uploadServerType() { return m_uploadServerType; };
-    QUrl uploadServerURL() { return m_uploadServerURL; };
-    int uploadServerPort() { return m_uploadServerPort; };
-
 public slots:
     QString string( StringEntry stringEntry ) const;
     QString versionedName() const { return string( VersionedName ); }
@@ -232,6 +234,7 @@ public slots:
 
     QString styleString( StyleEntry styleEntry ) const;
     QString imagePath( ImageEntry imageEntry ) const;
+    QString uploadServer( UploadServerEntry uploadServerEntry ) const;
 
     PanelSide sidebarSide() const { return m_sidebarSide; }
     PanelSide navigationSide() const { return m_navigationSide; }
@@ -242,12 +245,14 @@ private:
     static const QStringList s_stringEntryStrings;
     static const QStringList s_imageEntryStrings;
     static const QStringList s_styleEntryStrings;
+    static const QStringList s_uploadServerStrings;
 
     QString m_descriptorPath;  // Path to descriptor (e.g. "/etc/calamares/default/branding.desc")
     QString m_componentName;  // Matches last part of full path to containing directory
     QMap< QString, QString > m_strings;
     QMap< QString, QString > m_images;
     QMap< QString, QString > m_style;
+    QMap< QString, QString > m_uploadServer;
 
     /* The slideshow can be done in one of two ways:
      *  - as a sequence of images
@@ -269,10 +274,6 @@ private:
 
     bool m_welcomeStyleCalamares;
     bool m_welcomeExpandingLogo;
-
-    QString m_uploadServerType;
-    QUrl m_uploadServerURL;
-    int m_uploadServerPort;
 
     WindowExpansion m_windowExpansion;
     WindowDimension m_windowHeight, m_windowWidth;

--- a/src/libcalamaresui/Branding.h
+++ b/src/libcalamaresui/Branding.h
@@ -42,6 +42,7 @@ public:
      * e.g. *Branding::ProductName to get the string value for
      * the product name.
      */
+
     enum StringEntry
     {
         ProductName,
@@ -214,6 +215,13 @@ public:
      */
     void setGlobals( GlobalStorage* globalStorage ) const;
 
+
+     //Paste functionality related
+     bool logUploadEnable() { return m_logUploadEnable; };
+     QString logUploadURL() { return m_logUploadURL; };
+     int logUploadPort() { return m_logUploadPort; };
+     QString logUploadStyle() { return m_logUploadStyle; };
+
 public slots:
     QString string( StringEntry stringEntry ) const;
     QString versionedName() const { return string( VersionedName ); }
@@ -260,6 +268,11 @@ private:
 
     bool m_welcomeStyleCalamares;
     bool m_welcomeExpandingLogo;
+
+    bool m_logUploadEnable;
+    QString m_logUploadURL;
+    int m_logUploadPort;
+    QString m_logUploadStyle;
 
     WindowExpansion m_windowExpansion;
     WindowDimension m_windowHeight, m_windowWidth;

--- a/src/libcalamaresui/ViewManager.cpp
+++ b/src/libcalamaresui/ViewManager.cpp
@@ -4,6 +4,7 @@
  *   SPDX-FileCopyrightText: 2017-2018 Adriaan de Groot <groot@kde.org>
  *   SPDX-FileCopyrightText: 2019 Dominic Hayes <ferenosdev@outlook.com>
  *   SPDX-FileCopyrightText: 2019 Gabriel Craciunescu <crazy@frugalware.org>
+ *   SPDX-FileCopyrightText: 2021 Anubhav Choudhary <ac.10edu@gmail.com>
  *   SPDX-License-Identifier: GPL-3.0-or-later
  *
  *   Calamares is Free Software: see the License-Identifier above.
@@ -140,7 +141,7 @@ ViewManager::insertViewStep( int before, ViewStep* step )
 void
 ViewManager::onInstallationFailed( const QString& message, const QString& details )
 {
-    bool shouldOfferWebPaste = Calamares::Branding::instance()->logUploadEnable();  // TODO: config var
+    bool shouldOfferWebPaste = Calamares::Branding::instance()->logUploadEnable();
 
     cError() << "Installation failed:";
     cDebug() << "- message:" << message;
@@ -531,13 +532,9 @@ ViewManager::updateCancelEnabled( bool enabled )
 }
 
 void
-ViewManager::updateBackAndNextVisibility( bool visible)
-{
-    UPDATE_BUTTON_PROPERTY( backAndNextVisible, visible )
-}
+ViewManager::updateBackAndNextVisibility( bool visible ) { UPDATE_BUTTON_PROPERTY( backAndNextVisible, visible ) }
 
-QVariant
-ViewManager::data( const QModelIndex& index, int role ) const
+QVariant ViewManager::data( const QModelIndex& index, int role ) const
 {
     if ( !index.isValid() )
     {

--- a/src/libcalamaresui/ViewManager.cpp
+++ b/src/libcalamaresui/ViewManager.cpp
@@ -141,7 +141,7 @@ ViewManager::insertViewStep( int before, ViewStep* step )
 void
 ViewManager::onInstallationFailed( const QString& message, const QString& details )
 {
-    QString serverType = Calamares::Branding::instance()->uploadServerType();
+    QString serverType = Calamares::Branding::instance()->uploadServer( Calamares::Branding::Type );
     bool shouldOfferWebPaste = CalamaresUtils::UploadServersList.contains( serverType );
 
     cError() << "Installation failed:";
@@ -186,7 +186,7 @@ ViewManager::onInstallationFailed( const QString& message, const QString& detail
         if ( msgBox->buttonRole( button ) == QMessageBox::ButtonRole::YesRole )
         {
             QString pasteUrlMsg;
-            QString serverType = Calamares::Branding::instance()->uploadServerType();
+            QString serverType = Calamares::Branding::instance()->uploadServer( Calamares::Branding::Type );
             if ( serverType == "fiche" )
             {
                 pasteUrlMsg = CalamaresUtils::ficheLogUpload( msgBox );

--- a/src/libcalamaresui/ViewManager.cpp
+++ b/src/libcalamaresui/ViewManager.cpp
@@ -140,7 +140,7 @@ ViewManager::insertViewStep( int before, ViewStep* step )
 void
 ViewManager::onInstallationFailed( const QString& message, const QString& details )
 {
-    bool shouldOfferWebPaste = false;  // TODO: config var
+    bool shouldOfferWebPaste = Calamares::Branding::instance()->logUploadEnable();  // TODO: config var
 
     cError() << "Installation failed:";
     cDebug() << "- message:" << message;
@@ -183,8 +183,9 @@ ViewManager::onInstallationFailed( const QString& message, const QString& detail
     connect( msgBox, &QMessageBox::buttonClicked, [msgBox]( QAbstractButton* button ) {
         if ( msgBox->buttonRole( button ) == QMessageBox::ButtonRole::YesRole )
         {
-            // TODO: host and port should be configurable
-            QString pasteUrlMsg = CalamaresUtils::sendLogToPastebin( msgBox, QStringLiteral( "termbin.com" ), 9999 );
+            QString pasteURLHost = Calamares::Branding::instance()->logUploadURL();
+            int pasteURLPort = Calamares::Branding::instance()->logUploadPort();
+            QString pasteUrlMsg = CalamaresUtils::sendLogToPastebin( msgBox, pasteURLHost, pasteURLPort );
 
             QString pasteUrlTitle = tr( "Install Log Paste URL" );
             if ( pasteUrlMsg.isEmpty() )

--- a/src/libcalamaresui/ViewManager.cpp
+++ b/src/libcalamaresui/ViewManager.cpp
@@ -141,8 +141,8 @@ ViewManager::insertViewStep( int before, ViewStep* step )
 void
 ViewManager::onInstallationFailed( const QString& message, const QString& details )
 {
-    QString UploadServerType = Calamares::Branding::instance()->uploadServerType();
-    bool shouldOfferWebPaste = CalamaresUtils::UploadServersList.contains( UploadServerType );
+    QString serverType = Calamares::Branding::instance()->uploadServerType();
+    bool shouldOfferWebPaste = CalamaresUtils::UploadServersList.contains( serverType );
 
     cError() << "Installation failed:";
     cDebug() << "- message:" << message;
@@ -186,10 +186,10 @@ ViewManager::onInstallationFailed( const QString& message, const QString& detail
         if ( msgBox->buttonRole( button ) == QMessageBox::ButtonRole::YesRole )
         {
             QString pasteUrlMsg;
-            QString UploadServerType = Calamares::Branding::instance()->uploadServerType();
-            if ( UploadServerType == "fiche" )
+            QString serverType = Calamares::Branding::instance()->uploadServerType();
+            if ( serverType == "fiche" )
             {
-                pasteUrlMsg = CalamaresUtils::sendLogToPastebin( msgBox );
+                pasteUrlMsg = CalamaresUtils::ficheLogUpload( msgBox );
             }
             else
             {
@@ -545,7 +545,7 @@ ViewManager::updateBackAndNextVisibility( bool visible )
     UPDATE_BUTTON_PROPERTY( backAndNextVisible, visible )
 }
 
-QVariant 
+QVariant
 ViewManager::data( const QModelIndex& index, int role ) const
 {
     if ( !index.isValid() )

--- a/src/libcalamaresui/ViewManager.cpp
+++ b/src/libcalamaresui/ViewManager.cpp
@@ -141,7 +141,8 @@ ViewManager::insertViewStep( int before, ViewStep* step )
 void
 ViewManager::onInstallationFailed( const QString& message, const QString& details )
 {
-    bool shouldOfferWebPaste = Calamares::Branding::instance()->logUploadEnable();
+    QString UploadServerType = Calamares::Branding::instance()->uploadServerType();
+    bool shouldOfferWebPaste = CalamaresUtils::UploadServersList.contains( UploadServerType );
 
     cError() << "Installation failed:";
     cDebug() << "- message:" << message;
@@ -184,9 +185,16 @@ ViewManager::onInstallationFailed( const QString& message, const QString& detail
     connect( msgBox, &QMessageBox::buttonClicked, [msgBox]( QAbstractButton* button ) {
         if ( msgBox->buttonRole( button ) == QMessageBox::ButtonRole::YesRole )
         {
-            QString pasteURLHost = Calamares::Branding::instance()->logUploadURL();
-            int pasteURLPort = Calamares::Branding::instance()->logUploadPort();
-            QString pasteUrlMsg = CalamaresUtils::sendLogToPastebin( msgBox, pasteURLHost, pasteURLPort );
+            QString pasteUrlMsg;
+            QString UploadServerType = Calamares::Branding::instance()->uploadServerType();
+            if ( UploadServerType == "fiche" )
+            {
+                pasteUrlMsg = CalamaresUtils::sendLogToPastebin( msgBox );
+            }
+            else
+            {
+                pasteUrlMsg = QString();
+            }
 
             QString pasteUrlTitle = tr( "Install Log Paste URL" );
             if ( pasteUrlMsg.isEmpty() )
@@ -532,9 +540,13 @@ ViewManager::updateCancelEnabled( bool enabled )
 }
 
 void
-ViewManager::updateBackAndNextVisibility( bool visible ) { UPDATE_BUTTON_PROPERTY( backAndNextVisible, visible ) }
+ViewManager::updateBackAndNextVisibility( bool visible )
+{
+    UPDATE_BUTTON_PROPERTY( backAndNextVisible, visible )
+}
 
-QVariant ViewManager::data( const QModelIndex& index, int role ) const
+QVariant 
+ViewManager::data( const QModelIndex& index, int role ) const
 {
     if ( !index.isValid() )
     {

--- a/src/libcalamaresui/utils/Paste.cpp
+++ b/src/libcalamaresui/utils/Paste.cpp
@@ -33,8 +33,8 @@ QString
 ficheLogUpload( QObject* parent )
 {
 
-    const QString& ficheHost = Calamares::Branding::instance()->uploadServerURL().toString();
-    quint16 fichePort = Calamares::Branding::instance()->uploadServerPort();
+    const QString& ficheHost = Calamares::Branding::instance()->uploadServer( Calamares::Branding::URL );
+    quint16 fichePort = Calamares::Branding::instance()->uploadServer( Calamares::Branding::Port ).toInt();
 
     QString pasteUrlFmt = parent->tr( "Install log posted to\n\n%1\n\nLink copied to clipboard" );
 

--- a/src/libcalamaresui/utils/Paste.cpp
+++ b/src/libcalamaresui/utils/Paste.cpp
@@ -15,6 +15,8 @@
 #include <QRegularExpression>
 #include <QTcpSocket>
 #include <QUrl>
+#include <QClipboard>
+#include <QApplication>
 
 namespace CalamaresUtils
 {
@@ -22,7 +24,8 @@ namespace CalamaresUtils
 QString
 sendLogToPastebin( QObject* parent, const QString& ficheHost, quint16 fichePort )
 {
-    QString pasteUrlFmt = parent->tr( "Install log posted to:\n%1" );
+    QString pasteUrlFmt = parent->tr( "Install log posted to\n\n%1\n\nLink copied to clipboard" );
+
     QFile pasteSourceFile( Logger::logFile() );
     if ( !pasteSourceFile.open( QIODevice::ReadOnly | QIODevice::Text ) )
     {
@@ -77,6 +80,14 @@ sendLogToPastebin( QObject* parent, const QString& ficheHost, quint16 fichePort 
     QString pasteUrlStr = pasteUrl.toString();
     QRegularExpression pasteUrlRegex( "^http[s]?://" + ficheHost );
     QString pasteUrlMsg = QString( pasteUrlFmt ).arg( pasteUrlStr );
+
+    QClipboard* clipboard = QApplication::clipboard();
+    clipboard->setText(pasteUrlStr, QClipboard::Clipboard);
+
+    if (clipboard->supportsSelection())
+    {
+         clipboard->setText(pasteUrlStr, QClipboard::Selection);
+    }
 
     if ( nBytesRead < 8 || !pasteUrl.isValid() || !pasteUrlRegex.match( pasteUrlStr ).hasMatch() )
     {

--- a/src/libcalamaresui/utils/Paste.cpp
+++ b/src/libcalamaresui/utils/Paste.cpp
@@ -30,10 +30,10 @@ QStringList UploadServersList = {
 };
 
 QString
-sendLogToPastebin( QObject* parent )
+ficheLogUpload( QObject* parent )
 {
 
-    const QString& ficheHost = Calamares::Branding::instance()->uploadServerURL();
+    const QString& ficheHost = Calamares::Branding::instance()->uploadServerURL().toString();
     quint16 fichePort = Calamares::Branding::instance()->uploadServerPort();
 
     QString pasteUrlFmt = parent->tr( "Install log posted to\n\n%1\n\nLink copied to clipboard" );

--- a/src/libcalamaresui/utils/Paste.h
+++ b/src/libcalamaresui/utils/Paste.h
@@ -10,7 +10,7 @@
 #ifndef UTILS_PASTE_H
 #define UTILS_PASTE_H
 
-#include <qglobal.h>  // for quint16
+#include<QStringList>
 
 class QObject;
 class QString;
@@ -22,7 +22,9 @@ namespace CalamaresUtils
  *
  * Returns the (string) URL that the pastebin gives us.
  */
-QString sendLogToPastebin( QObject* parent, const QString& ficheHost, quint16 fichePort );
+QString sendLogToPastebin( QObject* parent );
+
+extern QStringList UploadServersList;
 
 }  // namespace CalamaresUtils
 

--- a/src/libcalamaresui/utils/Paste.h
+++ b/src/libcalamaresui/utils/Paste.h
@@ -22,7 +22,7 @@ namespace CalamaresUtils
  *
  * Returns the (string) URL that the pastebin gives us.
  */
-QString sendLogToPastebin( QObject* parent );
+QString ficheLogUpload( QObject* parent );
 
 extern QStringList UploadServersList;
 


### PR DESCRIPTION
This PR adds functionality of picking up `uploadServer` signals from `branding.desc` rather than hardcoding them (in ViewManager).

Addressing #1182 