### PR TITLE
Rework of error dialog

### DIFF
--- a/src/libcalamaresui/CMakeLists.txt
+++ b/src/libcalamaresui/CMakeLists.txt
@@ -20,6 +20,7 @@ set( calamaresui_SOURCES
     utils/CalamaresUtilsGui.cpp
     utils/ImageRegistry.cpp
     utils/Paste.cpp
+    utils/ErrorDialog/ErrorDialog.cpp
 
     viewpages/BlankViewStep.cpp
     viewpages/ExecutionViewStep.cpp
@@ -75,6 +76,8 @@ calamares_add_library( calamaresui
         Qt5::Svg
     RESOURCES libcalamaresui.qrc
     EXPORT Calamares
+    UI 
+        utils/ErrorDialog/ErrorDialog.ui    
     VERSION ${CALAMARES_VERSION_SHORT}
 )
 target_link_libraries( calamaresui PRIVATE yamlcpp::yamlcpp )

--- a/src/libcalamaresui/ViewManager.cpp
+++ b/src/libcalamaresui/ViewManager.cpp
@@ -17,6 +17,7 @@
 #include "JobQueue.h"
 #include "Settings.h"
 
+#include "utils/ErrorDialog/ErrorDialog.h"
 #include "utils/Logger.h"
 #include "utils/Paste.h"
 #include "utils/Retranslator.h"
@@ -25,15 +26,14 @@
 #include "viewpages/ExecutionViewStep.h"
 #include "viewpages/ViewStep.h"
 #include "widgets/TranslationFix.h"
-#include "utils/ErrorDialog/ErrorDialog.h"
 
 #include <QApplication>
 #include <QBoxLayout>
 #include <QClipboard>
+#include <QDialogButtonBox>
 #include <QFile>
 #include <QMessageBox>
 #include <QMetaObject>
-#include <QDialogButtonBox>
 
 #define UPDATE_BUTTON_PROPERTY( name, value ) \
     do \
@@ -161,24 +161,27 @@ ViewManager::onInstallationFailed( const QString& message, const QString& detail
     cDebug() << Logger::SubEntry << "- details:" << Logger::NoQuote << details;
 
     QString heading
-        = Calamares::Settings::instance()->isSetupMode() ? tr( "Setup Failed" ) : tr( "Installation Failed" );   
+        = Calamares::Settings::instance()->isSetupMode() ? tr( "Setup Failed" ) : tr( "Installation Failed" );
 
     ErrorDialog* errorDialog = new ErrorDialog();
     errorDialog->setWindowTitle( tr( "Error" ) );
     errorDialog->setHeading( "<strong>" + heading + "</strong>" );
     errorDialog->setInformativeText( message );
-    errorDialog->setShouldOfferWebPaste(shouldOfferWebPaste);
-    errorDialog->setDetails(details);
+    errorDialog->setShouldOfferWebPaste( shouldOfferWebPaste );
+    errorDialog->setDetails( details );
     errorDialog->show();
 
     cDebug() << "Calamares will quit when the dialog closes.";
-    connect( errorDialog, &QDialog::finished, [errorDialog]( int result ) {
-        if ( result == QDialog::Accepted && errorDialog->shouldOfferWebPaste() )
-        {
-            CalamaresUtils::Paste::doLogUploadUI( errorDialog );
-        }
-        QApplication::quit();
-    } );
+    connect( errorDialog,
+             &QDialog::finished,
+             [ errorDialog ]( int result )
+             {
+                 if ( result == QDialog::Accepted && errorDialog->shouldOfferWebPaste() )
+                 {
+                     CalamaresUtils::Paste::doLogUploadUI( errorDialog );
+                 }
+                 QApplication::quit();
+             } );
 }
 
 

--- a/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.cpp
+++ b/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.cpp
@@ -1,0 +1,89 @@
+#include "ErrorDialog.h"
+#include "ui_ErrorDialog.h"
+
+#include <QIcon>
+#include <QDialogButtonBox>
+
+namespace Calamares {
+
+
+ErrorDialog::ErrorDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::ErrorDialog)
+{
+    ui->setupUi(this);
+    ui->iconLabel->setPixmap(QIcon::fromTheme("dialog-error").pixmap(64));
+    ui->detailsWidget->hide();
+    ui->offerWebPasteLabel->hide();
+}
+
+ErrorDialog::~ErrorDialog()
+{
+    delete ui;
+}
+
+
+QString ErrorDialog::heading() const
+{
+    return ui->headingLabel->text();
+}
+
+QString ErrorDialog::informativeText() const
+{
+    return ui->informativeTextLabel->text();
+}
+
+QString ErrorDialog::details() const
+{
+    return ui->detailsBrowser->toPlainText();
+}
+
+void ErrorDialog::setHeading(const QString &newHeading)
+{
+    if (ui->headingLabel->text() == newHeading)
+        return;
+    ui->headingLabel->setText(newHeading);
+    emit headingChanged();
+}
+
+void ErrorDialog::setInformativeText(const QString &newInformativeText)
+{
+    if (ui->informativeTextLabel->text() == newInformativeText)
+        return;
+    ui->informativeTextLabel->setText(newInformativeText);
+    emit informativeTextChanged();
+}
+
+void ErrorDialog::setDetails(const QString &newDetails)
+{
+    if (ui->detailsBrowser->toPlainText() == newDetails)
+        return;   
+    ui->detailsBrowser->setPlainText(newDetails);
+    
+    ui->detailsWidget->setVisible(!ui->detailsBrowser->toPlainText().trimmed().isEmpty());
+    
+    emit detailsChanged();
+}
+
+bool ErrorDialog::shouldOfferWebPaste() const
+{
+    return m_shouldOfferWebPaste;
+}
+
+void ErrorDialog::setShouldOfferWebPaste(bool newShouldOfferWebPaste)
+{
+    if (m_shouldOfferWebPaste == newShouldOfferWebPaste)
+        return;
+    m_shouldOfferWebPaste = newShouldOfferWebPaste;
+    
+    ui->offerWebPasteLabel->setVisible(m_shouldOfferWebPaste);
+    
+    ui->buttonBox->setStandardButtons( m_shouldOfferWebPaste
+                                           ? (QDialogButtonBox::Yes | QDialogButtonBox::No)
+                                            : QDialogButtonBox::Close );
+
+    
+    emit shouldOfferWebPasteChanged();
+}
+
+} // namespace Calamares

