### PR TITLE
[partition] offer /boot also when other EFI partition was specified

### DIFF
--- a/src/modules/partition/gui/PartitionDialogHelpers.cpp
+++ b/src/modules/partition/gui/PartitionDialogHelpers.cpp
@@ -2,7 +2,7 @@
  *
  *   SPDX-FileCopyrightText: 2014 Aurélien Gâteau <agateau@kde.org>
  *   SPDX-FileCopyrightText: 2016 Teo Mrnjavac <teo@kde.org>
- *   SPDX-FileCopyrightText: 2018-2019 Adriaan de Groot <groot@kde.org>
+ *   SPDX-FileCopyrightText: 2018-2021 Adriaan de Groot <groot@kde.org>
  *   SPDX-License-Identifier: GPL-3.0-or-later
  *
  *   Calamares is Free Software: see the License-Identifier above.
@@ -23,14 +23,10 @@
 QStringList
 standardMountPoints()
 {
-    QStringList mountPoints { "/", "/home", "/opt", "/srv", "/usr", "/var" };
+    QStringList mountPoints { "/", "/boot", "/home", "/opt", "/srv", "/usr", "/var" };
     if ( PartUtils::isEfiSystem() )
     {
         mountPoints << Calamares::JobQueue::instance()->globalStorage()->value( "efiSystemPartition" ).toString();
-    }
-    else
-    {
-        mountPoints << QStringLiteral( "/boot" );
     }
     mountPoints.removeDuplicates();
     mountPoints.sort();


### PR DESCRIPTION
- it still makes sense to offer /boot in EFI
- example: /boot ext4, /boot/efi vfat
- this partly reverts 60f8a7c5fb276cac4b9c802f5d3fcedb54e56668
- see also: https://gitlab.manjaro.org/applications/calamares/-/issues/53