### PR TITLE
[RFC] [partition] FS choice for autopartition options

### DIFF
--- a/src/modules/partition/core/Config.cpp
+++ b/src/modules/partition/core/Config.cpp
@@ -207,6 +207,15 @@ Config::setSwapChoice( Config::SwapChoice c )
     }
 }
 
+void
+Config::setEraseFsTypeChoice(const QString& choice)
+{
+    if(choice != m_eraseFsTypeChoice){
+        m_eraseFsTypeChoice = choice;
+    }
+}
+
+
 bool
 Config::allowManualPartitioning() const
 {
@@ -239,6 +248,17 @@ Config::setConfigurationMap( const QVariantMap& configurationMap )
     Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
     gs->insert( "allowManualPartitioning",
                 CalamaresUtils::getBool( configurationMap, "allowManualPartitioning", true ) );
+
+    if ( configurationMap.contains( "availableFileSystemTypes" ) ) {
+        if(configurationMap.value(  "availableFileSystemTypes" ).type() == QVariant::List ){
+            m_eraseFsTypes.clear();
+            m_eraseFsTypes.append(configurationMap.value(  "availableFileSystemTypes" ).toStringList());
+            m_eraseFsTypeChoice = m_eraseFsTypes[0];
+        } else if ( configurationMap.value(  "availableFileSystemTypes" ).type() == QVariant::String  ){
+            m_eraseFsTypes.append(configurationMap.value(  "availableFileSystemTypes" ).toString());
+            m_eraseFsTypeChoice = m_eraseFsTypes[0];
+        }
+    }
 
     if ( configurationMap.contains( "requiredPartitionTableType" )
          && configurationMap.value( "requiredPartitionTableType" ).type() == QVariant::List )

--- a/src/modules/partition/core/Config.h
+++ b/src/modules/partition/core/Config.h
@@ -54,6 +54,8 @@ public:
     static const NamedEnumTable< SwapChoice >& swapChoiceNames();
     using SwapChoiceSet = QSet< SwapChoice >;
 
+    using EraseFsTypesSet = QStringList;
+
     void setConfigurationMap( const QVariantMap& );
     void updateGlobalStorage() const;
 
@@ -94,6 +96,11 @@ public:
      */
     SwapChoice swapChoice() const { return m_swapChoice; }
 
+    EraseFsTypesSet eraseFsTypes() const {return m_eraseFsTypes; }
+
+    QString eraseFsType() const {return m_eraseFsTypeChoice; }
+
+
     ///@brief Is manual partitioning allowed (not explicitly disnabled in the config file)?
     bool allowManualPartitioning() const;
 
@@ -102,6 +109,7 @@ public Q_SLOTS:
     void setInstallChoice( InstallChoice );
     void setSwapChoice( int );  ///< Translates a button ID or so to SwapChoice
     void setSwapChoice( SwapChoice );
+    void setEraseFsTypeChoice( const QString& );
 
 Q_SIGNALS:
     void installChoiceChanged( InstallChoice );
@@ -109,6 +117,8 @@ Q_SIGNALS:
 
 private:
     SwapChoiceSet m_swapChoices;
+    EraseFsTypesSet m_eraseFsTypes;
+    QString m_eraseFsTypeChoice;
     SwapChoice m_initialSwapChoice = NoSwap;
     SwapChoice m_swapChoice = NoSwap;
     InstallChoice m_initialInstallChoice = NoChoice;

--- a/src/modules/partition/core/PartitionActions.cpp
+++ b/src/modules/partition/core/PartitionActions.cpp
@@ -109,6 +109,10 @@ doAutopartition( PartitionCoreModule* core, Device* dev, Choices::AutoPartitionO
         partType = isEfi ? PartitionTable::gpt : PartitionTable::msdos;
     }
 
+    FileSystem::Type type;
+    PartUtils::findFS(o.defaultFsType, &type);
+    core->initLayout( type == FileSystem::Unknown ? FileSystem::Ext4 : type);
+
     core->createPartitionTable( dev, partType );
 
     if ( isEfi )

--- a/src/modules/partition/core/PartitionCoreModule.cpp
+++ b/src/modules/partition/core/PartitionCoreModule.cpp
@@ -381,6 +381,7 @@ PartitionCoreModule::createPartitionTable( Device* device, PartitionTable::Table
 
         OperationHelper helper( partitionModelForDevice( device ), this );
         deviceInfo->makeJob< CreatePartitionTableJob >( type );
+
     }
 }
 

--- a/src/modules/partition/gui/ChoicePage.cpp
+++ b/src/modules/partition/gui/ChoicePage.cpp
@@ -246,6 +246,14 @@ ChoicePage::setupChoices()
         m_eraseButton->addOptionsComboBox( m_eraseSwapChoiceComboBox );
     }
 
+    if ( m_config->eraseFsTypes().count() > 1)
+    {
+        m_eraseFsTypesChoiceComboBox = new QComboBox;
+        m_eraseFsTypesChoiceComboBox->addItems(m_config->eraseFsTypes());
+        connect(m_eraseFsTypesChoiceComboBox, &QComboBox::currentTextChanged, [this](const auto& currentString){m_config->setEraseFsTypeChoice(currentString); onActionChanged();});
+        m_eraseButton->addOptionsComboBox( m_eraseFsTypesChoiceComboBox );
+    }
+
     m_itemsLayout->addWidget( m_alongsideButton );
     m_itemsLayout->addWidget( m_replaceButton );
     m_itemsLayout->addWidget( m_eraseButton );
@@ -442,9 +450,8 @@ ChoicePage::applyActionChoice( InstallChoice choice )
     case InstallChoice::Erase:
     {
         auto gs = Calamares::JobQueue::instance()->globalStorage();
-
         PartitionActions::Choices::AutoPartitionOptions options { gs->value( "defaultPartitionTableType" ).toString(),
-                                                                  gs->value( "defaultFileSystemType" ).toString(),
+                                                                  m_config->eraseFsType(),
                                                                   m_encryptWidget->passphrase(),
                                                                   gs->value( "efiSystemPartition" ).toString(),
                                                                   CalamaresUtils::GiBtoBytes(

--- a/src/modules/partition/gui/ChoicePage.h
+++ b/src/modules/partition/gui/ChoicePage.h
@@ -139,6 +139,8 @@ private:
     Calamares::PrettyRadioButton* m_replaceButton;
     Calamares::PrettyRadioButton* m_somethingElseButton;
     QComboBox* m_eraseSwapChoiceComboBox;  // UI, see also m_eraseSwapChoice
+    QComboBox* m_eraseFsTypesChoiceComboBox;  // UI, see also m_eraseSwapChoice
+
 
     DeviceInfoWidget* m_deviceInfoWidget;
 

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -137,7 +137,7 @@ initialSwapChoice: none
 # If nothing is specified, Calamares defaults to "ext4".
 #
 # Names are case-sensitive and defined by KPMCore.
-defaultFileSystemType:  "ext4"
+availableFileSystemTypes:  ["ext4", "btrfs", "f2fs"]
 
 # Show/hide LUKS related functionality in automated partitioning modes.
 # Disable this if you choose not to deploy early unlocking support in GRUB2


### PR DESCRIPTION
Allows to choose filesystem when _erase disk_ is chosen (and potentially other autopartition options) and configure available filesystems using `partition.conf`.
![изображение](https://user-images.githubusercontent.com/7955026/113177597-c2efab00-925e-11eb-82c0-6677a59f99c8.png)
![изображение](https://user-images.githubusercontent.com/7955026/113177610-c6833200-925e-11eb-8e02-ae5951dfcb65.png)
