### PR TITLE
[logUpload] Limit upload size

### DIFF
--- a/src/branding/default/branding.desc
+++ b/src/branding/default/branding.desc
@@ -220,13 +220,17 @@ slideshowAPI: 2
 
 
 # These options are to customize online uploading of logs to pastebins:
-#  - type : Defines the kind of pastebin service to be used. Currently
-#           it accepts two values:
-#           - none    :    disables the pastebin functionality
-#           - fiche   :    use fiche pastebin server
-#  - url  : Defines the address of pastebin service to be used.
-#           Takes string as input. Important bits are the host and port,
-#           the scheme is not used.
+#  - type      : Defines the kind of pastebin service to be used. Currently
+#                it accepts two values:
+#                - none    :    disables the pastebin functionality
+#                - fiche   :    use fiche pastebin server
+#  - url       : Defines the address of pastebin service to be used.
+#                Takes string as input. Important bits are the host and port,
+#                the scheme is not used.
+#  - sizeLimit : Defines maximum size limit (in KiB) of log file to be pasted. 
+#                Takes integer as input. If <=0, no limit will be forced,
+#                else only last 'n' KiB of log file will be pasted. 
 uploadServer :
     type :    "fiche"
     url :     "http://termbin.com:9999"
+    sizeLimit : 20

--- a/src/branding/default/branding.desc
+++ b/src/branding/default/branding.desc
@@ -227,9 +227,11 @@ slideshowAPI: 2
 #  - url       : Defines the address of pastebin service to be used.
 #                Takes string as input. Important bits are the host and port,
 #                the scheme is not used.
-#  - sizeLimit : Defines maximum size limit (in KiB) of log file to be pasted. 
-#                Takes integer as input. If <=0, no limit will be forced,
-#                else only last 'n' KiB of log file will be pasted. 
+#  - sizeLimit : Defines maximum size limit (in KiB) of log file to be pasted.
+#                Takes integer as input. If < 0, no limit will be forced,
+#                else only last (approximately) 'n' KiB of log file will be pasted.
+#                Please note that upload size may be slightly over the limit (due
+#                to last minute logging), so provide a suitable value.
 uploadServer :
     type :    "fiche"
     url :     "http://termbin.com:9999"

--- a/src/branding/default/branding.desc
+++ b/src/branding/default/branding.desc
@@ -233,4 +233,4 @@ slideshowAPI: 2
 uploadServer :
     type :    "fiche"
     url :     "http://termbin.com:9999"
-    sizeLimit : 20
+    sizeLimit : -1

--- a/src/libcalamaresui/Branding.cpp
+++ b/src/libcalamaresui/Branding.cpp
@@ -153,15 +153,17 @@ uploadServerFromMap( const QVariantMap& map )
 
     QString typestring = map[ "type" ].toString();
     QString urlstring = map[ "url" ].toString();
