### PR TITLE
[luksopenswaphookcfg] set plugin name according to module name

### DIFF
--- a/src/modules/luksopenswaphookcfg/CMakeLists.txt
+++ b/src/modules/luksopenswaphookcfg/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Because LUKS Open Swap Hook (Job) is such a mouthful, we'll
 # use LOSH all over the place as a shorthand.
-calamares_add_plugin( luksopenswaphook
+calamares_add_plugin( luksopenswaphookcfg
     TYPE job
     EXPORT_MACRO PLUGINDLLEXPORT_PRO
     SOURCES


### PR DESCRIPTION
either this, or have all distros adjust settings.conf from luksopenswaphookcfg to luksopenswaphook