### PR TITLE
[locale] Update language always

### DIFF
--- a/src/modules/locale/Config.cpp
+++ b/src/modules/locale/Config.cpp
@@ -252,15 +252,21 @@ Config::setCurrentLocation( const QString& regionName, const QString& zoneName )
 void
 Config::setCurrentLocation( const CalamaresUtils::Locale::TimeZoneData* location )
 {
-    if ( location != m_currentLocation )
+    bool updateLocation = ( location != m_currentLocation );
+    if ( updateLocation )
     {
         m_currentLocation = location;
-        // Overwrite those settings that have not been made explicit.
-        auto newLocale = automaticLocaleConfiguration();
-        if ( !m_selectedLocaleConfiguration.explicit_lang )
-        {
-            setLanguage( newLocale.language() );
-        }
+    }
+
+    // Always lang should be updated
+    auto newLocale = automaticLocaleConfiguration();
+    if ( !m_selectedLocaleConfiguration.explicit_lang )
+    {
+        setLanguage( newLocale.language() );
+    }
+
+    if ( updateLocation )
+    {
         if ( !m_selectedLocaleConfiguration.explicit_lc )
         {
             m_selectedLocaleConfiguration.lc_numeric = newLocale.lc_numeric;


### PR DESCRIPTION
onActivate of locale updates the language only when currentLocation changed
or when onActivate of locale is called for the first time.
However, It is irrelevant solution since the language is set by the welcome.
So language should be updated always.
The language is used by keyboard module to guessing a layout of keyboard.
Once you face the locale, you can't change language in the welcome
if you don't change the timezone.