### PR TITLE
Add support for timers to systemd-services

### DIFF
--- a/src/modules/services-systemd/main.py
+++ b/src/modules/services-systemd/main.py
@@ -63,6 +63,8 @@ def systemctl(targets, command, suffix):
                     description = _("Cannot enable systemd service <code>{name!s}</code>.")
                 elif command == "enable" and suffix == ".target":
                     description = _("Cannot enable systemd target <code>{name!s}</code>.")
+                elif command == "enable" and suffix == ".timer":
+                    description = _("Cannot enable systemd timer <code>{name!s}</code>.")
                 elif command == "disable" and suffix == ".service":
                     description = _("Cannot enable systemd service <code>{name!s}</code>.")
                 elif command == "disable" and suffix == ".target":
@@ -94,6 +96,10 @@ def run():
         return r
 
     r = systemctl(cfg.get("targets", []), "enable", ".target")
+    if r is not None:
+        return r
+
+    r = systemctl(cfg.get("timers", []), "enable", ".timer")
     if r is not None:
         return r
 

--- a/src/modules/services-systemd/services-systemd.conf
+++ b/src/modules/services-systemd/services-systemd.conf
@@ -3,17 +3,17 @@
 #
 # Systemd services manipulation.
 #
-# This module can enable services and targets for systemd
-# (if packaging doesn't already do that). It can calso
-# disable services (but not targets).
+# This module can enable services, timers and targets for systemd
+# (if packaging doesn't already do that). It can also
+# disable services and targets as well as mask units.
 #
-# First, services are enabled; then targets; then services
-# are disabled -- this order of operations is fixed.
+# The order of operations is fixed.  Enable services, enable targets,
+# enable timers, disable services, disable targets and finally apply masks.
 ---
 
-# There are three configuration keys for this module:
-# *services*, *targets* and *disable*. The value of each
-# key is a list of entries. Each entry has two keys:
+# There are several configuration keys for this module:
+# *services*, *targets*, *timers*, *disable*, *disable-targets* and *mask*.
+# The value of each key is a list of entries. Each entry has two keys:
 #   - *name* is the (string) name of the service or target that is being
 #     changed. Use quotes. Don't include ".target" or ".service"
 #     in the name.

--- a/src/modules/services-systemd/services-systemd.conf
+++ b/src/modules/services-systemd/services-systemd.conf
@@ -15,12 +15,12 @@
 # *services*, *targets*, *timers*, *disable*, *disable-targets* and *mask*.
 # The value of each key is a list of entries. Each entry has two keys:
 #   - *name* is the (string) name of the service or target that is being
-#     changed. Use quotes. Don't include ".target" or ".service"
-#     in the name.
+#     changed. Use quotes. Don't include unit suffix in the name. For
+#     example, it should be "NetworkManager", not "NetworkManager.service"
 #   - *mandatory* is a boolean option, which states whether the change
 #     must be done successfully. If systemd reports an error while changing
 #     a mandatory entry, the installation will fail. When mandatory is false,
-#     errors for that entry (service or target) are ignored. If mandatory
+#     errors for that systemd unit are ignored. If mandatory
 #     is not specified, the default is false.
 #
 # An entry may also be given as a single string, which is then
@@ -45,6 +45,11 @@
 # targets:
 #   - name: "graphical"
 #     mandatory: true
+#
+# # Enables <name>.timer
+# timers:
+#   - name: "fstrim"
+#     mandatory: false
 #
 # # Disables <name>.service
 # disable:

--- a/src/modules/services-systemd/services-systemd.conf
+++ b/src/modules/services-systemd/services-systemd.conf
@@ -68,6 +68,7 @@
 # By default, no changes are made.
 services: []
 targets: []
+timers: []
 disable: []
 disable-targets: []
 mask: []


### PR DESCRIPTION
This adds support for timers to the systemd-services module.

I also made some updates to the documentation in services-systemd.conf since it there appeared to be several options which were not documented.