### PR TITLE
Changes to mount module for 3.3

### DIFF
--- a/src/modules/fstab/fstab.conf
+++ b/src/modules/fstab/fstab.conf
@@ -5,57 +5,8 @@
 # Also creates mount points for all the filesystems.
 #
 # When creating fstab entries for a filesystem, this module
-# uses the options for the filesystem type to write to the
-# options field of the file.
+# uses the options previously defined in the mount module
 ---
-# Mount options to use for all filesystems. If a specific filesystem
-# is listed here, use those options, otherwise use the *default*
-# options from this mapping.
-#
-# With kernels 5.15 and newer be cautious of adding the option space_cache
-# to the btrfs mount options.  The default in 5.15 changed to space_cache=v2.
-# If space_cache or space_cache=v1 are specified, it may fail to remount.
-#
-# btrfs_swap options are used when a swapfile is chosen with a btrfs root
-# the options are applied to the subvolume which holds the swap partition
-#
-# The settings shown here apply only the btrfs defaults; these
-# are generally the right ones. Commented-out lines show other
-# options wich **might** be applicable for specific situations.
-mountOptions:
-    default: defaults,noatime
-    # btrfs: defaults,noatime,autodefrag,compress=zstd
-    btrfs: defaults
-    # btrfs_swap: defaults,noatime
-    btrfs_swap: defaults
-
-# Mount options to use for the EFI System Partition. If not defined, the
-# *mountOptions* for *vfat* are used, or if that is not set either,
-# *default* from *mountOptions*.
-efiMountOptions: umask=0077
-
-# If a filesystem is on an SSD, add the following options. If a specific
-# filesystem is listed here, use those options, otherwise no additional
-# options are set (i.e. there is no *default* like in *mountOptions*).
-#
-# This example configuration applies the *discard* option to most
-# common filesystems on an SSD. This may not be the right option
-# for your distribution. If you use a systemd timer to trim the
-# SSD, it may interfere with the *discard* option. Opinions vary
-# as to whether *discard* is worth the effort -- it depends on
-# the usage pattern of the disk as well.
-#
-# ssdExtraMountOptions:
-#     ext4: discard
-#     jfs: discard
-#     xfs: discard
-#     swap: discard
-#     btrfs: discard,compress=lzo
-#
-# The standard configuration applies asynchronous discard support and ssd optimizations to btrfs
-# and does nothing for other filesystems.
-ssdExtraMountOptions:
-    btrfs: discard=async,ssd
 
 # Additional options added to each line in /etc/crypttab
 crypttabOptions: luks

--- a/src/modules/fstab/fstab.schema.yaml
+++ b/src/modules/fstab/fstab.schema.yaml
@@ -6,23 +6,4 @@ $id: https://calamares.io/schemas/fstab
 additionalProperties: false
 type: object
 properties:
-    mountOptions:
-        type: object
-        additionalProperties: true  # we don't know which FS exist
-        properties:
-            default: { type: string }
-            btrfs: { type: string }
-        required: [ default ]
-    ssdExtraMountOptions:
-        type: object
-        additionalProperties: true  # we don't know which FS exist
-        properties:
-            ext4: { type: string }
-            jfs: { type: string }
-            xfs: { type: string }
-            swap: { type: string }
-            btrfs: { type: string }
-            btrfs_swap: { type: string }
-    efiMountOptions: { type: string }
     crypttabOptions: { type: string }
-required: [ mountOptions ]

--- a/src/modules/fstab/main.py
+++ b/src/modules/fstab/main.py
@@ -234,7 +234,7 @@ class FstabGenerator(object):
             libcalamares.utils.debug("Ignoring foreign swap {!s} {!s}".format(disk_name, partition.get("uuid", None)))
             return None
 
-        options = self.get_mount_options(filesystem, mount_point)
+        options = self.get_mount_options(mount_point)
 
         if mount_point == "/" and filesystem != "btrfs":
             check = 1
@@ -276,8 +276,18 @@ class FstabGenerator(object):
             if partition["mountPoint"]:
                 mkdir_p(self.root_mount_point + partition["mountPoint"])
 
