### PR TITLE
initcpio module fixes

### DIFF
--- a/src/modules/initcpio/InitcpioJob.cpp
+++ b/src/modules/initcpio/InitcpioJob.cpp
@@ -72,7 +72,7 @@ InitcpioJob::exec()
     }
 
     // If the kernel option isn't set to a specific kernel, run mkinitcpio on all kernels
-    QStringList command = { "mkinitpio" };
+    QStringList command = { "mkinitcpio" };
     if ( m_kernel.isEmpty() || m_kernel == "all" )
     {
         command.append( "-P" );

--- a/src/modules/initcpio/InitcpioJob.cpp
+++ b/src/modules/initcpio/InitcpioJob.cpp
@@ -32,7 +32,7 @@ InitcpioJob::prettyName() const
     return tr( "Creating initramfs with mkinitcpio." );
 }
 
-/** @brief Sets conservative permissions on each initramfs
+/** @brief Sets secure permissions on each initramfs
  *
  * Iterates over each initramfs contained directly in the directory @p d.
  * For each initramfs found, the permissions are set to owner read/write only.

--- a/src/modules/initcpio/InitcpioJob.cpp
+++ b/src/modules/initcpio/InitcpioJob.cpp
@@ -1,6 +1,7 @@
 /* === This file is part of Calamares - <https://calamares.io> ===
  *
  *   SPDX-FileCopyrightText: 2019 Adriaan de Groot <groot@kde.org>
+ *   SPDX-FileCopyrightText: 2022 Evan James <dalto@fastmail.com>
  *   SPDX-License-Identifier: GPL-3.0-or-later
  *
  *   Calamares is Free Software: see the License-Identifier above.
@@ -31,15 +32,22 @@ InitcpioJob::prettyName() const
     return tr( "Creating initramfs with mkinitcpio." );
 }
 
+/** @brief Sets conservative permissions on each initramfs
+ *
+ * Iterates over each initramfs contained directly in the directory @p d.
+ * For each initramfs found, the permissions are set to owner read/write only.
+ *
+ */
 void
 fixPermissions( const QDir& d )
 {
-    for ( const auto& fi : d.entryInfoList( { "initramfs*" }, QDir::Files ) )
+    const auto initramList = d.entryInfoList( { "initramfs*" }, QDir::Files );
+    for ( const auto& fi : initramList )
     {
         QFile f( fi.absoluteFilePath() );
         if ( f.exists() )
         {
-            cDebug() << "initcpio fixing permissions for" << f.fileName();
+            cDebug() << "initcpio setting permissions for" << f.fileName();
             f.setPermissions( QFileDevice::ReadOwner | QFileDevice::WriteOwner );
         }
     }
@@ -63,9 +71,19 @@ InitcpioJob::exec()
         }
     }
 
+    // If the kernel option isn't set to a specific kernel, run mkinitcpio on all kernels
+    QStringList command = { "mkinitpio" };
+    if ( m_kernel.isEmpty() || m_kernel == "all" )
+    {
+        command.append( "-P" );
+    }
+    else
+    {
+        command.append( { "-p", m_kernel } );
+    }
+
     cDebug() << "Updating initramfs with kernel" << m_kernel;
-    auto r = CalamaresUtils::System::instance()->targetEnvCommand(
-        { "mkinitcpio", "-p", m_kernel }, QString(), QString() /* no timeout , 0 */ );
+    auto r = CalamaresUtils::System::instance()->targetEnvCommand( command, QString(), QString() /* no timeout , 0 */ );
     return r.explainProcess( "mkinitcpio", std::chrono::seconds( 10 ) /* fake timeout */ );
 }
 
