### PR TITLE
[packages] Drop urpmi support

### DIFF
--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -356,26 +356,6 @@ class PMPortage(PackageManager):
         pass
 
 
-class PMUrpmi(PackageManager):
-    backend = "urpmi"
-
-    def install(self, pkgs, from_local=False):
-        check_target_env_call(["urpmi", "--download-all", "--no-suggests",
-                               "--no-verify-rpm", "--fastunsafe",
-                               "--ignoresize", "--nolock",
-                               "--auto"] + pkgs)
-
-    def remove(self, pkgs):
-        check_target_env_call(["urpme", "--auto"] + pkgs)
-
-    def update_db(self):
-        check_target_env_call(["urpmi.update", "-a"])
-
-    def update_system(self):
-        # Doesn't need to update the system explicitly
-        pass
-
-
 class PMXbps(PackageManager):
     backend = "xbps"
 

--- a/src/modules/packages/packages.conf
+++ b/src/modules/packages/packages.conf
@@ -12,7 +12,6 @@
 #  - pacman      - Pacman
 #  - pamac       - Manjaro package manager
 #  - portage     - Gentoo package manager
-#  - urpmi       - Mandriva package manager
 #  - yum         - Yum RPM frontend
 #  - zypp        - Zypp RPM frontend
 #

--- a/src/modules/packages/packages.schema.yaml
+++ b/src/modules/packages/packages.schema.yaml
@@ -17,7 +17,6 @@ properties:
             - pacman
             - pamac
             - portage
-            - urpmi
             - yum
             - zypp
             - dummy


### PR DESCRIPTION
This code is essentially untested and unused, as OpenMandriva has been using DNF for three years now.

Reference: https://www.openmandriva.org/en/news/article/switching-to-rpmv4
