### PR TITLE
Fix empty UUID detection in fstab

### DIFF
--- a/src/modules/fstab/main.py
+++ b/src/modules/fstab/main.py
@@ -265,7 +265,7 @@ class FstabGenerator(object):
 
         if has_luks:
             device = "/dev/mapper/" + partition["luksMapperName"]
-        elif partition["uuid"] is not None:
+        elif partition["uuid"]:
             device = "UUID=" + partition["uuid"]
         else:
             device = partition["device"]


### PR DESCRIPTION
The check for an empty UUID fails when it is an empty string.