### PR TITLE
Allow the packagechooser module to modify the netinstall module

### DIFF
--- a/src/modules/netinstall/NetInstallPage.cpp
+++ b/src/modules/netinstall/NetInstallPage.cpp
@@ -76,6 +76,6 @@ NetInstallPage::onActivate()
     const QVariantList groups = gs->value( "NetinstallAdd" ).toList();
     if ( !groups.isEmpty() )
     {
-        m_config->model()->appendModelData( groups, "packageChooser" );
+        m_config->model()->appendModelData( groups );
     }
 }

--- a/src/modules/netinstall/NetInstallPage.cpp
+++ b/src/modules/netinstall/NetInstallPage.cpp
@@ -15,6 +15,7 @@
 #include "PackageModel.h"
 #include "ui_page_netinst.h"
 
+#include "GlobalStorage.h"
 #include "JobQueue.h"
 
 #include "network/Manager.h"
@@ -62,4 +63,19 @@ void
 NetInstallPage::onActivate()
 {
     ui->groupswidget->setFocus();
+
+    Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
+    if ( gs->contains( "NetinstallSelect" ) && gs->value( "NetinstallSelect" ).canConvert( QVariant::StringList ) )
+    {
+        const QStringList selectNames = gs->value( "NetinstallSelect" ).toStringList();
+
+        static_cast< PackageModel* >( ui->groupswidget->model() )->setSelections( selectNames );
+    }
+
+    if ( gs->contains( "NetinstallAdd" ) && gs->value( "NetinstallAdd" ).canConvert( QVariant::List ) )
+    {
+        const QVariantList groups = gs->value( "NetinstallAdd" ).toList();
+
+        static_cast< PackageModel* >( ui->groupswidget->model() )->appendModelData( groups );
+    }
 }

--- a/src/modules/netinstall/NetInstallPage.cpp
+++ b/src/modules/netinstall/NetInstallPage.cpp
@@ -64,20 +64,18 @@ NetInstallPage::onActivate()
 {
     ui->groupswidget->setFocus();
 
-    // The NetInstallSelect global sotrage value can be used to make additional items selected by default
+    // The NetInstallSelect global storage value can be used to make additional items selected by default
     Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
-    if ( gs->contains( "NetinstallSelect" ) && gs->value( "NetinstallSelect" ).canConvert( QVariant::StringList ) )
+    const QStringList selectNames = gs->value( "NetinstallSelect" ).toStringList();
+    if ( !selectNames.isEmpty() )
     {
-        const QStringList selectNames = gs->value( "NetinstallSelect" ).toStringList();
-
-        static_cast< PackageModel* >( ui->groupswidget->model() )->setSelections( selectNames );
+        m_config->model()->setSelections( selectNames );
     }
 
     // If NetInstallAdd is found in global storage, add those items to the tree
-    if ( gs->contains( "NetinstallAdd" ) && gs->value( "NetinstallAdd" ).canConvert( QVariant::List ) )
+    const QVariantList groups = gs->value( "NetinstallAdd" ).toList();
+    if ( !groups.isEmpty() )
     {
-        const QVariantList groups = gs->value( "NetinstallAdd" ).toList();
-
-        static_cast< PackageModel* >( ui->groupswidget->model() )->appendModelData( groups, "packageChooser" );
+        m_config->model()->appendModelData( groups, "packageChooser" );
     }
 }

--- a/src/modules/netinstall/NetInstallPage.cpp
+++ b/src/modules/netinstall/NetInstallPage.cpp
@@ -78,6 +78,6 @@ NetInstallPage::onActivate()
     {
         const QVariantList groups = gs->value( "NetinstallAdd" ).toList();
 
-        static_cast< PackageModel* >( ui->groupswidget->model() )->appendModelData( groups );
+        static_cast< PackageModel* >( ui->groupswidget->model() )->appendModelData( groups, "packageChooser" );
     }
 }

