### PR TITLE
[umount] Add support for umount to be an emergency module

### DIFF
--- a/src/modules/umount/module.desc
+++ b/src/modules/umount/module.desc
@@ -5,3 +5,4 @@ type:       "job"
 name:       "umount"
 interface:  "python"
 script:     "main.py"
+emergency:  true

--- a/src/modules/umount/umount.conf
+++ b/src/modules/umount/umount.conf
@@ -28,3 +28,7 @@
 #srcLog:      "/home/live/installation.log"
 #destLog:     "/var/log/installation.log"
 srcLog: "/bogus/just/do/not/use/this/anymore.txt"
+
+# Setting emergency to true will make it so this module is still run
+# when a prior module fails
+# emergency: true


### PR DESCRIPTION
The purpose of this minor change is twofold:
* Provide an example of settings a Python module as an emergency module
* Make it easy and obvious to set umount as an emergency module because in most cases it probably should be set as emergency

