### PR TITLE
[mount] Ensure path is available when creating nested btrfs subvolumes

### DIFF
--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -193,6 +193,7 @@ def mount_partition(root_mount_point, partition, partitions):
         for s in btrfs_subvolumes:
             if not s["subvolume"]:
                 continue
+            os.makedirs(root_mount_point + os.path.dirname(s["subvolume"]), exist_ok=True)
             subprocess.check_call(["btrfs", "subvolume", "create",
                                    root_mount_point + s["subvolume"]])
             if s["mountPoint"] == "/":


### PR DESCRIPTION
This resolves https://github.com/calamares/calamares/issues/1838