--- a/src/modules/netinstall/NetInstallPage.cpp
+++ b/src/modules/netinstall/NetInstallPage.cpp
@@ -64,6 +64,7 @@ NetInstallPage::onActivate()
 {
     ui->groupswidget->setFocus();
 
+    // The NetInstallSelect global sotrage value can be used to make additional items selected by default
     Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
     if ( gs->contains( "NetinstallSelect" ) && gs->value( "NetinstallSelect" ).canConvert( QVariant::StringList ) )
     {
@@ -72,6 +73,7 @@ NetInstallPage::onActivate()
         static_cast< PackageModel* >( ui->groupswidget->model() )->setSelections( selectNames );
     }
 
+    // If NetInstallAdd is found in global storage, add those items to the tree
     if ( gs->contains( "NetinstallAdd" ) && gs->value( "NetinstallAdd" ).canConvert( QVariant::List ) )
     {
         const QVariantList groups = gs->value( "NetinstallAdd" ).toList();

--- a/src/modules/netinstall/NetInstallPage.cpp
+++ b/src/modules/netinstall/NetInstallPage.cpp
@@ -66,14 +66,14 @@ NetInstallPage::onActivate()
 
     // The NetInstallSelect global storage value can be used to make additional items selected by default
     Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
-    const QStringList selectNames = gs->value( "NetinstallSelect" ).toStringList();
+    const QStringList selectNames = gs->value( "netinstallSelect" ).toStringList();
     if ( !selectNames.isEmpty() )
     {
         m_config->model()->setSelections( selectNames );
     }
 
     // If NetInstallAdd is found in global storage, add those items to the tree
-    const QVariantList groups = gs->value( "NetinstallAdd" ).toList();
+    const QVariantList groups = gs->value( "netinstallAdd" ).toList();
     if ( !groups.isEmpty() )
     {
         m_config->model()->appendModelData( groups );

--- a/src/modules/netinstall/PackageModel.cpp
+++ b/src/modules/netinstall/PackageModel.cpp
@@ -170,6 +170,15 @@ PackageModel::headerData( int section, Qt::Orientation orientation, int role ) c
     return QVariant();
 }
 
+/** @brief Sets the checked flag on matching groups in the tree
+ *
+ * Recursively traverses the tree pointed to by m_rootItem and
+ * checks if a group name matches any of the items in @p selectNames.
+ * If a match is found, set check the box for that group and it's children.
+ *
+ * Individual packages will not be matched.
+ *
+ */
 void
 PackageModel::setSelections( QStringList selectNames )
 {
@@ -333,7 +342,13 @@ PackageModel::setupModelData( const QVariantList& l )
     emit endResetModel();
 }
 
-
+/** @brief Appends groups to the tree
+ *
+ * Uses the data from @p groupList to add elements to the
+ * existing tree that m_rootItem points to.  If m_rootItem
+ * is not valid, it does nothing
+ *
+ */
 void
 PackageModel::appendModelData( const QVariantList& groupList )
 {

--- a/src/modules/netinstall/PackageModel.cpp
+++ b/src/modules/netinstall/PackageModel.cpp
@@ -378,13 +378,18 @@ PackageModel::appendModelData( const QVariantList& groupList )
         if ( !sources.isEmpty() )
         {
             // Prune any existing data from the same source
+            QList< int > removeList;
             for ( int i = 0; i < m_rootItem->childCount(); i++ )
             {
                 PackageTreeItem* child = m_rootItem->child( i );
                 if ( sources.contains( child->source() ) )
                 {
-                    m_rootItem->removeChild( i );
+                    removeList.insert( 0, i );
                 }
+            }
+            for ( const int& item : qAsConst( removeList ) )
+            {
+                m_rootItem->removeChild( item );
             }
         }
 

--- a/src/modules/netinstall/PackageModel.cpp
+++ b/src/modules/netinstall/PackageModel.cpp
@@ -342,20 +342,26 @@ PackageModel::setupModelData( const QVariantList& l )
     emit endResetModel();
 }
 
-/** @brief Appends groups to the tree
- *
- * Uses the data from @p groupList to add elements to the
- * existing tree that m_rootItem points to.  If m_rootItem
- * is not valid, it does nothing
- *
- */
 void
-PackageModel::appendModelData( const QVariantList& groupList )
+PackageModel::appendModelData( const QVariantList& groupList, const QString source )
 {
     if ( m_rootItem )
     {
         emit beginResetModel();
+
+        // Prune any existing data from the same source
+        for ( int i = 0; i < m_rootItem->childCount(); i++ )
+        {
+            PackageTreeItem* child = m_rootItem->child( i );
+            if ( child->source() == source )
+            {
+                m_rootItem->removeChild( i );
+            }
+        }
+
+        // Add the new data to the model
         setupModelData( groupList, m_rootItem );
+
         emit endResetModel();
     }
 }

--- a/src/modules/netinstall/PackageModel.cpp
+++ b/src/modules/netinstall/PackageModel.cpp
@@ -170,6 +170,29 @@ PackageModel::headerData( int section, Qt::Orientation orientation, int role ) c
     return QVariant();
 }
 
+void
+PackageModel::setSelections( QStringList selectNames )
+{
+    if ( m_rootItem )
+    {
+        setSelections( selectNames, m_rootItem );
+    }
+}
+
+void
+PackageModel::setSelections( QStringList selectNames, PackageTreeItem* item )
+{
+    for ( int i = 0; i < item->childCount(); i++ )
+    {
+        auto* child = item->child( i );
+        setSelections( selectNames, child );
+    }
+    if ( item->isGroup() && selectNames.contains( item->name() ) )
+    {
+        item->setSelected( Qt::CheckState::Checked );
+    }
+}
+
 PackageTreeItem::List
 PackageModel::getPackages() const
 {
@@ -308,4 +331,16 @@ PackageModel::setupModelData( const QVariantList& l )
     m_rootItem = new PackageTreeItem();
     setupModelData( l, m_rootItem );
     emit endResetModel();
+}
+
+
+void
+PackageModel::appendModelData( const QVariantList& groupList )
+{
+    if ( m_rootItem )
+    {
+        emit beginResetModel();
+        setupModelData( groupList, m_rootItem );
+        emit endResetModel();
+    }
 }

--- a/src/modules/netinstall/PackageModel.h
+++ b/src/modules/netinstall/PackageModel.h
@@ -54,8 +54,13 @@ public:
     int rowCount( const QModelIndex& parent = QModelIndex() ) const override;
     int columnCount( const QModelIndex& parent = QModelIndex() ) const override;
 
+    void setSelections( QStringList selectNames );
+    void setSelections(QStringList selectNames, PackageTreeItem *item );
+
     PackageTreeItem::List getPackages() const;
     PackageTreeItem::List getItemPackages( PackageTreeItem* item ) const;
+
+    void appendModelData( const QVariantList& groupList );
 
 private:
     friend class ItemTests;

--- a/src/modules/netinstall/PackageModel.h
+++ b/src/modules/netinstall/PackageModel.h
@@ -54,8 +54,16 @@ public:
     int rowCount( const QModelIndex& parent = QModelIndex() ) const override;
     int columnCount( const QModelIndex& parent = QModelIndex() ) const override;
 
-    void setSelections( QStringList selectNames );
-    void setSelections( QStringList selectNames, PackageTreeItem* item );
+    /** @brief Sets the checked flag on matching groups in the tree
+     *
+     * Recursively traverses the tree pointed to by m_rootItem and
+     * checks if a group name matches any of the items in @p selectNames.
+     * If a match is found, set check the box for that group and it's children.
+     *
+     * Individual packages will not be matched.
+     *
+     */
+    void setSelections(const QStringList &selectNames );
 
     PackageTreeItem::List getPackages() const;
     PackageTreeItem::List getItemPackages( PackageTreeItem* item ) const;
@@ -71,7 +79,7 @@ public:
      * data is pruned first
      *
      */
-    void appendModelData( const QVariantList& groupList, const QString source );
+    void appendModelData(const QVariantList& groupList, const QString &source );
 
 private:
     friend class ItemTests;

--- a/src/modules/netinstall/PackageModel.h
+++ b/src/modules/netinstall/PackageModel.h
@@ -68,18 +68,7 @@ public:
     PackageTreeItem::List getPackages() const;
     PackageTreeItem::List getItemPackages( PackageTreeItem* item ) const;
 
-    /** @brief Appends groups to the tree
-     *
-     * Uses the data from @p groupList to add elements to the
-     * existing tree that m_rootItem points to.  If m_rootItem
-     * is not valid, it does nothing
-     *
-     * Before adding anything to the model, it ensures that there
-     * is no existing data from the same source.  If there is, that
-     * data is pruned first
-     *
-     */
-    void appendModelData(const QVariantList& groupList, const QString &source );
+    void appendModelData(const QVariantList& groupList);
 
 private:
     friend class ItemTests;

--- a/src/modules/netinstall/PackageModel.h
+++ b/src/modules/netinstall/PackageModel.h
@@ -55,12 +55,23 @@ public:
     int columnCount( const QModelIndex& parent = QModelIndex() ) const override;
 
     void setSelections( QStringList selectNames );
-    void setSelections(QStringList selectNames, PackageTreeItem *item );
+    void setSelections( QStringList selectNames, PackageTreeItem* item );
 
     PackageTreeItem::List getPackages() const;
     PackageTreeItem::List getItemPackages( PackageTreeItem* item ) const;
 
-    void appendModelData( const QVariantList& groupList );
+    /** @brief Appends groups to the tree
+     *
+     * Uses the data from @p groupList to add elements to the
+     * existing tree that m_rootItem points to.  If m_rootItem
+     * is not valid, it does nothing
+     *
+     * Before adding anything to the model, it ensures that there
+     * is no existing data from the same source.  If there is, that
+     * data is pruned first
+     *
+     */
+    void appendModelData( const QVariantList& groupList, const QString source );
 
 private:
     friend class ItemTests;

--- a/src/modules/netinstall/PackageTreeItem.cpp
+++ b/src/modules/netinstall/PackageTreeItem.cpp
@@ -258,7 +258,7 @@ PackageTreeItem::removeChild( int row )
     }
     else
     {
-        cWarning() << "Attempt to remove invalid child in removeChild() at row " + QString::number( row );
+        cWarning() << "Attempt to remove invalid child in removeChild() at row " << row;
     }
 }
 

