### PR TITLE
Additional pacman options in the packages module

### DIFF
--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -442,9 +442,8 @@ class PMPacman(PackageManager):
 
         command += pkgs
 
-        self.run_pacman(command, True)
-
         self.reset_progress()
+        self.run_pacman(command, True)
 
     def remove(self, pkgs):
         self.reset_progress()
@@ -458,7 +457,7 @@ class PMPacman(PackageManager):
         if self.pacman_disable_timeout is True:
             command.append("--disable-download-timeout")
 
-        self.run_pacman(command, True)
+        self.run_pacman(command)
 
 
 class PMPamac(PackageManager):

--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -406,13 +406,17 @@ class PMPacman(PackageManager):
         # These are globals
         self.progress_fraction = (completed_packages * 1.0 / total_packages)
 
-    def run_pacman(self, command, callback=None):
+    def run_pacman(self, command, callback=False):
         # Call pacman in a loop until it is successful or the number of retries is exceeded
         pacman_count = 0
         while pacman_count <= self.pacman_num_retries:
             pacman_count += 1
             try:
-                libcalamares.utils.target_env_process_output(command, callback)
+                if callback is True:
+                    libcalamares.utils.target_env_process_output(command, self.line_cb)
+                else:
+                    libcalamares.utils.target_env_process_output(command)
+
                 return
             except subprocess.CalledProcessError:
                 if pacman_count <= self.pacman_num_retries:
@@ -438,13 +442,13 @@ class PMPacman(PackageManager):
 
         command += pkgs
 
-        self.run_pacman(command, self.line_cb)
+        self.run_pacman(command, True)
 
         self.reset_progress()
 
     def remove(self, pkgs):
         self.reset_progress()
-        self.run_pacman(["pacman", "-Rs", "--noconfirm"] + pkgs, self.line_cb)
+        self.run_pacman(["pacman", "-Rs", "--noconfirm"] + pkgs, True)
 
     def update_db(self):
         self.run_pacman(["pacman", "-Sy"])
@@ -454,7 +458,7 @@ class PMPacman(PackageManager):
         if self.pacman_disable_timeout is True:
             command.append("--disable-download-timeout")
 
-        self.run_pacman(command, self.line_cb)
+        self.run_pacman(command, True)
 
 
 class PMPamac(PackageManager):

--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -407,7 +407,13 @@ class PMPacman(PackageManager):
         self.progress_fraction = (completed_packages * 1.0 / total_packages)
 
     def run_pacman(self, command, callback=False):
-        # Call pacman in a loop until it is successful or the number of retries is exceeded
+        """
+        Call pacman in a loop until it is successful or the number of retries is exceeded
+        :param command: The pacman command to run
+        :param callback: An optional boolean that indicates if this pacman run should use the callback
+        :return:
+        """
+
         pacman_count = 0
         while pacman_count <= self.pacman_num_retries:
             pacman_count += 1

--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -406,13 +406,13 @@ class PMPacman(PackageManager):
         # These are globals
         self.progress_fraction = (completed_packages * 1.0 / total_packages)
 
-    def run_pacman(self, command):
+    def run_pacman(self, command, callback=None):
         # Call pacman in a loop until it is successful or the number of retries is exceeded
         pacman_count = 0
         while pacman_count <= self.pacman_num_retries:
             pacman_count += 1
             try:
-                libcalamares.utils.target_env_process_output(command, self.line_cb)
+                libcalamares.utils.target_env_process_output(command, callback)
                 return
             except subprocess.CalledProcessError:
                 if pacman_count <= self.pacman_num_retries:
@@ -438,13 +438,13 @@ class PMPacman(PackageManager):
 
         command += pkgs
 
-        self.run_pacman(command)
+        self.run_pacman(command, self.line_cb)
 
         self.reset_progress()
 
     def remove(self, pkgs):
         self.reset_progress()
-        self.run_pacman(["pacman", "-Rs", "--noconfirm"] + pkgs)
+        self.run_pacman(["pacman", "-Rs", "--noconfirm"] + pkgs, self.line_cb)
 
     def update_db(self):
         self.run_pacman(["pacman", "-Sy"])
@@ -454,7 +454,7 @@ class PMPacman(PackageManager):
         if self.pacman_disable_timeout is True:
             command.append("--disable-download-timeout")
 
-        self.run_pacman(command)
+        self.run_pacman(command, self.line_cb)
 
 
 class PMPamac(PackageManager):

--- a/src/modules/packages/packages.conf
+++ b/src/modules/packages/packages.conf
@@ -62,6 +62,22 @@ skip_if_no_internet: false
 update_db: true
 update_system: false
 
+# pacman specific options
+#
+# pacman_num_retries should be a positive integer which sepcifies the
+# number of times the call to pacman will be retried in the event of a
+# failure.  If it is missing, it will be set to 0
+#
+# pacman_disable_download_timeout is a boolean that, when true, includes
+# the flag --disable-download-timeout on calls to pacman.  When missing,
+# false is assumed
+#
+# pacman_needed_only is a boolean that includes the pacman argument --needed
+# when set to true.  If missing, false is assumed
+pacman_num_retries: 0
+pacman_disable_download_timeout: false
+pacman_needed_only: false
+
 #
 # List of maps with package operations such as install or remove.
 # Distro developers can provide a list of packages to remove

--- a/src/modules/packages/packages.schema.yaml
+++ b/src/modules/packages/packages.schema.yaml
@@ -26,6 +26,10 @@ properties:
     update_system: { type: boolean, default: false }
     skip_if_no_internet: { type: boolean, default: false }
 
+    pacman_num_retries: { type: integer, default: 0 }
+    pacman_disable_download_timeout: { type: boolean, default: false }
+    pacman_needed_only: { type: boolean, default: false }
+
     operations:
         type: array
         items:


### PR DESCRIPTION
This PR adds 3 options for pacman to the packages module
* Allows you to set a number of retries that the calls to pacman will attempt if it fails
* Supports optionally sending the `--disable-download-timeout` flag to pacman
* Adds config to optionally add the `--needed` flag to pacman calls

By default, all values are set at their previous defaults.