### PR TITLE
usersq: use system colorscheme instead of hardcoded colors

### DIFF
--- a/src/modules/usersq/usersq.qml
+++ b/src/modules/usersq/usersq.qml
@@ -23,9 +23,6 @@ Kirigami.ScrollablePage {
     width: parent.width
     height: parent.height
 
-    Kirigami.Theme.backgroundColor: "#EFF0F1"
-    Kirigami.Theme.textColor: "#1F1F1F"
-
     header: Kirigami.Heading {
         Layout.fillWidth: true
         height: 50
@@ -57,8 +54,8 @@ Kirigami.ScrollablePage {
                 text: config.fullName
                 onTextChanged: config.setFullName(text)
 
-                palette.base: _userNameField.text.length ? "#f0fff0" : "#FBFBFB"
-                palette.highlight : _userNameField.text.length ? "#dcffdc" : "#FBFBFB"
+                palette.base: _userNameField.text.length ? Kirigami.Theme.backgroundColor : Kirigami.Theme.backgroundColor
+                palette.highlight : _userNameField.text.length ? Kirigami.Theme.positiveBackgroundColor : Kirigami.Theme.backgroundColor
             }
         }
 
@@ -89,8 +86,8 @@ Kirigami.ScrollablePage {
                 palette.base: _userLoginField.text.length
                     ? ( acceptableInput
                     ? ( _userLoginField.text === "root"
-                    ? "#ffdae0" : "#f0fff0" ) : "#ffdae0" ) : "#FBFBFB"
-                palette.highlight : _userLoginField.text.length ? "#dcffdc" : "#FBFBFB"
+                    ? Kirigami.Theme.negativeBackgroundColor : Kirigami.Theme.backgroundColor ) : Kirigami.Theme.negativeBackgroundColor ) : Kirigami.Theme.backgroundColor
+                palette.highlight : _userLoginField.text.length ? Kirigami.Theme.positiveBackgroundColor : Kirigami.Theme.backgroundColor
             }
 
             Label {
@@ -98,7 +95,6 @@ Kirigami.ScrollablePage {
                 text: qsTr("If more than one person will use this computer, you can create multiple accounts after installation.")
                 font.weight: Font.Thin
                 font.pointSize: 8
-                color: "#6D6D6D"
             }
         }
 
