### PR TITLE
Avoid Reinitializing partition layout.

### DIFF
--- a/src/modules/partition/core/PartitionActions.cpp
+++ b/src/modules/partition/core/PartitionActions.cpp
@@ -108,12 +108,6 @@ doAutopartition( PartitionCoreModule* core, Device* dev, Choices::AutoPartitionO
         partType = isEfi ? PartitionTable::gpt : PartitionTable::msdos;
     }
 
-    // Looking up the defaultFsType (which should name a filesystem type)
-    // will log an error and set the type to Unknown if there's something wrong.
-    FileSystem::Type type = FileSystem::Unknown;
-    PartUtils::canonicalFilesystemName( o.defaultFsType, &type );
-    core->initLayout( type == FileSystem::Unknown ? FileSystem::Ext4 : type );
-
     core->createPartitionTable( dev, partType );
 
     if ( isEfi )


### PR DESCRIPTION
Partition layout are determined from config file - partition.conf
Calling init will cause to clear layout entries, thus loosing
partition layout specified in conf file.
Without this, calamares end up creating partitions layout that is made
of only boot and root partition

Signed-off-by: Santosh Mahto <santosh.mahto@collabora.com>