### PR TITLE
allow viewing live log during execution

### DIFF
--- a/src/libcalamaresui/CMakeLists.txt
+++ b/src/libcalamaresui/CMakeLists.txt
@@ -30,6 +30,7 @@ set( calamaresui_SOURCES
     widgets/ErrorDialog.cpp
     widgets/FixedAspectRatioLabel.cpp
     widgets/PrettyRadioButton.cpp
+    widgets/LogWidget.cpp
     widgets/TranslationFix.cpp
     widgets/WaitingWidget.cpp
     ${CMAKE_SOURCE_DIR}/3rdparty/waitingspinnerwidget.cpp

--- a/src/libcalamaresui/viewpages/ExecutionViewStep.cpp
+++ b/src/libcalamaresui/viewpages/ExecutionViewStep.cpp
@@ -30,6 +30,14 @@
 #include <QLabel>
 #include <QProgressBar>
 #include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QToolBar>
+#include <QAction>
+#include <QToolButton>
+#include <QTabWidget>
+#include <QPlainTextEdit>
+#include <QTabBar>
+#include "utils/Logger.h"
 
 static Calamares::Slideshow*
 makeSlideshow( QWidget* parent )
@@ -60,23 +68,43 @@ ExecutionViewStep::ExecutionViewStep( QObject* parent )
     , m_progressBar( new QProgressBar )
     , m_label( new QLabel )
     , m_slideshow( makeSlideshow( m_widget ) )
+    , m_tab_widget( new QTabWidget )
 {
     m_widget->setObjectName( "slideshow" );
     m_progressBar->setObjectName( "exec-progress" );
     m_label->setObjectName( "exec-message" );
 
     QVBoxLayout* layout = new QVBoxLayout( m_widget );
-    QVBoxLayout* innerLayout = new QVBoxLayout;
+    QVBoxLayout* bottomLayout = new QVBoxLayout;
+    QHBoxLayout* barLayout = new QHBoxLayout;
 
     m_progressBar->setMaximum( 10000 );
 
-    layout->addWidget( m_slideshow->widget() );
-    CalamaresUtils::unmarginLayout( layout );
-    layout->addLayout( innerLayout );
+    auto m_log_widget = new QPlainTextEdit;
+    m_log_widget->setReadOnly(true);
 
-    innerLayout->addSpacing( CalamaresUtils::defaultFontHeight() / 2 );
-    innerLayout->addWidget( m_progressBar );
-    innerLayout->addWidget( m_label );
+
+    m_tab_widget->addTab(m_slideshow->widget(), "Slideshow");
+    m_tab_widget->addTab(m_log_widget, "Log");
+    m_tab_widget->tabBar()->hide();
+
+    layout->addWidget( m_tab_widget );
+    CalamaresUtils::unmarginLayout( layout );
+    layout->addLayout( bottomLayout );
+
+    bottomLayout->addSpacing( CalamaresUtils::defaultFontHeight() / 2 );
+    bottomLayout->addLayout( barLayout );
+    bottomLayout->addWidget( m_label );
+
+    QToolBar* toolBar = new QToolBar;
+    auto toggleLogAction = toolBar->addAction(QIcon::fromTheme("file-icon"), "Toggle log");
+    auto toggleLogButton = dynamic_cast<QToolButton*>(toolBar->widgetForAction(toggleLogAction));
+    connect( toggleLogButton, &QToolButton::clicked, this, &ExecutionViewStep::toggleLog );
+
+
+    barLayout->addWidget(m_progressBar);
+    barLayout->addWidget(toolBar);
+
 
     connect( JobQueue::instance(), &JobQueue::progress, this, &ExecutionViewStep::updateFromJobQueue );
 }
@@ -198,6 +226,12 @@ ExecutionViewStep::updateFromJobQueue( qreal percent, const QString& message )
     {
         m_label->setText( message );
     }
+}
+
+void
+ExecutionViewStep::toggleLog()
+{
+    m_tab_widget->setCurrentIndex((m_tab_widget->currentIndex() + 1) % m_tab_widget->count());
 }
 
 void

--- a/src/libcalamaresui/viewpages/ExecutionViewStep.cpp
+++ b/src/libcalamaresui/viewpages/ExecutionViewStep.cpp
@@ -97,7 +97,7 @@ ExecutionViewStep::ExecutionViewStep( QObject* parent )
     bottomLayout->addWidget( m_label );
 
     QToolBar* toolBar = new QToolBar;
