### PR TITLE
[packages] Ensure all pacman output is available in debug log

### DIFF
--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -392,7 +392,7 @@ class PMPacman(PackageManager):
                     global custom_status_message
                     custom_status_message = "pacman: " + line.strip()
                     libcalamares.job.setprogress(self.progress_fraction)
-                    libcalamares.utils.debug(line)
+            libcalamares.utils.debug(line)
 
         self.in_package_changes = False
         self.line_cb = line_cb


### PR DESCRIPTION
Currently, the pacman implementation is only writing the output that is displayed to the screen in the debug log.

This means, among other things, that when there are errors, there is no way to troubleshoot them.