@@ -133,7 +129,7 @@ Kirigami.ScrollablePage {
                 placeholderText: qsTr("Computer Name")
                 text: config.hostName
                 validator: RegularExpressionValidator { regularExpression: /[a-zA-Z0-9][-a-zA-Z0-9_]+/ }
-
+                color: Kirigami.Theme.textColor
                 onTextChanged: acceptableInput
                     ? ( _hostName.text === "localhost"
                     ? forbiddenHost.visible=true
@@ -143,10 +139,10 @@ Kirigami.ScrollablePage {
 
                 palette.base: _hostName.text.length
                     ? ( acceptableInput
-                    ? ( _hostName.text === "localhost" ? "#ffdae0" : "#f0fff0" )
-                    : "#ffdae0")
-                    : "#FBFBFB"
-                palette.highlight : _hostName.text.length ? "#dcffdc" : "#FBFBFB"
+                    ? ( _hostName.text === "localhost" ? Kirigami.Theme.negativeBackgroundColor : Kirigami.Theme.backgroundColor )
+                    : Kirigami.Theme.negativeBackgroundColor)
+                    : Kirigami.Theme.backgroundColor
+                palette.highlight : _hostName.text.length ? Kirigami.Theme.positiveBackgroundColor : Kirigami.Theme.backgroundColor
             }
 
             Label {
@@ -154,7 +150,6 @@ Kirigami.ScrollablePage {
                 text: qsTr("This name will be used if you make the computer visible to others on a network.")
                 font.weight: Font.Thin
                 font.pointSize: 8
-                color: "#6D6D6D"
             }
         }
 
@@ -194,8 +189,8 @@ Kirigami.ScrollablePage {
                     text: config.userPassword
                     onTextChanged: config.setUserPassword(text)
 
-                    palette.base: _passwordField.text.length ? "#f0fff0" : "#FBFBFB"
-                    palette.highlight : _passwordField.text.length ? "#dcffdc" : "#FBFBFB"
+                    palette.base: _passwordField.text.length ? Kirigami.Theme.backgroundColor : Kirigami.Theme.neutralBackgroundColor
+                    palette.highlight : _passwordField.text.length ? Kirigami.Theme.positiveBackgroundColor : Kirigami.Theme.backgroundColor
 
                     echoMode: TextInput.Password
                     passwordMaskDelay: 300
@@ -217,9 +212,9 @@ Kirigami.ScrollablePage {
 
                     palette.base: _verificationPasswordField.text.length
                         ? ( _passwordField.text === _verificationPasswordField.text
-                        ? "#f0fff0" : "#ffdae0" )
-                        : "#FBFBFB"
-                    palette.highlight : _verificationPasswordField.text.length ? "#dcffdc" : "#FBFBFB"
+                        ? Kirigami.Theme.backgroundColor : Kirigami.Theme.negativeBackgroundColor )
+                        : Kirigami.Theme.backgroundColor
+                    palette.highlight : _verificationPasswordField.text.length ? Kirigami.Theme.positiveBackgroundColor : Kirigami.Theme.backgroundColor
 
                     echoMode: TextInput.Password
                     passwordMaskDelay: 300
@@ -233,7 +228,6 @@ Kirigami.ScrollablePage {
                 font.weight: Font.Thin
                 font.pointSize: 8
                 wrapMode: Text.WordWrap
-                color: "#6D6D6D"
             }
         }
 
@@ -272,7 +266,6 @@ Kirigami.ScrollablePage {
             text: qsTr("Use the same password for the administrator account.")
             font.weight: Font.Thin
             font.pointSize: 8
-            color: "#6D6D6D"
         }
 
         Column {
@@ -297,8 +290,8 @@ Kirigami.ScrollablePage {
 
                     onTextChanged: config.setRootPassword(text)
 
-                    palette.base: _rootPasswordField.text.length ? "#f0fff0" : "#FBFBFB"
-                    palette.highlight : _rootPasswordField.text.length ? "#dcffdc" : "#FBFBFB"
+                    palette.base: _rootPasswordField.text.length ? Kirigami.Theme.backgroundColor : Kirigami.Theme.neutralBackgroundColor
+                    palette.highlight : _rootPasswordField.text.length ? Kirigami.Theme.positiveBackgroundColor : Kirigami.Theme.backgroundColor
 
                     echoMode: TextInput.Password
                     passwordMaskDelay: 300
@@ -320,8 +313,8 @@ Kirigami.ScrollablePage {
 
                     palette.base: _verificationRootPasswordField.text.length
                         ? ( _rootPasswordField.text === _verificationRootPasswordField.text
-                        ? "#f0fff0" : "#ffdae0") : "#FBFBFB"
-                    palette.highlight : _verificationRootPasswordField.text.length ? "#dcffdc" : "#FBFBFB"
+                        ? Kirigami.Theme.backgroundColor : Kirigami.Theme.negativeBackgroundColor) : Kirigami.Theme.backgroundColor
+                    palette.highlight : _verificationRootPasswordField.text.length ? Kirigami.Theme.positiveBackgroundColor : Kirigami.Theme.backgroundColor
 
                     echoMode: TextInput.Password
                     passwordMaskDelay: 300
@@ -383,7 +376,6 @@ Kirigami.ScrollablePage {
             text: qsTr("When this box is checked, password-strength checking is done and you will not be able to use a weak password.")
             font.weight: Font.Thin
             font.pointSize: 8
-            color: "#6D6D6D"
         }
     }
 }


### PR DESCRIPTION
With these changes the built-in style for usersq module now picks the system color scheme, resulting in better visuals when using different color schemes, like dark ones.