--- a/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.cpp
+++ b/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.cpp
@@ -1,19 +1,20 @@
 #include "ErrorDialog.h"
 #include "ui_ErrorDialog.h"
 
-#include <QIcon>
-#include <QDialogButtonBox>
 #include "widgets/TranslationFix.h"
+#include <QDialogButtonBox>
+#include <QIcon>
 
-namespace Calamares {
-
-
-ErrorDialog::ErrorDialog(QWidget *parent) :
-    QDialog(parent),
-    ui(new Ui::ErrorDialog)
+namespace Calamares
 {
-    ui->setupUi(this);
-    ui->iconLabel->setPixmap(QIcon::fromTheme("dialog-error").pixmap(64));
+
+
+ErrorDialog::ErrorDialog( QWidget* parent )
+    : QDialog( parent )
+    , ui( new Ui::ErrorDialog )
+{
+    ui->setupUi( this );
+    ui->iconLabel->setPixmap( QIcon::fromTheme( "dialog-error" ).pixmap( 64 ) );
     ui->detailsWidget->hide();
     ui->offerWebPasteLabel->hide();
 }
@@ -24,68 +25,75 @@ ErrorDialog::~ErrorDialog()
 }
 
 
-QString ErrorDialog::heading() const
+QString
+ErrorDialog::heading() const
 {
     return ui->headingLabel->text();
 }
 
-QString ErrorDialog::informativeText() const
+QString
+ErrorDialog::informativeText() const
 {
     return ui->informativeTextLabel->text();
 }
 
-QString ErrorDialog::details() const
+QString
+ErrorDialog::details() const
 {
     return ui->detailsBrowser->toPlainText();
 }
 
-void ErrorDialog::setHeading(const QString &newHeading)
+void
+ErrorDialog::setHeading( const QString& newHeading )
 {
-    if (ui->headingLabel->text() == newHeading)
+    if ( ui->headingLabel->text() == newHeading )
         return;
-    ui->headingLabel->setText(newHeading);
+    ui->headingLabel->setText( newHeading );
     emit headingChanged();
 }
 
-void ErrorDialog::setInformativeText(const QString &newInformativeText)
+void
+ErrorDialog::setInformativeText( const QString& newInformativeText )
 {
-    if (ui->informativeTextLabel->text() == newInformativeText)
+    if ( ui->informativeTextLabel->text() == newInformativeText )
         return;
-    ui->informativeTextLabel->setText(newInformativeText);
+    ui->informativeTextLabel->setText( newInformativeText );
     emit informativeTextChanged();
 }
 
-void ErrorDialog::setDetails(const QString &newDetails)
+void
+ErrorDialog::setDetails( const QString& newDetails )
 {
-    if (ui->detailsBrowser->toPlainText() == newDetails)
-        return;   
-    ui->detailsBrowser->setPlainText(newDetails);
-    
-    ui->detailsWidget->setVisible(!ui->detailsBrowser->toPlainText().trimmed().isEmpty());
-    
+    if ( ui->detailsBrowser->toPlainText() == newDetails )
+        return;
+    ui->detailsBrowser->setPlainText( newDetails );
+
+    ui->detailsWidget->setVisible( !ui->detailsBrowser->toPlainText().trimmed().isEmpty() );
+
     emit detailsChanged();
 }
 
-bool ErrorDialog::shouldOfferWebPaste() const
+bool
+ErrorDialog::shouldOfferWebPaste() const
 {
     return m_shouldOfferWebPaste;
 }
 
-void ErrorDialog::setShouldOfferWebPaste(bool newShouldOfferWebPaste)
+void
+ErrorDialog::setShouldOfferWebPaste( bool newShouldOfferWebPaste )
 {
-    if (m_shouldOfferWebPaste == newShouldOfferWebPaste)
+    if ( m_shouldOfferWebPaste == newShouldOfferWebPaste )
         return;
     m_shouldOfferWebPaste = newShouldOfferWebPaste;
-    
-    ui->offerWebPasteLabel->setVisible(m_shouldOfferWebPaste);
-    
-    ui->buttonBox->setStandardButtons( m_shouldOfferWebPaste
-                                           ? (QDialogButtonBox::Yes | QDialogButtonBox::No)
-                                            : QDialogButtonBox::Close );
-    
-    fixButtonLabels(ui->buttonBox);    
-    
+
+    ui->offerWebPasteLabel->setVisible( m_shouldOfferWebPaste );
+
+    ui->buttonBox->setStandardButtons( m_shouldOfferWebPaste ? ( QDialogButtonBox::Yes | QDialogButtonBox::No )
+                                                             : QDialogButtonBox::Close );
+
+    fixButtonLabels( ui->buttonBox );
+
     emit shouldOfferWebPasteChanged();
 }
 
-} // namespace Calamares
+}  // namespace Calamares