-    auto toggleLogAction = toolBar->addAction(QIcon::fromTheme("file-icon"), "Toggle log");
+    auto toggleLogAction = toolBar->addAction(QIcon::fromTheme("utilities-terminal"), "Toggle log");
     auto toggleLogButton = dynamic_cast<QToolButton*>(toolBar->widgetForAction(toggleLogAction));
     connect( toggleLogButton, &QToolButton::clicked, this, &ExecutionViewStep::toggleLog );
 

--- a/src/libcalamaresui/viewpages/ExecutionViewStep.cpp
+++ b/src/libcalamaresui/viewpages/ExecutionViewStep.cpp
@@ -25,6 +25,7 @@
 #include "utils/Dirs.h"
 #include "utils/Logger.h"
 #include "utils/Retranslator.h"
+#include "widgets/LogWidget.h"
 
 #include <QDir>
 #include <QLabel>
@@ -37,7 +38,6 @@
 #include <QTabWidget>
 #include <QPlainTextEdit>
 #include <QTabBar>
-#include "utils/Logger.h"
 
 static Calamares::Slideshow*
 makeSlideshow( QWidget* parent )
@@ -69,6 +69,7 @@ ExecutionViewStep::ExecutionViewStep( QObject* parent )
     , m_label( new QLabel )
     , m_slideshow( makeSlideshow( m_widget ) )
     , m_tab_widget( new QTabWidget )
+    , m_log_widget( new LogWidget )
 {
     m_widget->setObjectName( "slideshow" );
     m_progressBar->setObjectName( "exec-progress" );
@@ -79,10 +80,6 @@ ExecutionViewStep::ExecutionViewStep( QObject* parent )
     QHBoxLayout* barLayout = new QHBoxLayout;
 
     m_progressBar->setMaximum( 10000 );
-
-    auto m_log_widget = new QPlainTextEdit;
-    m_log_widget->setReadOnly(true);
-
 
     m_tab_widget->addTab(m_slideshow->widget(), "Slideshow");
     m_tab_widget->addTab(m_log_widget, "Log");
@@ -240,4 +237,6 @@ ExecutionViewStep::onLeave()
     m_slideshow->changeSlideShowState( Slideshow::Stop );
 }
 
+
 }  // namespace Calamares
+

--- a/src/libcalamaresui/viewpages/ExecutionViewStep.h
+++ b/src/libcalamaresui/viewpages/ExecutionViewStep.h
@@ -13,6 +13,7 @@
 
 #include "ViewStep.h"
 #include "modulesystem/InstanceKey.h"
+#include "widgets/LogWidget.h"
 
 #include <QStringList>
 
@@ -20,7 +21,6 @@ class QLabel;
 class QObject;
 class QProgressBar;
 class QTabWidget;
-class QPlainTextEdit;
 
 namespace Calamares
 {
@@ -59,7 +59,7 @@ private:
     QLabel* m_label;
     Slideshow* m_slideshow;
     QTabWidget* m_tab_widget;
-    QPlainTextEdit* m_log_widget;
+    LogWidget* m_log_widget;
 
     QList< ModuleSystem::InstanceKey > m_jobInstanceKeys;
 

--- a/src/libcalamaresui/viewpages/ExecutionViewStep.h
+++ b/src/libcalamaresui/viewpages/ExecutionViewStep.h
@@ -19,6 +19,8 @@
 class QLabel;
 class QObject;
 class QProgressBar;
+class QTabWidget;
+class QPlainTextEdit;
 
 namespace Calamares
 {
@@ -56,10 +58,14 @@ private:
     QProgressBar* m_progressBar;
     QLabel* m_label;
     Slideshow* m_slideshow;
+    QTabWidget* m_tab_widget;
+    QPlainTextEdit* m_log_widget;
 
     QList< ModuleSystem::InstanceKey > m_jobInstanceKeys;
 
     void updateFromJobQueue( qreal percent, const QString& message );
+
+    void toggleLog();
 };
 
 }  // namespace Calamares

