### PR TITLE
Comment : preservefiles on Sat Dec 11 06:11:45 PM CET 2021

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ CMakeLists.txt.user
 # Kate
 *.kate-swp
 tags
+git*

--- a/src/modules/preservefiles/preservefiles.conf
+++ b/src/modules/preservefiles/preservefiles.conf
@@ -34,15 +34,13 @@
 #   - *log*, for the complete log file (up to the moment the preservefiles
 #     module is run),
 #   - *config*, for a JSON dump of the contents of global storage
----
 files:
-  - /etc/oem-information
   - from: log
-    dest: /root/install.log
+    dest: /var/log/Calamares.log
     perm: root:wheel:644
   - from: config
-    dest: /root/install.json
-    perm: root:wheel:400
+    dest: /var/log/Camamares-install.json
+    perm: root:wheel:644
 
 # The *perm* key contains a default value to apply to all files listed
 # above that do not have a *perm* key of their own. If not set,


### PR DESCRIPTION
Add these extra lines to move the two major files to /var/log to keep them together.
+
If choosing encrypted then /var/log/Calamares.log will not be there unless you add it to preserve files
tested out see telegram channel and here in this image
![cal](https://user-images.githubusercontent.com/10594806/145685509-f81a7e9c-c3a5-4304-8eea-a941f4adab3d.jpg)
