### PR TITLE
[grubcfg] Add configuration for default kernel_params

### DIFF
--- a/src/modules/grubcfg/grubcfg.conf
+++ b/src/modules/grubcfg/grubcfg.conf
@@ -31,6 +31,10 @@ prefer_grub_d: false
 # some way (e.g. uses shell-command substitution).
 keepDistributor: false
 
+# The default kernel params that should always be applied
+# This is an array of strings
+kernel_params: [ "quiet" ]
+
 # Default entries to write to /etc/default/grub if it does not exist yet or if
 # we are overwriting it.
 #

--- a/src/modules/grubcfg/grubcfg.schema.yaml
+++ b/src/modules/grubcfg/grubcfg.schema.yaml
@@ -9,6 +9,7 @@ properties:
     overwrite: { type: boolean, default: false }
     keepDistributor: { type: boolean, default: false }
     prefer_grub_d: { type: boolean, default: false }
+    kernel_params: { type: array }
     defaults:
         type: object
         additionalProperties: true  # Other fields are acceptable

--- a/src/modules/grubcfg/main.py
+++ b/src/modules/grubcfg/main.py
@@ -172,7 +172,7 @@ def modify_grub_default(partitions, root_mount_point, distributor):
             if partition["fs"] == "zfs" and partition["mountPoint"] == "/":
                 zfs_root_path = get_zfs_root()
 
-    kernel_params = ["quiet"]
+    kernel_params = libcalamares.job.configuration.get("kernel_params", [])
 
     # Currently, grub doesn't detect this properly so it must be set manually
     if zfs_root_path:


### PR DESCRIPTION
Currently the default kernel params in the grubcfg module are hard-coded to "quiet"

This makes that an option in the conf file.  