### PR TITLE
[fstab] Use different options for the btrfs swap subvolume

### DIFF
--- a/src/modules/fstab/fstab.conf
+++ b/src/modules/fstab/fstab.conf
@@ -15,9 +15,13 @@
 # With kernels 5.15 and newer be cautious of adding the option space_cache
 # to the btrfs mount options.  The default in 5.15 changed to space_cache=v2.
 # If space_cache or space_cache=v1 are specified, it may fail to remount.
+#
+# btrfs_swap options are used when a swapfile is chosen with a btrfs root
+# the options are applied to the subvolume which holds the swap partition
 mountOptions:
     default: defaults,noatime
     btrfs: defaults,noatime,autodefrag,compress=zstd
+    btrfs_swap: defaults,noatime
 
 # Mount options to use for the EFI System Partition. If not defined, the
 # *mountOptions* for *vfat* are used, or if that is not set either,

--- a/src/modules/fstab/fstab.schema.yaml
+++ b/src/modules/fstab/fstab.schema.yaml
@@ -22,6 +22,7 @@ properties:
             xfs: { type: string }
             swap: { type: string }
             btrfs: { type: string }
+            btrfs_swap: { type: string }
     efiMountOptions: { type: string }
     crypttabOptions: { type: string }
 required: [ mountOptions ]

--- a/src/modules/fstab/main.py
+++ b/src/modules/fstab/main.py
@@ -236,7 +236,10 @@ class FstabGenerator(object):
             libcalamares.utils.debug("Ignoring foreign swap {!s} {!s}".format(disk_name, partition.get("uuid", None)))
             return None
 
-        options = self.get_mount_options(filesystem, mount_point)
+        if filesystem == "btrfs" and partition["subvol"] == "/@swap":
+            options = self.get_mount_options("btrfs_swap", mount_point)
+        else:
+            options = self.get_mount_options(filesystem, mount_point)
 
         if is_ssd:
             extra = self.ssd_extra_mount_options.get(filesystem)

--- a/src/modules/fstab/main.py
+++ b/src/modules/fstab/main.py
@@ -236,6 +236,7 @@ class FstabGenerator(object):
             libcalamares.utils.debug("Ignoring foreign swap {!s} {!s}".format(disk_name, partition.get("uuid", None)))
             return None
 
+        # If this is btrfs subvol a dedicated to a swapfile, use different options than a normal btrfs subvol
         if filesystem == "btrfs" and partition["subvol"] == "/@swap":
             options = self.get_mount_options("btrfs_swap", mount_point)
         else:


### PR DESCRIPTION
This PR adds a separate set of mount options for the btrfs subvolume that holds the swapfile when Calamares is installed to a btrfs root and a swapfile is selected.