--- a/src/modules/netinstall/PackageTreeItem.cpp
+++ b/src/modules/netinstall/PackageTreeItem.cpp
@@ -70,6 +70,7 @@ PackageTreeItem::PackageTreeItem( const QVariantMap& groupData, GroupTag&& paren
     , m_description( CalamaresUtils::getString( groupData, "description" ) )
     , m_preScript( CalamaresUtils::getString( groupData, "pre-install" ) )
     , m_postScript( CalamaresUtils::getString( groupData, "post-install" ) )
+    , m_source( CalamaresUtils::getString( groupData, "source" ) )
     , m_isGroup( true )
     , m_isCritical( parentCriticality( groupData, parent.parent ) )
     , m_isHidden( CalamaresUtils::getBool( groupData, "hidden", false ) )
@@ -246,6 +247,19 @@ PackageTreeItem::setChildrenSelected( Qt::CheckState isSelected )
             child->m_selected = isSelected;
             child->setChildrenSelected( isSelected );
         }
+}
+
+void
+PackageTreeItem::removeChild( int row )
+{
+    if ( row < m_childItems.count() )
+    {
+        m_childItems.removeAt( row );
+    }
+    else
+    {
+        cWarning() << "Attempt to remove invalid child in removeChild() at row " + QString::number( row );
+    }
 }
 
 int