--- a/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.cpp
+++ b/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.cpp
@@ -1,3 +1,12 @@
+/* === This file is part of Calamares - <https://calamares.io> ===
+ *
+ *   SPDX-FileCopyrightText: 2021 Artem Grinev <agrinev@manjaro.org>
+ *   SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ *   Calamares is Free Software: see the License-Identifier above.
+ *
+ */
+
 #include "ErrorDialog.h"
 #include "ui_ErrorDialog.h"
 

--- a/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.cpp
+++ b/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.cpp
@@ -3,6 +3,7 @@
 
 #include <QIcon>
 #include <QDialogButtonBox>
+#include "widgets/TranslationFix.h"
 
 namespace Calamares {
 
@@ -81,7 +82,8 @@ void ErrorDialog::setShouldOfferWebPaste(bool newShouldOfferWebPaste)
     ui->buttonBox->setStandardButtons( m_shouldOfferWebPaste
                                            ? (QDialogButtonBox::Yes | QDialogButtonBox::No)
                                             : QDialogButtonBox::Close );
-
+    
+    fixButtonLabels(ui->buttonBox);    
     
     emit shouldOfferWebPasteChanged();
 }

--- a/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.h
+++ b/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.h
@@ -1,0 +1,57 @@
+#ifndef ERRORDIALOG_H
+#define ERRORDIALOG_H
+
+#include <QDialog>
+
+
+namespace Ui {
+class ErrorDialog;
+}
+class QDialogButtonBox;
+namespace Calamares
+{
+class ErrorDialog : public QDialog
+{
+    Q_OBJECT
+    
+    Q_PROPERTY(QString heading READ heading WRITE setHeading NOTIFY headingChanged)
+    Q_PROPERTY(QString informativeText READ informativeText WRITE setInformativeText NOTIFY informativeTextChanged)
+    Q_PROPERTY(QString details READ details WRITE setDetails NOTIFY detailsChanged)
+    Q_PROPERTY(bool shouldOfferWebPaste READ shouldOfferWebPaste WRITE setShouldOfferWebPaste NOTIFY shouldOfferWebPasteChanged)
+    
+public:
+    explicit ErrorDialog(QWidget *parent = nullptr);
+    ~ErrorDialog();
+    
+    QString heading() const;
+    
+    QString informativeText() const;
+    
+    QString details() const;
+    
+    void setHeading(const QString &newHeading);
+    
+    void setInformativeText(const QString &newInformativeText);
+    
+    void setDetails(const QString &newDetails);
+    
+    bool shouldOfferWebPaste() const;
+    void setShouldOfferWebPaste(bool newShouldOfferWebPaste);
+    
+signals:
+    void headingChanged();
+    
+    void informativeTextChanged();
+    
+    void detailsChanged();
+    
+    void shouldOfferWebPasteChanged();
+    
+private:
+    Ui::ErrorDialog *ui;
+    bool m_shouldOfferWebPaste;
+};
+
+}; // namespace Calamares
+
+#endif // ERRORDIALOG_H