@@ -73,28 +91,6 @@ void
 InitcpioJob::setConfigurationMap( const QVariantMap& configurationMap )
 {
     m_kernel = CalamaresUtils::getString( configurationMap, "kernel" );
-    if ( m_kernel.isEmpty() )
-    {
-        m_kernel = QStringLiteral( "all" );
-    }
-    else if ( m_kernel == "$uname" )
-    {
-        auto r = CalamaresUtils::System::runCommand( CalamaresUtils::System::RunLocation::RunInHost,
-                                                     { "/bin/uname", "-r" },
-                                                     QString(),
-                                                     QString(),
-                                                     std::chrono::seconds( 3 ) );
-        if ( r.getExitCode() == 0 )
-        {
-            m_kernel = r.getOutput();
-            cDebug() << "*initcpio* using running kernel" << m_kernel;
-        }
-        else
-        {
-            cWarning() << "*initcpio* could not determine running kernel, using 'all'." << Logger::Continuation
-                       << r.getExitCode() << r.getOutput();
-        }
-    }
 
     m_unsafe = CalamaresUtils::getBool( configurationMap, "be_unsafe", false );
 }

--- a/src/modules/initcpio/initcpio.conf
+++ b/src/modules/initcpio/initcpio.conf
@@ -5,16 +5,22 @@
 ---
 # This key defines the kernel to be loaded.
 # It can have the following values:
-#  - the name of a single preset
-#  - empty or unset, interpreted as "all"
+#  - the name of a single mkinitcpio preset
+#  - empty or unset
 #  - the literal string "all"
 #
-# If kernel is "all" or empty/unset then mkinitpio is called for all kernels.  Otherwise
-# it is called with a single prefix with the value contained in kernel
+# If kernel is set to "all" or empty/unset then mkinitpio is called for all
+# kernels.  Otherwise it is called with a single preset with the value
+# contained in kernel.
 #
 kernel: linux
 
 # Set this to true to turn off mitigations for lax file
 # permissions on initramfs (which, in turn, can compromise
 # your LUKS encryption keys, CVS-2019-13179).
+#
+# If your initramfs are stored in the EFI partition or another non-POSIX
+# filesystem, this has no effect as the file permissions cannot be changed.
+# In this case, ensure the partition is mounted securely.
+#
 be_unsafe: false

--- a/src/modules/initcpio/initcpio.conf
+++ b/src/modules/initcpio/initcpio.conf
@@ -5,19 +5,14 @@
 ---
 # This key defines the kernel to be loaded.
 # It can have the following values:
+#  - the name of a single preset
 #  - empty or unset, interpreted as "all"
-#  - the literal string "$uname" (without quotes, with dollar),
-#    which will use the output of `uname -r` to determine the
-#    running kernel, and use that.
-#  - any other string.
+#  - the literal string "all"
 #
-# Whatever is set, that string is passed as *preset* argument to the
-# `-p` option of *mkinitcpio*. Take care that both "$uname" operates
-# in the host system, and might not be correct if the target system is
-# updated (to a newer kernel) as part of the installation.
+# If kernel is "all" or empty/unset then mkinitpio is called for all kernels.  Otherwise
+# it is called with a single prefix with the value contained in kernel
 #
-# Note that "all" is probably not a good preset to use either.
-kernel: linux312
+kernel: linux
 
 # Set this to true to turn off mitigations for lax file
 # permissions on initramfs (which, in turn, can compromise


### PR DESCRIPTION
The current initcpio module is broken in several ways:
* Setting `kernel` to "all" no longer works
* Having `kernel` be unset or empty kernel value no longer works
* If `uname` fails to run there is a warning that it couldn't find the kernel version so "all" will used.  However, it doesn't actually set it to "all".
* Setting kernel to `$uname` doesn't work because `uname` doesn't return anything that can be used as a valid preset.(Tested on Arch, KaOS and Manjaro.  If there are other distros that use mkinitcpio directly I can check those as well)

Basically, it only works if you set `kernel` to be the name of single mkinitcpio preset.

This PR makes the following changes:
* Removes the support for setting `kernel` to `$uname`
* Fixes support for leaving `kernel` unset or setting it to `all`
* Updates the documentation