### PR TITLE
Ensure that a trailing slash doesn't cause issues with an unencrypted /boot

### DIFF
--- a/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
+++ b/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
@@ -17,6 +17,8 @@
 #include "GlobalStorage.h"
 #include "JobQueue.h"
 
+#include <QDir>
+
 LuksBootKeyFileJob::LuksBootKeyFileJob( QObject* parent )
     : Calamares::CppJob( parent )
 {
@@ -162,7 +164,7 @@ hasUnencryptedSeparateBoot()
     {
         QVariantMap partitionMap = partition.toMap();
         QString mountPoint = partitionMap.value( QStringLiteral( "mountPoint" ) ).toString();
-        if ( mountPoint == QStringLiteral( "/boot" ) )
+        if ( QDir::cleanPath( mountPoint ) == QStringLiteral( "/boot" ) )
         {
             return !partitionMap.contains( QStringLiteral( "luksMapperName" ) );
         }


### PR DESCRIPTION
It was discovered by several individuals that if you manually type `/boot/` into the mountpoint during manual partitioning the lukskeyfile is still placed in the initramfs.  This happens because `/boot/` is different than `/boot`.

This PR fixes that issue.