--- a/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.h
+++ b/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.h
@@ -1,3 +1,12 @@
+/* === This file is part of Calamares - <https://calamares.io> ===
+ *
+ *   SPDX-FileCopyrightText: 2021 Artem Grinev <agrinev@manjaro.org>
+ *   SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ *   Calamares is Free Software: see the License-Identifier above.
+ *
+ */
+
 #ifndef ERRORDIALOG_H
 #define ERRORDIALOG_H
 

--- a/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.h
+++ b/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.h
@@ -4,7 +4,8 @@
 #include <QDialog>
 
 
-namespace Ui {
+namespace Ui
+{
 class ErrorDialog;
 }
 class QDialogButtonBox;
@@ -13,45 +14,46 @@ namespace Calamares
 class ErrorDialog : public QDialog
 {
     Q_OBJECT
-    
-    Q_PROPERTY(QString heading READ heading WRITE setHeading NOTIFY headingChanged)
-    Q_PROPERTY(QString informativeText READ informativeText WRITE setInformativeText NOTIFY informativeTextChanged)
-    Q_PROPERTY(QString details READ details WRITE setDetails NOTIFY detailsChanged)
-    Q_PROPERTY(bool shouldOfferWebPaste READ shouldOfferWebPaste WRITE setShouldOfferWebPaste NOTIFY shouldOfferWebPasteChanged)
-    
+
+    Q_PROPERTY( QString heading READ heading WRITE setHeading NOTIFY headingChanged )
+    Q_PROPERTY( QString informativeText READ informativeText WRITE setInformativeText NOTIFY informativeTextChanged )
+    Q_PROPERTY( QString details READ details WRITE setDetails NOTIFY detailsChanged )
+    Q_PROPERTY( bool shouldOfferWebPaste READ shouldOfferWebPaste WRITE setShouldOfferWebPaste NOTIFY
+                    shouldOfferWebPasteChanged )
+
 public:
-    explicit ErrorDialog(QWidget *parent = nullptr);
+    explicit ErrorDialog( QWidget* parent = nullptr );
     ~ErrorDialog();
-    
+
     QString heading() const;
-    
+
     QString informativeText() const;
-    
+
     QString details() const;
-    
-    void setHeading(const QString &newHeading);
-    
-    void setInformativeText(const QString &newInformativeText);
-    
-    void setDetails(const QString &newDetails);
-    
+
+    void setHeading( const QString& newHeading );
+
+    void setInformativeText( const QString& newInformativeText );
+
+    void setDetails( const QString& newDetails );
+
     bool shouldOfferWebPaste() const;
-    void setShouldOfferWebPaste(bool newShouldOfferWebPaste);
-    
+    void setShouldOfferWebPaste( bool newShouldOfferWebPaste );
+
 signals:
     void headingChanged();
-    
+
     void informativeTextChanged();
-    
+
     void detailsChanged();
-    
+
     void shouldOfferWebPasteChanged();
-    
+
 private:
-    Ui::ErrorDialog *ui;
+    Ui::ErrorDialog* ui;
     bool m_shouldOfferWebPaste = false;
 };
 
-}; // namespace Calamares
+};  // namespace Calamares
 
