### PR TITLE
Ensure root subvolume is set correctly for systemd-boot

### DIFF
--- a/src/modules/bootloader/main.py
+++ b/src/modules/bootloader/main.py
@@ -178,10 +178,13 @@ def create_systemd_boot_conf(install_path, efi_dir, uuid, entry, entry_name, ker
                                   + partition["luksMapperName"]]
 
     for partition in partitions:
-        # systemd-boot with a BTRFS root filesystem needs to be told
-        # about the root subvolume.
+        # systemd-boot with a BTRFS root filesystem needs to be told abouut the root subvolume.
+        # If a btrfs root subvolume wasn't set, it means the root is directly on the partition
+        # and this option isn't needed
         if is_btrfs_root(partition):
-            kernel_params.append("rootflags=subvol=@")
+            btrfs_root_subvolume = libcalamares.globalstorage.value("btrfsRootSubvolume")
+            if btrfs_root_subvolume:
+                kernel_params.append("rootflags=subvol=" + btrfs_root_subvolume)
 
         # zfs needs to be told the location of the root dataset
         if is_zfs_root(partition):


### PR DESCRIPTION
This fixes issue https://github.com/calamares/calamares/issues/1821

The root subvolume is currently being hard-coded to `@` which is problematic for a couple of reasons:
* The actual root subvolume is configurable in mount.conf
* Sometimes, distros choose to not have a separate subvolume for root

This should address both those issues.

NOTE: I must have accidentally triggered my editor to fix format issues in the mount module.  I took a look at the changes and they all look sensible so I left them.  If you would prefer them removed from this PR just let me know.