--- a/src/modules/netinstall/PackageTreeItem.h
+++ b/src/modules/netinstall/PackageTreeItem.h
@@ -56,6 +56,7 @@ public:
     QString description() const { return m_description; }
     QString preScript() const { return m_preScript; }
     QString postScript() const { return m_postScript; }
+    QString source() const { return m_source; }
 
     /** @brief Is this item a group-item?
      *
@@ -124,6 +125,8 @@ public:
     void setSelected( Qt::CheckState isSelected );
     void setChildrenSelected( Qt::CheckState isSelected );
 
+    void removeChild( int row );
+
     /** @brief Update selectedness based on the children's states
      *
      * This only makes sense for groups, which might have packages
@@ -157,6 +160,7 @@ private:
     QString m_description;
     QString m_preScript;
     QString m_postScript;
+    QString m_source;
     bool m_isGroup = false;
     bool m_isCritical = false;
     bool m_isHidden = false;

--- a/src/modules/packagechooser/Config.cpp
+++ b/src/modules/packagechooser/Config.cpp
@@ -55,6 +55,8 @@ PackageChooserMethodNames()
         { "custom", PackageChooserMethod::Legacy },
         { "contextualprocess", PackageChooserMethod::Legacy },
         { "packages", PackageChooserMethod::Packages },
+        { "netinstall-add", PackageChooserMethod::NetAdd },
+        { "netinstall-select", PackageChooserMethod::NetSelect },
     };
     return names;
 }
@@ -120,6 +122,23 @@ Config::updateGlobalStorage( const QStringList& selected ) const
         cDebug() << m_defaultId << "packages to install" << packageNames;
         CalamaresUtils::Packages::setGSPackageAdditions(
             Calamares::JobQueue::instance()->globalStorage(), m_defaultId, packageNames );
+    }
+    else if ( m_method == PackageChooserMethod::NetAdd )
+    {
+        QVariantList netinstallDataList = m_model->getNetinstallDataForNames( selected );
+        if ( netinstallDataList.isEmpty() )
+        {
+            cWarning() << "No netinstall information found for " << selected;
+        }
+        else
+        {
+            Calamares::JobQueue::instance()->globalStorage()->insert( "NetinstallAdd", netinstallDataList );
+        }
+    }
+    else if ( m_method == PackageChooserMethod::NetSelect )
+    {
+        cDebug() << m_defaultId << "groups to select in netinstall" << selected;
+        Calamares::JobQueue::instance()->globalStorage()->insert( "NetinstallSelect", selected );
     }
     else
     {

--- a/src/modules/packagechooser/Config.cpp
+++ b/src/modules/packagechooser/Config.cpp
@@ -132,13 +132,46 @@ Config::updateGlobalStorage( const QStringList& selected ) const
         }
         else
         {
-            Calamares::JobQueue::instance()->globalStorage()->insert( "NetinstallAdd", netinstallDataList );
+            auto* gs = Calamares::JobQueue::instance()->globalStorage();
+
+            // If an earlier packagechooser instance added this data to global storage, combine them
+            if ( gs->contains( "NetinstallAdd" ) )
+            {
+                auto netinstallAddOrig = gs->value( "NetinstallAdd" );
+                if ( netinstallAddOrig.canConvert( QVariant::List ) )
+                {
+                    netinstallDataList += netinstallAddOrig.toList();
+                }
+                else
+                {
+                    cWarning() << "Invalid NetinstallAdd data in global storage.  Earlier selections purged";
+                }
+                gs->remove( "NetinstallAdd" );
+            }
+            gs->insert( "NetinstallAdd", netinstallDataList );
         }
     }
     else if ( m_method == PackageChooserMethod::NetSelect )
     {
         cDebug() << m_defaultId << "groups to select in netinstall" << selected;
-        Calamares::JobQueue::instance()->globalStorage()->insert( "NetinstallSelect", selected );
+        QStringList newSelected = selected;
+        auto* gs = Calamares::JobQueue::instance()->globalStorage();
+
+        // If an earlier packagechooser instance added this data to global storage, combine them
+        if ( gs->contains( "NetinstallSelect" ) )
+        {
+            auto selectedOrig = gs->value( "NetinstallSelect" );
+            if ( selectedOrig.canConvert( QVariant::StringList ) )
+            {
+                newSelected += selectedOrig.toStringList();
+            }
+            else
+            {
+                cWarning() << "Invalid NetinstallSelect data in global storage.  Earlier selections purged";
+            }
+            gs->remove( "NetinstallSelect" );
+        }
+        gs->insert( "NetinstallSelect", newSelected );
     }
     else
     {

--- a/src/modules/packagechooser/Config.cpp
+++ b/src/modules/packagechooser/Config.cpp
@@ -140,7 +140,7 @@ Config::updateGlobalStorage( const QStringList& selected ) const
                 auto netinstallAddOrig = gs->value( "NetinstallAdd" );
                 if ( netinstallAddOrig.canConvert( QVariant::List ) )
                 {
-                    netinstallDataList += netinstallAddOrig.toList();
+                    //netinstallDataList += netinstallAddOrig.toList();
                 }
                 else
                 {

--- a/src/modules/packagechooser/Config.cpp
+++ b/src/modules/packagechooser/Config.cpp
@@ -132,7 +132,7 @@ Config::updateGlobalStorage( const QStringList& selected ) const
         }
         else
         {
-            Calamares::JobQueue::instance()->globalStorage()->insert( "NetinstallAdd", netinstallDataList );
+            Calamares::JobQueue::instance()->globalStorage()->insert( "netinstallAdd", netinstallDataList );
         }
     }
     else if ( m_method == PackageChooserMethod::NetSelect )
@@ -142,9 +142,9 @@ Config::updateGlobalStorage( const QStringList& selected ) const
         auto* gs = Calamares::JobQueue::instance()->globalStorage();
 
         // If an earlier packagechooser instance added this data to global storage, combine them
-        if ( gs->contains( "NetinstallSelect" ) )
+        if ( gs->contains( "netinstallSelect" ) )
         {
-            auto selectedOrig = gs->value( "NetinstallSelect" );
+            auto selectedOrig = gs->value( "netinstallSelect" );
             if ( selectedOrig.canConvert( QVariant::StringList ) )
             {
                 newSelected += selectedOrig.toStringList();
@@ -153,9 +153,9 @@ Config::updateGlobalStorage( const QStringList& selected ) const
             {
                 cWarning() << "Invalid NetinstallSelect data in global storage.  Earlier selections purged";
             }
-            gs->remove( "NetinstallSelect" );
+            gs->remove( "netinstallSelect" );
         }
-        gs->insert( "NetinstallSelect", newSelected );
+        gs->insert( "netinstallSelect", newSelected );
     }
     else
     {

--- a/src/modules/packagechooser/Config.cpp
+++ b/src/modules/packagechooser/Config.cpp
@@ -132,23 +132,7 @@ Config::updateGlobalStorage( const QStringList& selected ) const
         }
         else
         {
-            auto* gs = Calamares::JobQueue::instance()->globalStorage();
-
-            // If an earlier packagechooser instance added this data to global storage, combine them
-            if ( gs->contains( "NetinstallAdd" ) )
-            {
-                auto netinstallAddOrig = gs->value( "NetinstallAdd" );
-                if ( netinstallAddOrig.canConvert( QVariant::List ) )
-                {
-                    //netinstallDataList += netinstallAddOrig.toList();
-                }
-                else
-                {
-                    cWarning() << "Invalid NetinstallAdd data in global storage.  Earlier selections purged";
-                }
-                gs->remove( "NetinstallAdd" );
-            }
-            gs->insert( "NetinstallAdd", netinstallDataList );
+            Calamares::JobQueue::instance()->globalStorage()->insert( "NetinstallAdd", netinstallDataList );
         }
     }
     else if ( m_method == PackageChooserMethod::NetSelect )

--- a/src/modules/packagechooser/Config.h
+++ b/src/modules/packagechooser/Config.h
@@ -33,6 +33,8 @@ enum class PackageChooserMethod
 {
     Legacy,  // use contextualprocess or other custom
     Packages,  // use the packages module
+    NetAdd,  // adds packages to the netinstall module
+    NetSelect, // makes selections in the netinstall module
 };
 
 const NamedEnumTable< PackageChooserMethod >& PackageChooserMethodNames();

--- a/src/modules/packagechooser/PackageModel.cpp
+++ b/src/modules/packagechooser/PackageModel.cpp
@@ -140,11 +140,16 @@ QVariantList
 PackageListModel::getNetinstallDataForNames( const QStringList& ids ) const
 {
     QVariantList l;
-    for ( const auto& p : qAsConst( m_packages ) )
+    for ( auto &p : m_packages )
     {
         if ( ids.contains( p.id ) )
         {
-            l.append( p.netinstallData );
+            if ( !p.netinstallData.isEmpty() )
+            {
+                QVariantMap newData = p.netinstallData;
+                newData["source"] = "packageChooser";
+                l.append( newData );
+            }
         }
     }
     return l;

--- a/src/modules/packagechooser/PackageModel.cpp
+++ b/src/modules/packagechooser/PackageModel.cpp
@@ -15,6 +15,14 @@
 
 #include <QFileInfo>
 
+static QVariantMap
+getSubMap( const QVariantMap& map, const QString& key )
+{
+    bool success;
+
+    return CalamaresUtils::getSubMap( map, key, success );
+}
+
 static QPixmap
 loadScreenshot( const QString& path )
 {
@@ -51,12 +59,13 @@ PackageItem::PackageItem( const QString& a_id,
 {
 }
 
-PackageItem::PackageItem::PackageItem( const QVariantMap& item_map )
+PackageItem::PackageItem( const QVariantMap& item_map )
     : id( CalamaresUtils::getString( item_map, "id" ) )
     , name( CalamaresUtils::Locale::TranslatedString( item_map, "name" ) )
     , description( CalamaresUtils::Locale::TranslatedString( item_map, "description" ) )
     , screenshot( loadScreenshot( CalamaresUtils::getString( item_map, "screenshot" ) ) )
     , packageNames( CalamaresUtils::getStringList( item_map, "packages" ) )
+    , netinstallData( getSubMap( item_map, "netinstall" ) )
 {
     if ( name.isEmpty() && id.isEmpty() )
     {
@@ -120,6 +129,20 @@ PackageListModel::getInstallPackagesForNames( const QStringList& ids ) const
         if ( ids.contains( p.id ) )
         {
             l.append( p.packageNames );
+        }
+    }
+    return l;
+}
+
+QVariantList
+PackageListModel::getNetinstallDataForNames( const QStringList& ids ) const
+{
+    QVariantList l;
+    for ( const auto& p : qAsConst( m_packages ) )
+    {
+        if ( ids.contains( p.id ) )
+        {
+            l.append( p.netinstallData );
         }
     }
     return l;

--- a/src/modules/packagechooser/PackageModel.cpp
+++ b/src/modules/packagechooser/PackageModel.cpp
@@ -140,14 +140,14 @@ QVariantList
 PackageListModel::getNetinstallDataForNames( const QStringList& ids ) const
 {
     QVariantList l;
-    for ( auto &p : m_packages )
+    for ( auto& p : m_packages )
     {
         if ( ids.contains( p.id ) )
         {
             if ( !p.netinstallData.isEmpty() )
             {
                 QVariantMap newData = p.netinstallData;
-                newData["source"] = "packageChooser";
+                newData[ "source" ] = QStringLiteral( "packageChooser" );
                 l.append( newData );
             }
         }

--- a/src/modules/packagechooser/PackageModel.cpp
+++ b/src/modules/packagechooser/PackageModel.cpp
@@ -15,6 +15,8 @@
 
 #include <QFileInfo>
 
+/** @brief A wrapper for CalamaresUtils::getSubMap that excludes the success param
+ */
 static QVariantMap
 getSubMap( const QVariantMap& map, const QString& key )
 {

--- a/src/modules/packagechooser/PackageModel.h
+++ b/src/modules/packagechooser/PackageModel.h
@@ -26,6 +26,7 @@ struct PackageItem
     CalamaresUtils::Locale::TranslatedString description;
     QPixmap screenshot;
     QStringList packageNames;
+    QVariantMap netinstallData;
 
     /// @brief Create blank PackageItem
     PackageItem();
@@ -110,6 +111,14 @@ public:
      * Concatenates installPackagesForName() for each id in @p ids.
      */
     QStringList getInstallPackagesForNames( const QStringList& ids ) const;
+
+    /** @brief Does a name lookup (based on id) and returns the netinstall data
+     *
+     * If there is a package with an id in @p ids, returns their netinstall data
+     *
+     * returns a list of netinstall data or an emply list if none is found
+     */
+    QVariantList getNetinstallDataForNames( const QStringList& ids ) const;
 
     enum Roles : int
     {

--- a/src/modules/packagechooser/packagechooser.conf
+++ b/src/modules/packagechooser/packagechooser.conf
@@ -33,6 +33,15 @@ mode: required
 #   in the `exec` section. These package settings will then be handed
 #   off to whatever package manager is configured there.
 #
+# - "netinstall-select"
+#   When this is set, the id(s) selected are passed to the netinstall module.
+#   Any id that matches a group name in that module is set to checked
+#
+# - "netinstall-add"
+#   With this method, the packagechooser module is used to add groups to the
+#   netinstall module.  For this to hav=e any effect.  You must set netinstall,
+#   which is described below.
+#
 # There is no need to put this module in the `exec` section. There
 # are no jobs that this module provides. You should put **other**
 # modules, either *contextualprocess* or *packages* or some custom
@@ -101,12 +110,18 @@ labels:
 #       an additional attempt is made to load the image from the **branding**
 #       directory.
 #
-# The following field is **optional** for an item:
+# The following fields are **optional** for an item:
 #
 #  - *packages* :
 #       List of package names for the product. If using the *method*
 #       "packages", consider this item mandatory (because otherwise
 #       selecting the item would install no packages).
+#
+#  - *netinstall* :
+#       The data in this field should follow the format of a group
+#       from the netinstall module documented in
+#       src/modules/netinstall/netinstall.conf.  This is only used
+#       when method is set to "netinstall-add"
 #
 # # AppData Items #
 #


### PR DESCRIPTION
This adds two new optional methods to the packagechooser module.  Each of these methods are used to modify the netinstall module.  The netinstall module is also modified to read and act on these optional values.

#### The first is netinstall-add
This allows for dynamically adding groups/packages to the netinstall tree.  There are many use cases for this functionality but the way it is being used initially is to give the user a choice between several custom editions which are mutually exclusive.  Adding them to the netinstall has two advantages.  It adds clarity to the end-user so they aren't wondering why the things they selected earlier in the process aren't showing up.  It allows them to refine the selection, for example if they want to remove some of the optional packages.

#### The second is netinstall-select
This allows you to preselect certain groups.  The use case for this is when you have a situation where you want to provide a "pretty" way to describe a group of packages and make selections easy but still allow the user to refine those selections.  For example, you could put a DE picker before the netinstall module and give the user a lot more information about each DE.