-#endif // ERRORDIALOG_H
+#endif  // ERRORDIALOG_H

--- a/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.h
+++ b/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.h
@@ -49,7 +49,7 @@ signals:
     
 private:
     Ui::ErrorDialog *ui;
-    bool m_shouldOfferWebPaste;
+    bool m_shouldOfferWebPaste = false;
 };
 
 }; // namespace Calamares

--- a/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.ui
+++ b/src/libcalamaresui/utils/ErrorDialog/ErrorDialog.ui
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ErrorDialog</class>
+ <widget class="QDialog" name="ErrorDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>425</width>
+    <height>262</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="1">
+    <widget class="QLabel" name="headingLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string notr="true"/>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QWidget" name="detailsWidget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Details:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QTextBrowser" name="detailsBrowser"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0" rowspan="2">
+    <widget class="QLabel" name="iconLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string notr="true"/>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="informativeTextLabel">
+     <property name="text">
+      <string notr="true"/>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="offerWebPasteLabel">
+     <property name="text">
+      <string>Would you like to paste the install log to the web?</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ErrorDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ErrorDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/libcalamaresui/widgets/TranslationFix.cpp
+++ b/src/libcalamaresui/widgets/TranslationFix.cpp
@@ -10,21 +10,16 @@
 #include "TranslationFix.h"
 
 #include <QAbstractButton>
+#include <QPushButton>
 #include <QCoreApplication>
 #include <QMessageBox>
