### PR TITLE
[initramfs] Fix condition when call to uname fails

### DIFF
--- a/src/modules/initramfs/InitramfsJob.cpp
+++ b/src/modules/initramfs/InitramfsJob.cpp
@@ -81,6 +81,7 @@ InitramfsJob::setConfigurationMap( const QVariantMap& configurationMap )
         }
         else
         {
+            m_kernel = QStringLiteral( "all" );
             cWarning() << "*initramfs* could not determine running kernel, using 'all'." << Logger::Continuation
                        << r.getExitCode() << r.getOutput();
         }


### PR DESCRIPTION
When the call to uname fails, the initramfs module writes a warning that it failed and the "all" will be used instead.  However, it doesn't actually set it to all.  This fixes that.

I should note that I didn't test this change because none of my test setups involve a Debian-based distro but I think the change is fairly safe.  Also, even if it is wrong, it is no worse than it was before.  Further, the scenario where this code is actually used is hard to reach in practice which may explain why it has never been noticed.