+    qint64 sizeLimit = map[ "sizeLimit" ].toLongLong();
 
     if ( typestring.isEmpty() || urlstring.isEmpty() )
     {
-        return Branding::UploadServerInfo( Branding::UploadServerType::None, QUrl() );
+        return Branding::UploadServerInfo( Branding::UploadServerType::None, QUrl(), -1 );
     }
 
     bool bogus = false;  // we don't care about type-name lookup success here
     return Branding::UploadServerInfo( names.find( typestring, bogus ),
-                                       QUrl( urlstring, QUrl::ParsingMode::StrictMode ) );
+                                       QUrl( urlstring, QUrl::ParsingMode::StrictMode ),
+                                       sizeLimit );
 }
 
 /** @brief Load the @p map with strings from @p config

--- a/src/libcalamaresui/Branding.cpp
+++ b/src/libcalamaresui/Branding.cpp
@@ -153,7 +153,7 @@ uploadServerFromMap( const QVariantMap& map )
 
     QString typestring = map[ "type" ].toString();
     QString urlstring = map[ "url" ].toString();
-    qint64 sizeLimit = map[ "sizeLimit" ].toLongLong();
+    qint64 sizeLimitKiB = map[ "sizeLimit" ].toLongLong();
 
     if ( typestring.isEmpty() || urlstring.isEmpty() )
     {
@@ -163,7 +163,7 @@ uploadServerFromMap( const QVariantMap& map )
     bool bogus = false;  // we don't care about type-name lookup success here
     return Branding::UploadServerInfo( names.find( typestring, bogus ),
                                        QUrl( urlstring, QUrl::ParsingMode::StrictMode ),
-                                       sizeLimit );
+                                       sizeLimitKiB );
 }
 
 /** @brief Load the @p map with strings from @p config

--- a/src/libcalamaresui/Branding.cpp
+++ b/src/libcalamaresui/Branding.cpp
@@ -157,13 +157,13 @@ uploadServerFromMap( const QVariantMap& map )
 
     if ( typestring.isEmpty() || urlstring.isEmpty() )
     {
-        return Branding::UploadServerInfo( Branding::UploadServerType::None, QUrl(), -1 );
+        return Branding::UploadServerInfo( Branding::UploadServerType::None, QUrl(), 0 );
     }
 
     bool bogus = false;  // we don't care about type-name lookup success here
     return Branding::UploadServerInfo( names.find( typestring, bogus ),
                                        QUrl( urlstring, QUrl::ParsingMode::StrictMode ),
-                                       sizeLimitKiB );
+                                       ( sizeLimitKiB >=0 ) ? sizeLimitKiB * 1024 : -1 );
 }
 
 /** @brief Load the @p map with strings from @p config

--- a/src/libcalamaresui/Branding.cpp
+++ b/src/libcalamaresui/Branding.cpp
@@ -18,6 +18,7 @@
 #include "utils/ImageRegistry.h"
 #include "utils/Logger.h"
 #include "utils/NamedEnum.h"
+#include "utils/Units.h"
 #include "utils/Yaml.h"
 
 #include <QDir>
@@ -161,9 +162,10 @@ uploadServerFromMap( const QVariantMap& map )
     }
 
     bool bogus = false;  // we don't care about type-name lookup success here
-    return Branding::UploadServerInfo( names.find( typestring, bogus ),
-                                       QUrl( urlstring, QUrl::ParsingMode::StrictMode ),
-                                       ( sizeLimitKiB >= 0 ) ? sizeLimitKiB * 1024 : -1 );
+    return Branding::UploadServerInfo(
+        names.find( typestring, bogus ),
+        QUrl( urlstring, QUrl::ParsingMode::StrictMode ),
+        sizeLimitKiB >= 0 ? CalamaresUtils::KiBtoBytes( static_cast< unsigned long long >( sizeLimitKiB ) ) : -1 );
 }
 
 /** @brief Load the @p map with strings from @p config

--- a/src/libcalamaresui/Branding.cpp
+++ b/src/libcalamaresui/Branding.cpp
@@ -163,7 +163,7 @@ uploadServerFromMap( const QVariantMap& map )
     bool bogus = false;  // we don't care about type-name lookup success here
     return Branding::UploadServerInfo( names.find( typestring, bogus ),
                                        QUrl( urlstring, QUrl::ParsingMode::StrictMode ),
-                                       ( sizeLimitKiB >=0 ) ? sizeLimitKiB * 1024 : -1 );
+                                       ( sizeLimitKiB >= 0 ) ? sizeLimitKiB * 1024 : -1 );
 }
 
 /** @brief Load the @p map with strings from @p config

--- a/src/libcalamaresui/Branding.h
+++ b/src/libcalamaresui/Branding.h
@@ -223,8 +223,9 @@ public:
 
     /** @brief Upload server configuration
      *
-     * This is both the type (which may be none, in which case the URL
-     * is irrelevant and usually empty) and the URL for the upload.
+     * This object has 3 items : the type (which may be none, in which case the URL
+     * is irrelevant and usually empty), the URL for the upload and the size limit of upload
+     * in bytes (for configuration value < 0, it serves -1, which stands for having no limit).
      */
     using UploadServerInfo = std::tuple< UploadServerType, QUrl, qint64 >;
     UploadServerInfo uploadServer() const { return m_uploadServer; }

