### PR TITLE
Remove space_cache from btrfs mount options

### DIFF
--- a/src/modules/fstab/fstab.conf
+++ b/src/modules/fstab/fstab.conf
@@ -12,11 +12,9 @@
 # is listed here, use those options, otherwise use the *default*
 # options from this mapping.
 #
-# With kernels 5.15 and newer be cautious of adding the option
-# space_cache to the btrfs mount options.  If the root volume is initially
-# mounted with one version of space_cache and the mount option specifies
-# a different version or implies v1 when v2 is in use, it may fail to
-# remount properly.
+# With kernels 5.15 and newer be cautious of adding the option space_cache
+# to the btrfs mount options.  The default in 5.15 changed to space_cache=v2.
+# If space_cache or space_cache=v1 are specified, it may fail to remount.
 mountOptions:
     default: defaults,noatime
     btrfs: defaults,noatime,autodefrag,compress=zstd

--- a/src/modules/fstab/fstab.conf
+++ b/src/modules/fstab/fstab.conf
@@ -11,6 +11,12 @@
 # Mount options to use for all filesystems. If a specific filesystem
 # is listed here, use those options, otherwise use the *default*
 # options from this mapping.
+#
+# With kernels 5.15 and newer be cautious of adding the option
+# space_cache to the btrfs mount options.  If the root volume is initially
+# mounted with one version of space_cache and the mount option specifies
+# a different version or implies v1 when v2 is in use, it may fail to
+# remount properly.
 mountOptions:
     default: defaults,noatime
     btrfs: defaults,noatime,autodefrag,compress=zstd

--- a/src/modules/fstab/fstab.conf
+++ b/src/modules/fstab/fstab.conf
@@ -13,7 +13,7 @@
 # options from this mapping.
 mountOptions:
     default: defaults,noatime
-    btrfs: defaults,noatime,space_cache,autodefrag,compress=zstd
+    btrfs: defaults,noatime,autodefrag,compress=zstd
 
 # Mount options to use for the EFI System Partition. If not defined, the
 # *mountOptions* for *vfat* are used, or if that is not set either,


### PR DESCRIPTION
Since the most release when installing with btrfs the `systemd-remount-fs` service fails to run properly.

Upon investigation it appears the cause of this issue is that the root filesystem is mounted initially with `space_cache=v2` and when it tries to remount it with `space_cache`, it fails.

<s>Although I was unable to find any specific commit which would cause this behaviour, removing `space_cache` from the mount options avoids this conflict.  Additionally, since `space_cache=v1` has been the default since 4.5, I don't think removing it would be impactful.</s>

Based on the below, it seems the problem is caused by the default in kernel 5.15 being changed to space_cache=v2.  