### PR TITLE
Avoid setting rootfs partition name to "root" by default.

### DIFF
--- a/src/modules/partition/core/PartitionCoreModule.cpp
+++ b/src/modules/partition/core/PartitionCoreModule.cpp
@@ -982,10 +982,6 @@ PartitionCoreModule::layoutApply( Device* dev,
         {
             part->setLabel( "boot" );
         }
-        if ( is_root( part ) )
-        {
-            part->setLabel( "root" );
-        }
         if ( ( separate_boot_partition && is_boot( part ) ) || ( !separate_boot_partition && is_root( part ) ) )
         {
             createPartition(


### PR DESCRIPTION
By default, calamares renames the label of root partition
to "root" overriding the name specified in partiton.conf

Signed-off-by: Santosh Mahto <santosh.mahto@collabora.com>