### PR TITLE
copy resolvconf as link

### DIFF
--- a/src/modules/networkcfg/main.py
+++ b/src/modules/networkcfg/main.py
@@ -59,7 +59,7 @@ def run():
                 continue
 
             try:
-                shutil.copy(source_network, target_network)
+                shutil.copy(source_network, target_network, follow_symlinks=False)
             except FileNotFoundError:
                 libcalamares.utils.debug(
                     "Can't copy network configuration files in "
@@ -80,7 +80,7 @@ def run():
                 )
 
         try:
-            shutil.copy(source_resolv, target_resolv)
+            shutil.copy(source_resolv, target_resolv, follow_symlinks=False)
         except Exception as err:
             libcalamares.utils.debug(
                 "Can't copy resolv.conf from {}: {}".format(source_resolv, err)


### PR DESCRIPTION
Hi, maybe this patch will resolve this issue. https://github.com/calamares/calamares/issues/1630 
Basically copy /etc/resolv.conf as it is at the moment that you install to chroot.