--- a/src/libcalamaresui/widgets/LogWidget.cpp
+++ b/src/libcalamaresui/widgets/LogWidget.cpp
@@ -13,6 +13,13 @@ LogThread::LogThread(QObject *parent)
 
 }
 
+LogThread::~LogThread()
+{
+    quit();
+    requestInterruption();
+    wait();
+}
+
 void LogThread::run()
 {
     auto filePath = Logger::logFile();

--- a/src/libcalamaresui/widgets/LogWidget.cpp
+++ b/src/libcalamaresui/widgets/LogWidget.cpp
@@ -1,0 +1,75 @@
+#include "LogWidget.h"
+#include <QStackedLayout>
+#include "utils/Logger.h"
+#include <QTextStream>
+#include <QThread>
+#include <QFile>
+
+namespace Calamares
+{
+
+LogThread::LogThread(QObject *parent)
+    : QThread(parent) {
+
+}
+
+void LogThread::run()
+{
+    auto filePath = Logger::logFile();
+
+    qint64 lastPosition = 0;
+
+    while (!QThread::currentThread()->isInterruptionRequested()) {
+        auto filePath = Logger::logFile();
+        QFile file(filePath);
+
+        qint64 fileSize = file.size();
+        // Check whether the file size has changed since last time
+        // we read the file.
+        if (lastPosition != fileSize && file.open(QFile::ReadOnly | QFile::Text)) {
+
+            // Start reading at the position we ended up last time we read the file.
+            file.seek(lastPosition);
+
+            QTextStream in(&file);
+            auto chunk = in.readAll();
+            qint64 newPosition = in.pos();
+
+            lastPosition = newPosition;
+
+            onLogChunk(chunk);
+        }
+        QThread::msleep(100);
+    }
+}
+
+LogWidget::LogWidget(QWidget *parent)
+    : QWidget(parent)
+    , m_text( new QPlainTextEdit )
+    , m_log_thread( this )
+{
+    auto layout = new QStackedLayout(this);
+    setLayout(layout);
+
+    m_text->setReadOnly(true);
+
+    QFont monospaceFont("monospace");
+    monospaceFont.setStyleHint(QFont::Monospace);
+    m_text->setFont(monospaceFont);
+
+    layout->addWidget(m_text);
+
+    connect(&m_log_thread, &LogThread::onLogChunk, this, &LogWidget::handleLogChunk);
+
+    m_log_thread.start();
+}
+
+void
+LogWidget::handleLogChunk(const QString &logChunk)
+{
+    m_text->appendPlainText(logChunk);
+    m_text->moveCursor(QTextCursor::End);
+    m_text->ensureCursorVisible();
+}
+
+}

--- a/src/libcalamaresui/widgets/LogWidget.h
+++ b/src/libcalamaresui/widgets/LogWidget.h
@@ -16,6 +16,7 @@ class LogThread : public QThread
 
 public:
     explicit LogThread(QObject *parent = nullptr);
+    ~LogThread() override;
 
 signals:
     void onLogChunk(const QString &logChunk);

--- a/src/libcalamaresui/widgets/LogWidget.h
+++ b/src/libcalamaresui/widgets/LogWidget.h
@@ -1,0 +1,37 @@
+#ifndef LIBCALAMARESUI_LOGWIDGET_H
+#define LIBCALAMARESUI_LOGWIDGET_H
+
+#include <QWidget>
+#include <QPlainTextEdit>
+#include <QThread>
+
+namespace Calamares
+{
+
+class LogThread : public QThread
+{
+    Q_OBJECT
+
+    void run() override;
+
+public:
+    explicit LogThread(QObject *parent = nullptr);
+
+signals:
+    void onLogChunk(const QString &logChunk);
+};
+
+class LogWidget : public QWidget
+{
+    Q_OBJECT
+
+    QPlainTextEdit* m_text;
+    LogThread m_log_thread;
+public:
+    explicit LogWidget(QWidget *parent = nullptr);
+
+    void handleLogChunk(const QString &logChunk);
+};
+
+}
+#endif // LOGWIDGET_H


### PR DESCRIPTION
Resolves https://github.com/calamares/calamares/issues/1896

This adds a button during execution to switch between the slideshow and a log viewer. The log viewer reads (and follows) the log file.

![image](https://user-images.githubusercontent.com/6375609/157737249-b87e46b8-b190-404a-afbf-7b7262338471.png)
