### PR TITLE
modules/bootloader: Use the correct names for the shim binaries

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,6 +38,7 @@ and moral support from (alphabetically by first name or nickname):
  - Kevin Kofler
  - Kyle Robertze
  - Lisa Vitolo
+ - Neal Gompa
  - n3rdopolis
  - Philip Müller
  - Ramon Buldó

--- a/src/modules/bootloader/main.py
+++ b/src/modules/bootloader/main.py
@@ -14,6 +14,7 @@
 #   SPDX-FileCopyrightText: 2017-2019 Adriaan de Groot <groot@kde.org>
 #   SPDX-FileCopyrightText: 2017 Gabriel Craciunescu <crazy@frugalware.org>
 #   SPDX-FileCopyrightText: 2017 Ben Green <Bezzy1999@hotmail.com>
+#   SPDX-FileCopyrightText: 2021 Neal Gompa <ngompa13@gmail.com>
 #   SPDX-License-Identifier: GPL-3.0-or-later
 #
 #   Calamares is Free Software: see the License-Identifier above.
@@ -372,9 +373,9 @@ def install_secureboot(efi_directory):
     install_efi_directory = install_path + efi_directory
 
     if efi_word_size() == "64":
-        install_efi_bin = "shim64.efi"
-    else:
-        install_efi_bin = "shim.efi"
+        install_efi_bin = "shimx64.efi"
+    elif efi_word_size() == "32":
+        install_efi_bin = "shimia32.efi"
 
     # Copied, roughly, from openSUSE's install script,
     # and pythonified. *disk* is something like /dev/sda,


### PR DESCRIPTION
Ever since signed shim binaries for multiple architectures became available, the shim binaries installed in Linux distributions have been renamed to include the EFI architecture in the binary names.

This started in Fedora, but is now used in openSUSE and Ubuntu too.

Reference for shim binary names comes from shim spec in Fedora: https://src.fedoraproject.org/rpms/shim/blob/d8c3c8e39235507feb17b4e81851da087ae83c77/f/shim.spec#_23-32