-    def get_mount_options(self, filesystem, mountpoint):
-        return next((x for x in self.mount_options_list if x["mountpoint"] == mountpoint), "defaults")
+    def get_mount_options(self, mountpoint):
+        """
+        Returns the mount options for a given mountpoint
+
+        :param mountpoint: A string containing the mountpoint for the fstab entry
+        :return: A string containing the mount options for the entry or "defaults" if nothing is found
+        """
+        mount_options_item = next((x for x in self.mount_options_list if x.get("mountpoint") == mountpoint), None)
+        if mount_options_item:
+            return mount_options_item.get("option_string", "defaults")
+        else:
+            return "defaults"
 
 
 def create_swapfile(root_mount_point, root_btrfs):

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -58,21 +58,20 @@ def disk_name_for_partition(partition):
 
 
 def is_ssd_disk(partition):
-    """ Checks if given disk is actually a ssd disk.
+    """ Checks if given partition is on an ssd disk.
 
-    :param partition:
-    :return:
+    :param partition: A dict containing the partition information
+    :return: True is the partition in on an ssd, False otherwise
     """
 
-    disk_name = disk_name_for_partition(partition)
-    filename = os.path.join("/sys/block", disk_name, "queue/rotational")
+    try:
+        disk_name = disk_name_for_partition(partition)
+        filename = os.path.join("/sys/block", disk_name, "queue/rotational")
 
-    if not os.path.exists(filename):
-        # Should not happen unless sysfs changes, but better safe than sorry
+        with open(filename) as sysfile:
+            return sysfile.read() == "0\n"
+    except:
         return False
-
-    with open(filename) as sysfile:
-        return sysfile.read() == "0\n"
 
 
 def get_mount_options(filesystem, mount_options, partition):

--- a/src/modules/mount/mount.conf
+++ b/src/modules/mount/mount.conf
@@ -5,16 +5,15 @@
 # target as a usable chroot / "live" system). Filesystems are
 # automatically mounted from the partitioning module. Filesystems
 # listed here are **extra**. The filesystems listed in *extraMounts*
-# are mounted in all target systems. The filesystems listed in
-# *extraMountsEfi* are mounted in the target system **only** if
-# the host machine uses UEFI.
+# are mounted in all target systems.
 ---
 # Extra filesystems to mount. The key's value is a list of entries; each
-# entry has four keys:
+# entry has five keys:
 #   - device    The device node to mount
 #   - fs (optional) The filesystem type to use
 #   - mountPoint Where to mount the filesystem
-#   - options (optional) Extra options to pass to mount(8)
+#   - options (optional) An array of options to pass to mount
+#   - efi (optional) A boolean that when true is only mounted for UEFI installs
 #
 # The device is not mounted if the mountPoint is unset or if the fs is
 # set to unformatted.
@@ -47,7 +46,7 @@ extraMounts:
 # It is possible to prevent subvolume creation -- this is likely only relevant
 # for the root (/) subvolume -- by giving an empty string as a subvolume
 # name. In this case no subvolume will be created.
-
+#
 btrfsSubvolumes:
     - mountPoint: /
       subvolume: /@
@@ -61,17 +60,63 @@ btrfsSubvolumes:
     - mountPoint: /var/log
       subvolume: /@log
 
+# The name of the btrfs subvolume holding the swapfile.  This only used when
+# a swapfile is selected and the root filesystem is btrfs
+#
 btrfsSwapSubvol: /@swap
 
+# The mount options used to mount each filesystem.
+#
+# filsystem contains the name of the filesystem or on of three special
+# values, "default", efi" and "btrfs_swap".  The logic is applied in this manner:
+#   - If the partition is the EFI partition, the "efi" entry will be used
+#   - If the fs is btrfs and the subvolume is for the swapfile,
+#     the "btrfs_swap" entry is used
+#   - If the  filesystem is an exact match for filesystem, that entry is used
+#   - If no match is found in the above, the default entry is used
+#   - If there is no match and no default entry, "defaults" is used
+#   - If the mountOptions key is not present, "defaults" is used
+#
+# Each filesystem entry contains 3 keys, all of which are optional
+#   options - An array of mount options that is used on all disk types
+#   ssdOptions - An array of mount options combined with options for ssds
+#   hddOptions - An array of mount options combined with options for hdds
+# If combining these options results in an empty array, "defaults" is used
+#
+# Example 1
+# In this example, there are specific options for ext4 and btrfs filesystems,
+# the EFI partition and the subvolume holding the btrfs swapfile.  All other
+# filesystems use the default entry.  For the btrfs filesystem, there are
+# additional options specific to hdds and ssds
+#
+# mountOptions:
+#    - filesystem: default
+#      options: [ defaults ]
+#    - filesystem: efi
+#      options: [ defaults, umask=0077 ]
+#    - filesystem: ext4
+#      options: [ defaults, noatime ]
+#    - filesystem: btrfs
+#      options: [ defaults, noatime, compress=zstd:1 ]
+#      ssdOptions: [ discard=async ]
+#      hddOptions: [ autodefrag ]
+#    - filesystem: btrfs_swap
+#      options: [ defaults, noatime ]
+#
+# Example 2
+# In this example there is a single default used by all filesystems
+#
+# mountOptions:
+#    - filesystem: default
+#      options: [ defaults, noatime ]
+#
 mountOptions:
     - filesystem: default
       options: [ defaults, noatime ]
     - filesystem: efi
       options: [ defaults, umask=0077 ]
     - filesystem: btrfs
-      options: [ defaults, noatime, compress ]
-      ssdOptions: [ discard=async ]
-      hddOptions: [ autodefrag ]
+      options: [ defaults, noatime, compress=lzo ]
     - filesystem: btrfs_swap
       options: [ defaults, noatime ]
 

--- a/src/modules/mount/mount.conf
+++ b/src/modules/mount/mount.conf
@@ -35,11 +35,10 @@ extraMounts:
     - device: /run/udev
       mountPoint: /run/udev
       options: bind
-
-extraMountsEfi:
     - device: efivarfs
       fs: efivarfs
       mountPoint: /sys/firmware/efi/efivars
+      efi: true
 
 # Btrfs subvolumes to create if root filesystem is on btrfs volume.
 # If *mountpoint* is mounted already to another partition, it is ignored.
@@ -47,9 +46,7 @@ extraMountsEfi:
 #
 # It is possible to prevent subvolume creation -- this is likely only relevant
 # for the root (/) subvolume -- by giving an empty string as a subvolume
-# name. In this case no subvolume will be created. When using snapper as
-# a rollback mechanism, it is recommended to **not** create a subvolume
-# for root.
+# name. In this case no subvolume will be created.
 
 btrfsSubvolumes:
     - mountPoint: /
@@ -63,3 +60,21 @@ btrfsSubvolumes:
       subvolume: /@cache
     - mountPoint: /var/log
       subvolume: /@log
+
+btrfsSwapSubvol: /@swap
+
+mountOptions:
+    - filesystem: default
+      options: [ defaults, noatime ]
+    - filesystem: efi
+      options: [ defaults, umask=0077 ]
+    - filesystem: btrfs
+      options: [ defaults, noatime, compress ]
+      ssdOptions: [ discard=async ]
+      hddOptions: [ autodefrag ]
+    - filesystem: btrfs_swap
+      options: [ defaults, noatime ]
+
+
+
+

--- a/src/modules/mount/mount.conf
+++ b/src/modules/mount/mount.conf
@@ -28,13 +28,13 @@ extraMounts:
       mountPoint: /sys
     - device: /dev
       mountPoint: /dev
-      options: bind
+      options: [ bind ]
     - device: tmpfs
       fs: tmpfs
       mountPoint: /run
     - device: /run/udev
       mountPoint: /run/udev
-      options: bind
+      options: [ bind ]
     - device: efivarfs
       fs: efivarfs
       mountPoint: /sys/firmware/efi/efivars

--- a/src/modules/mount/mount.conf
+++ b/src/modules/mount/mount.conf
@@ -67,7 +67,7 @@ btrfsSwapSubvol: /@swap
 
 # The mount options used to mount each filesystem.
 #
-# filsystem contains the name of the filesystem or on of three special
+# filesystem contains the name of the filesystem or on of three special
 # values, "default", efi" and "btrfs_swap".  The logic is applied in this manner:
 #   - If the partition is the EFI partition, the "efi" entry will be used
 #   - If the fs is btrfs and the subvolume is for the swapfile,

--- a/src/modules/mount/mount.schema.yaml
+++ b/src/modules/mount/mount.schema.yaml
@@ -6,7 +6,6 @@ $id: https://calamares.io/schemas/mount
 additionalProperties: false
 type: object
 properties:
-    # TODO: share the schema definition, since these are identical
     extraMounts:
         type: array
         items:
@@ -17,17 +16,7 @@ properties:
                 fs: { type: string }
                 mountPoint: { type: string }
                 options: { type: string }
-            required: [ device, mountPoint ]
-    extraMountsEfi:
-        type: array
-        items:
-            type: object
-            additionalProperties: false
-            properties:
-                device: { type: string }
-                fs: { type: string }
-                mountPoint: { type: string }
-                options: { type: string }
+                efi: { type: boolean, default: false }
             required: [ device, mountPoint ]
     btrfsSubvolumes:
         type: array
@@ -38,3 +27,17 @@ properties:
                 mountPoint: { type: string }
                 subvolume: { type: string }
             required: [ subvolume, mountPoint ]
+    btrfsSwapSubvol: { type: string }
+    mountOptions:
+        type: array
+        items:
+            type: object
+            additionalProperties: false
+            properties:
+                filesystem: { type: string }
+                options: { type: array }
+                ssdOptions: { type: array }
+                hddOptions: { type: array }
+            required: [ filesystem ]
+
+

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -156,7 +156,7 @@ defaultFileSystemType:  "ext4"
 #
 # If not specified at all, uses *defaultFileSystemType* without a
 # warning (this matches traditional no-choice-available behavior best).
-# availableFileSystemTypes:  ["ext4","f2fs"]
+availableFileSystemTypes:  ["ext4","f2fs","btrfs"]
 
 # Show/hide LUKS related functionality in automated partitioning modes.
 # Disable this if you choose not to deploy early unlocking support in GRUB2

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -156,7 +156,7 @@ defaultFileSystemType:  "ext4"
 #
 # If not specified at all, uses *defaultFileSystemType* without a
 # warning (this matches traditional no-choice-available behavior best).
-availableFileSystemTypes:  ["ext4","f2fs","btrfs"]
+# availableFileSystemTypes:  ["ext4","f2fs"]
 
 # Show/hide LUKS related functionality in automated partitioning modes.
 # Disable this if you choose not to deploy early unlocking support in GRUB2


### PR DESCRIPTION
This PR has a number of changes to the mount module.

Here is the TLDR version with more detailed explanations below:
* Moved mount options to the mount module
* Refactored the mount config settings
* Added support for separate options for both hdds and ssds
* Added an option to set the name of the subvol for the brtrs swapfile
* Refactored the remainder of the mount config to simply and avoid duplication
* Added documentation

The first and most significant change is that the mount options were moved from the fstab module to the mount module.  This has the advantage of applying mount options to the files in the install.  It will apply all mount options but the most notable is probably for filesystems like btrfs that support compression via a mount option.  Currently, the files from the install aren't being compressed in that scenario.

In moving the mount options config, it has also been refactored.  There are 3 primary changes here:
* Group the config together by filesystem
* Use arrays to store lists instead of comma separated strings
* Add support for additional options for HDDs in addition to SSDs

Since major changes were being made to the mount module config the opportunity was taken to refactor the remaining settings.  Most notably:
* `extraMountsEfi` and `extraMounts` were combined
* A setting for the name of the subvol for the brtrs swapfile was added so it was no longer hardcoded to `@swap`
* As above, it now uses arrays to store lists instead of comma separated strings

Lastly, additional documentation was added throughout the mount module.

It should be noted that since the fstab module needs a rewrite, the changes were to fstab were made as minimal as possible.