--- a/src/libcalamaresui/Branding.h
+++ b/src/libcalamaresui/Branding.h
@@ -226,7 +226,7 @@ public:
      * This is both the type (which may be none, in which case the URL
      * is irrelevant and usually empty) and the URL for the upload.
      */
-    using UploadServerInfo = QPair< UploadServerType, QUrl >;
+    using UploadServerInfo = std::tuple< UploadServerType, QUrl, qint64 >;
     UploadServerInfo uploadServer() const { return m_uploadServer; }
 
     /**

--- a/src/libcalamaresui/ViewManager.cpp
+++ b/src/libcalamaresui/ViewManager.cpp
@@ -144,7 +144,7 @@ void
 ViewManager::onInstallationFailed( const QString& message, const QString& details )
 {
     bool shouldOfferWebPaste
-        = Calamares::Branding::instance()->uploadServer().first != Calamares::Branding::UploadServerType::None;
+        = std::get<2>(Calamares::Branding::instance()->uploadServer()) != Calamares::Branding::UploadServerType::None;
 
     cError() << "Installation failed:" << message;
     cDebug() << Logger::SubEntry << "- message:" << message;

--- a/src/libcalamaresui/ViewManager.cpp
+++ b/src/libcalamaresui/ViewManager.cpp
@@ -143,9 +143,9 @@ ViewManager::insertViewStep( int before, ViewStep* step )
 void
 ViewManager::onInstallationFailed( const QString& message, const QString& details )
 {
-    bool shouldOfferWebPaste
-        = std::get<0>(Calamares::Branding::instance()->uploadServer()) != Calamares::Branding::UploadServerType::None
-          and std::get<2>(Calamares::Branding::instance()->uploadServer()) != 0;
+    bool shouldOfferWebPaste = std::get< 0 >( Calamares::Branding::instance()->uploadServer() )
+            != Calamares::Branding::UploadServerType::None
+        and std::get< 2 >( Calamares::Branding::instance()->uploadServer() ) != 0;
 
     cError() << "Installation failed:" << message;
     cDebug() << Logger::SubEntry << "- message:" << message;

--- a/src/libcalamaresui/ViewManager.cpp
+++ b/src/libcalamaresui/ViewManager.cpp
@@ -144,7 +144,7 @@ void
 ViewManager::onInstallationFailed( const QString& message, const QString& details )
 {
     bool shouldOfferWebPaste
-        = std::get<2>(Calamares::Branding::instance()->uploadServer()) != Calamares::Branding::UploadServerType::None;
+        = std::get<0>(Calamares::Branding::instance()->uploadServer()) != Calamares::Branding::UploadServerType::None;
 
     cError() << "Installation failed:" << message;
     cDebug() << Logger::SubEntry << "- message:" << message;

--- a/src/libcalamaresui/ViewManager.cpp
+++ b/src/libcalamaresui/ViewManager.cpp
@@ -144,7 +144,8 @@ void
 ViewManager::onInstallationFailed( const QString& message, const QString& details )
 {
     bool shouldOfferWebPaste
-        = std::get<0>(Calamares::Branding::instance()->uploadServer()) != Calamares::Branding::UploadServerType::None;
+        = std::get<0>(Calamares::Branding::instance()->uploadServer()) != Calamares::Branding::UploadServerType::None
+          and std::get<2>(Calamares::Branding::instance()->uploadServer()) != 0;
 
     cError() << "Installation failed:" << message;
     cDebug() << Logger::SubEntry << "- message:" << message;

--- a/src/libcalamaresui/utils/Paste.cpp
+++ b/src/libcalamaresui/utils/Paste.cpp
@@ -32,9 +32,9 @@ using namespace CalamaresUtils::Units;
 STATICTEST QByteArray
 logFileContents( const qint64 sizeLimitBytes )
 {
-    if( sizeLimitBytes != -1 )
+    if ( sizeLimitBytes != -1 )
     {
-        cDebug() << "Log upload size limit was limited to" <<  sizeLimitBytes << "bytes";
+        cDebug() << "Log upload size limit was limited to" << sizeLimitBytes << "bytes";
     }
     const QString name = Logger::logFile();
     QFile pasteSourceFile( name );
@@ -43,14 +43,14 @@ logFileContents( const qint64 sizeLimitBytes )
         cWarning() << "Could not open log file" << name;
         return QByteArray();
     }
-    if( sizeLimitBytes == -1 )
+    if ( sizeLimitBytes == -1 )
     {
         return pasteSourceFile.readAll();
     }
     QFileInfo fi( pasteSourceFile );
     if ( fi.size() > sizeLimitBytes )
     {
-        cDebug() << "Only last" << sizeLimitBytes << "bytes of log file (sized" << fi.size() << "bytes) uploaded" ;
+        cDebug() << "Only last" << sizeLimitBytes << "bytes of log file (sized" << fi.size() << "bytes) uploaded";
         fi.refresh();
         pasteSourceFile.seek( fi.size() - sizeLimitBytes );
     }

--- a/src/libcalamaresui/utils/Paste.cpp
+++ b/src/libcalamaresui/utils/Paste.cpp
@@ -108,7 +108,7 @@ ficheLogUpload( const QByteArray& pasteData, const QUrl& serverUrl, QObject* par
 QString
 CalamaresUtils::Paste::doLogUpload( QObject* parent )
 {
-    auto [ type, serverUrl, sizeLimit ] = Calamares::Branding::instance()->uploadServer();
+    auto [ type, serverUrl, sizeLimitKiB ] = Calamares::Branding::instance()->uploadServer();
     if ( !serverUrl.isValid() )
     {
         cWarning() << "Upload configure with invalid URL";
@@ -120,7 +120,7 @@ CalamaresUtils::Paste::doLogUpload( QObject* parent )
         return QString();
     }
 
-    QByteArray pasteData = logFileContents( sizeLimit );
+    QByteArray pasteData = logFileContents( sizeLimitKiB );
     if ( pasteData.isEmpty() )
     {
         // An error has already been logged
@@ -172,6 +172,6 @@ CalamaresUtils::Paste::doLogUploadUI( QWidget* parent )
 bool
 CalamaresUtils::Paste::isEnabled()
 {
-    auto [ type, serverUrl, sizeLimit ] = Calamares::Branding::instance()->uploadServer();
+    auto [ type, serverUrl, sizeLimitKiB ] = Calamares::Branding::instance()->uploadServer();
     return type != Calamares::Branding::UploadServerType::None;
 }

--- a/src/libcalamaresui/utils/Paste.cpp
+++ b/src/libcalamaresui/utils/Paste.cpp
@@ -40,7 +40,7 @@ logFileContents( qint64 sizeLimit )
         return QByteArray();
     }
     QFileInfo fi( pasteSourceFile );
-    sizeLimit *= 1024;            //For KiB to bytes
+    sizeLimit = ( sizeLimit < 0 ) ? 1024*1024 : sizeLimit * 1024;            //For KiB to bytes
     cDebug() << "Log upload size limit was set to " << sizeLimit << " bytes";
     if ( fi.size() > sizeLimit and sizeLimit > 0 )
     {

--- a/src/libcalamaresui/utils/TestPaste.cpp
+++ b/src/libcalamaresui/utils/TestPaste.cpp
@@ -16,7 +16,7 @@
 #include <QDateTime>
 #include <QtTest/QtTest>
 
-extern QByteArray logFileContents( qint64 sizeLimit );
+extern QByteArray logFileContents( qint64 sizeLimitKiB );
 extern QString ficheLogUpload( const QByteArray& pasteData, const QUrl& serverUrl, QObject* parent );
 
 class TestPaste : public QObject

--- a/src/libcalamaresui/utils/TestPaste.cpp
+++ b/src/libcalamaresui/utils/TestPaste.cpp
@@ -16,7 +16,7 @@
 #include <QDateTime>
 #include <QtTest/QtTest>
 
-extern QByteArray logFileContents( qint64 sizeLimitKiB );
+extern QByteArray logFileContents( qint64 sizeLimitBytes );
 extern QString ficheLogUpload( const QByteArray& pasteData, const QUrl& serverUrl, QObject* parent );
 
 class TestPaste : public QObject

--- a/src/libcalamaresui/utils/TestPaste.cpp
+++ b/src/libcalamaresui/utils/TestPaste.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "Paste.h"
+#include "network/Manager.h"
 
 #include "utils/Logger.h"
 
@@ -30,6 +31,7 @@ public:
 private Q_SLOTS:
     void testGetLogFile();
     void testFichePaste();
+    void testUploadSize();
 };
 
 void
@@ -64,7 +66,19 @@ TestPaste::testFichePaste()
     QVERIFY( !s.isEmpty() );
 }
 
+void
+TestPaste::testUploadSize()
+{
+    QByteArray logContent = logFileContents( 100 );
+    QString s = ficheLogUpload( logContent, QUrl( "http://termbin.com:9999" ), nullptr );
 
+    QVERIFY( !s.isEmpty() );
+
+    QUrl url( s );
+    QByteArray returnedData = CalamaresUtils::Network::Manager::instance().synchronousGet( url );
+
+    QCOMPARE( returnedData.size(), 100 );
+}
 QTEST_GUILESS_MAIN( TestPaste )
 
 #include "utils/moc-warnings.h"

--- a/src/libcalamaresui/utils/TestPaste.cpp
+++ b/src/libcalamaresui/utils/TestPaste.cpp
@@ -37,14 +37,18 @@ TestPaste::testGetLogFile()
 {
     QFile::remove( Logger::logFile() );
     // This test assumes nothing **else** has set up logging yet
-    QByteArray contentsOfLogfileBefore = logFileContents( 16 );
-    QVERIFY( contentsOfLogfileBefore.isEmpty() );
+    QByteArray logLimitedBefore = logFileContents( 16 );
+    QVERIFY( logLimitedBefore.isEmpty() );
+    QByteArray logUnlimitedBefore = logFileContents( -1 );
+    QVERIFY( logUnlimitedBefore.isEmpty() );
 
     Logger::setupLogLevel( Logger::LOGDEBUG );
     Logger::setupLogfile();
 
-    QByteArray contentsOfLogfileAfterSetup = logFileContents( 16 );
-    QVERIFY( !contentsOfLogfileAfterSetup.isEmpty() );
+    QByteArray logLimitedAfter = logFileContents( 16 );
+    QVERIFY( !logLimitedAfter.isEmpty() );
+    QByteArray logUnlimitedAfter = logFileContents( -1 );
+    QVERIFY( !logUnlimitedAfter.isEmpty() );
 }
 
 void

--- a/src/libcalamaresui/utils/TestPaste.cpp
+++ b/src/libcalamaresui/utils/TestPaste.cpp
@@ -16,7 +16,7 @@
 #include <QDateTime>
 #include <QtTest/QtTest>
 
-extern QByteArray logFileContents();
+extern QByteArray logFileContents( qint64 sizeLimit );
 extern QString ficheLogUpload( const QByteArray& pasteData, const QUrl& serverUrl, QObject* parent );
 
 class TestPaste : public QObject
@@ -37,13 +37,13 @@ TestPaste::testGetLogFile()
 {
     QFile::remove( Logger::logFile() );
     // This test assumes nothing **else** has set up logging yet
-    QByteArray contentsOfLogfileBefore = logFileContents();
+    QByteArray contentsOfLogfileBefore = logFileContents( 16 );
     QVERIFY( contentsOfLogfileBefore.isEmpty() );
 
     Logger::setupLogLevel( Logger::LOGDEBUG );
     Logger::setupLogfile();
 
-    QByteArray contentsOfLogfileAfterSetup = logFileContents();
+    QByteArray contentsOfLogfileAfterSetup = logFileContents( 16 );
     QVERIFY( !contentsOfLogfileAfterSetup.isEmpty() );
 }
 


### PR DESCRIPTION
Implementing a configuration key `sizeLimit` from `branding.desc` to limit maximum size of logs to be uploaded.