### PR TITLE
Remove setState call to resolve compat issue with older kpmcore

### DIFF
--- a/src/modules/partition/jobs/CreatePartitionJob.cpp
+++ b/src/modules/partition/jobs/CreatePartitionJob.cpp
@@ -77,7 +77,6 @@ createZfs( Partition* partition, Device* device )
     }
 
     partition->setPartitionPath( deviceNode );
-    partition->setState( Partition::State::None );
 
     // If it is a gpt device, set the partition UUID
     if ( device->partitionTable()->type() == PartitionTable::gpt && partition->uuid().isEmpty() )


### PR DESCRIPTION
It seems that `Partition::State::None` isn't available in older versions of kpmcore.

However, after performing some testing, this call is non-critical to the function of the application.

Removing it is probably the most sensible way to resolve this issue.