### PR TITLE
[initcpiocfg] Only add zfs hook if zfs is enabled

### DIFF
--- a/src/modules/initcpiocfg/main.py
+++ b/src/modules/initcpiocfg/main.py
@@ -173,7 +173,8 @@ def find_initcpio_features(partitions, root_mount_point):
         if partition["fs"] == "btrfs":
             uses_btrfs = True
 
-        if partition["fs"] == "zfs":
+        # In addition to checking the filesystem, check to ensure that zfs is enabled
+        if partition["fs"] == "zfs" and libcalamares.globalstorage.contains("zfsPoolInfo"):
             uses_zfs = True
 
         if "lvm2" in partition["fs"]:


### PR DESCRIPTION
Currently, if you don't provide zfs support on the ISO, have a pre-existing zfs partition and don't let Calamares overwrite this partition then Calamares will add zfs modules and the call to mkinitcpio will fail. 

Adding an additional check here resolves this condition.