+#include <QDialogButtonBox>
 
 namespace Calamares
 {
 
-void
-fixButtonLabels( QMessageBox* box )
-{
-    if ( !box )
-    {
-        return;
-    }
-
-    static std::pair< decltype( QMessageBox::Ok ), const char* > maps[] = {
+//Using QMessageBox's StandardButton enum here but according to headers they should be kept in-sync between multiple classes.
+static std::pair< decltype( QMessageBox::Ok ), const char* > maps[] = {
         { QMessageBox::Ok, QT_TRANSLATE_NOOP( "StandardButtons", "&OK" ) },
         { QMessageBox::Yes, QT_TRANSLATE_NOOP( "StandardButtons", "&Yes" ) },
         { QMessageBox::No, QT_TRANSLATE_NOOP( "StandardButtons", "&No" ) },
@@ -32,14 +27,34 @@ fixButtonLabels( QMessageBox* box )
         { QMessageBox::Close, QT_TRANSLATE_NOOP( "StandardButtons", "&Close" ) },
     };
 
+template<typename TButtonBox>
+void fixButtonLabels ( TButtonBox* box )
+{
+    if ( !box )
+    {
+        return;
+    }
+    
     for ( auto [ sb, label ] : maps )
     {
-        auto* button = box->button( sb );
+        auto* button = box->button( static_cast<typename TButtonBox::StandardButton>(int(sb)) );
         if ( button )
         {
             button->setText( QCoreApplication::translate( "StandardButtons", label ) );
         }
     }
+}
+
+void
+fixButtonLabels( QMessageBox* box )
+{
+    fixButtonLabels<QMessageBox>(box);
+}
+
+void
+fixButtonLabels(QDialogButtonBox *box)
+{
+    fixButtonLabels<QDialogButtonBox>(box);
 }
 
 }  // namespace Calamares

--- a/src/libcalamaresui/widgets/TranslationFix.cpp
+++ b/src/libcalamaresui/widgets/TranslationFix.cpp
@@ -10,34 +10,35 @@
 #include "TranslationFix.h"
 
 #include <QAbstractButton>
-#include <QPushButton>
 #include <QCoreApplication>
-#include <QMessageBox>
 #include <QDialogButtonBox>
+#include <QMessageBox>
+#include <QPushButton>
 
 namespace Calamares
 {
 
 //Using QMessageBox's StandardButton enum here but according to headers they should be kept in-sync between multiple classes.
 static std::pair< decltype( QMessageBox::Ok ), const char* > maps[] = {
-        { QMessageBox::Ok, QT_TRANSLATE_NOOP( "StandardButtons", "&OK" ) },
-        { QMessageBox::Yes, QT_TRANSLATE_NOOP( "StandardButtons", "&Yes" ) },
-        { QMessageBox::No, QT_TRANSLATE_NOOP( "StandardButtons", "&No" ) },
-        { QMessageBox::Cancel, QT_TRANSLATE_NOOP( "StandardButtons", "&Cancel" ) },
-        { QMessageBox::Close, QT_TRANSLATE_NOOP( "StandardButtons", "&Close" ) },
-    };
+    { QMessageBox::Ok, QT_TRANSLATE_NOOP( "StandardButtons", "&OK" ) },
+    { QMessageBox::Yes, QT_TRANSLATE_NOOP( "StandardButtons", "&Yes" ) },
+    { QMessageBox::No, QT_TRANSLATE_NOOP( "StandardButtons", "&No" ) },
+    { QMessageBox::Cancel, QT_TRANSLATE_NOOP( "StandardButtons", "&Cancel" ) },
+    { QMessageBox::Close, QT_TRANSLATE_NOOP( "StandardButtons", "&Close" ) },
+};
 
-template<typename TButtonBox>
-void fixButtonLabels ( TButtonBox* box )
+template < typename TButtonBox >
+void
+fixButtonLabels( TButtonBox* box )
 {
     if ( !box )
     {
         return;
     }
-    
+
     for ( auto [ sb, label ] : maps )
     {
-        auto* button = box->button( static_cast<typename TButtonBox::StandardButton>(int(sb)) );
+        auto* button = box->button( static_cast< typename TButtonBox::StandardButton >( int( sb ) ) );
         if ( button )
         {
             button->setText( QCoreApplication::translate( "StandardButtons", label ) );
@@ -48,13 +49,13 @@ void fixButtonLabels ( TButtonBox* box )
 void
 fixButtonLabels( QMessageBox* box )
 {
-    fixButtonLabels<QMessageBox>(box);
+    fixButtonLabels< QMessageBox >( box );
 }
 
 void
-fixButtonLabels(QDialogButtonBox *box)
+fixButtonLabels( QDialogButtonBox* box )
 {
-    fixButtonLabels<QDialogButtonBox>(box);
+    fixButtonLabels< QDialogButtonBox >( box );
 }
 
 }  // namespace Calamares

--- a/src/libcalamaresui/widgets/TranslationFix.h
+++ b/src/libcalamaresui/widgets/TranslationFix.h
@@ -13,6 +13,7 @@
 #include "DllMacro.h"
 
 class QMessageBox;
+class QDialogButtonBox;
 
 namespace Calamares
 {
@@ -26,6 +27,8 @@ namespace Calamares
  * guess the context.
  */
 void UIDLLEXPORT fixButtonLabels( QMessageBox* );
+
+void UIDLLEXPORT fixButtonLabels( QDialogButtonBox* );
 }  // namespace Calamares
 
 #endif


### PR DESCRIPTION
Currently Calamares uses plain QMessageBox to show an error. This PR gives some visual uplift by creating a dedicated dialog with a text browser for error details thus visually separating them from the actual message.
![image](https://user-images.githubusercontent.com/7955026/144729245-c06e0069-ee16-4641-8333-61baeff109b5.png)
