### PR TITLE
[partition] Disable delete button for extended partition

### DIFF
--- a/src/modules/partition/gui/PartitionPage.cpp
+++ b/src/modules/partition/gui/PartitionPage.cpp
@@ -139,6 +139,11 @@ PartitionPage::updateButtons()
         bool isFree = CalamaresUtils::Partition::isPartitionFreeSpace( partition );
         bool isExtended = partition->roles().has( PartitionRole::Extended );
 
+        bool hasChildren = isExtended
+            && ( partition->children().length() > 1
+                 || ( partition->children().length() == 1
+                      && !CalamaresUtils::Partition::isPartitionFreeSpace( partition->children().at( 0 ) ) ) );
+
         bool isInVG = m_core->isInVG( partition );
 
         create = isFree;
@@ -151,7 +156,7 @@ PartitionPage::updateButtons()
         // order.
         // TODO: See if LVM PVs can be edited in Calamares
         edit = !isFree && !isExtended;
-        del = !isFree && !isInVG;
+        del = !isFree && !isInVG && !hasChildren;
     }
 
     if ( m_ui->deviceComboBox->currentIndex() >= 0 )


### PR DESCRIPTION
Extended partition can't be removed when contains children and Calamares allows this, what causes installer crash. This PR
adds missing check.

![2021-08-12_02-15](https://user-images.githubusercontent.com/7955026/129110832-b4a1e144-be31-45e4-a302-f582ef533157.png)
![2021-08-12_02-15_1](https://user-images.githubusercontent.com/7955026/129110837-fe581edf-6fe2-4482-afdc-d2e0a72d9e1d.png)
