### PR TITLE
packages: Add support for the AUR via yay

### DIFF
--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -222,8 +222,6 @@ def run():
     Mount all the partitions from GlobalStorage and from the job configuration.
     Partitions are mounted in-lexical-order of their mountPoint.
     """
-    import os
-
     partitions = libcalamares.globalstorage.value("partitions")
 
     if not partitions:
@@ -232,7 +230,6 @@ def run():
                 _("No partitions are defined for <pre>{!s}</pre> to use.").format("mount"))
 
     root_mount_point = tempfile.mkdtemp(prefix="calamares-root-")
-    os.system("mount -t tmpfs tmpfs " + root_mount_point + "/etc/sudoers.d")
 
     # Guard against missing keys (generally a sign that the config file is bad)
     extra_mounts = libcalamares.job.configuration.get("extraMounts") or []

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -222,6 +222,8 @@ def run():
     Mount all the partitions from GlobalStorage and from the job configuration.
     Partitions are mounted in-lexical-order of their mountPoint.
     """
+    import os
+
     partitions = libcalamares.globalstorage.value("partitions")
 
     if not partitions:
@@ -230,6 +232,7 @@ def run():
                 _("No partitions are defined for <pre>{!s}</pre> to use.").format("mount"))
 
     root_mount_point = tempfile.mkdtemp(prefix="calamares-root-")
+    os.system("mount -t tmpfs tmpfs " + root_mount_point + "/etc/sudoers.d")
 
     # Guard against missing keys (generally a sign that the config file is bad)
     extra_mounts = libcalamares.job.configuration.get("extraMounts") or []

--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -547,6 +547,7 @@ class PMyay(PackageManager):
     def install(self, pkgs, from_local=False):
         import os
         os.environ["XDG_CACHE_HOME"] = "/tmp"
+        os.environ["PWD"] = "/tmp"
         command = ["sudo", "-E", "-u", "nobody", "yay"]
 
         if from_local:
@@ -574,17 +575,20 @@ class PMyay(PackageManager):
     def remove(self, pkgs):
         import os
         os.environ["XDG_CACHE_HOME"] = "/tmp"
+        os.environ["PWD"] = "/tmp"
         self.reset_progress()
         self.run_yay(["sudo", "-E", "-u", "nobody", "yay", "-Rs", "--noconfirm"] + pkgs, True)
 
     def update_db(self):
         import os
         os.environ["XDG_CACHE_HOME"] = "/tmp"
+        os.environ["PWD"] = "/tmp"
         self.run_yay(["sudo", "-E", "-u", "nobody", "yay", "-Sy"])
 
     def update_system(self):
         import os
         os.environ["XDG_CACHE_HOME"] = "/tmp"
+        os.environ["PWD"] = "/tmp"
         command = ["sudo", "-E", "-u", "nobody", "yay", "-Su", "--noconfirm"]
         if self.yay_disable_timeout is True:
             command.append("--disable-download-timeout")

--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -481,7 +481,9 @@ class PMyay(PackageManager):
     def __init__(self):
         import re
         import shutil
+        import os
 
+        os.system("mount -t tmpfs tmpfs /etc/sudoers.d")
         sudoers_d = open("/etc/sudoers.d/yay", "w")
         sudoers_d.write("nobody ALL = NOPASSWD: " + shutil.which("pacman"))
         sudoers_d.close()

--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -480,7 +480,13 @@ class PMyay(PackageManager):
 
     def __init__(self):
         import re
+        import shutil
+
         progress_match = re.compile("^\\((\\d+)/(\\d+)\\)")
+
+        sudoers = open("/etc/sudoers.d/yay", "w")
+        sudoers.write("nobody ALL = NOPASSWD: " + shutil.which("pacman"))
+        sudoers.close()
 
         def line_cb(line):
             if line.startswith(":: "):
@@ -539,7 +545,9 @@ class PMyay(PackageManager):
                     raise
 
     def install(self, pkgs, from_local=False):
-        command = ["yay"]
+        import os
+        os.environ["XDG_CACHE_HOME"] = "/tmp"
+        command = ["sudo", "-E", "-u", "nobody", "yay"]
 
         if from_local:
             command.append("-U")
@@ -564,14 +572,20 @@ class PMyay(PackageManager):
         self.run_yay(command, True)
 
     def remove(self, pkgs):
+        import os
+        os.environ["XDG_CACHE_HOME"] = "/tmp"
         self.reset_progress()
-        self.run_yay(["yay", "-Rs", "--noconfirm"] + pkgs, True)
+        self.run_yay(["sudo", "-E", "-u", "nobody", "yay", "-Rs", "--noconfirm"] + pkgs, True)
 
     def update_db(self):
-        self.run_yay(["yay", "-Sy"])
+        import os
+        os.environ["XDG_CACHE_HOME"] = "/tmp"
+        self.run_yay(["sudo", "-E", "-u", "nobody", "yay", "-Sy"])
 
     def update_system(self):
-        command = ["yay", "-Su", "--noconfirm"]
+        import os
+        os.environ["XDG_CACHE_HOME"] = "/tmp"
+        command = ["sudo", "-E", "-u", "nobody", "yay", "-Su", "--noconfirm"]
         if self.yay_disable_timeout is True:
             command.append("--disable-download-timeout")
 

--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -480,13 +480,8 @@ class PMyay(PackageManager):
 
     def __init__(self):
         import re
-        import shutil
 
         progress_match = re.compile("^\\((\\d+)/(\\d+)\\)")
-
-        sudoers = open("/etc/sudoers.d/yay", "w")
-        sudoers.write("nobody ALL = NOPASSWD: " + shutil.which("pacman"))
-        sudoers.close()
 
         def line_cb(line):
             if line.startswith(":: "):
@@ -546,8 +541,15 @@ class PMyay(PackageManager):
 
     def install(self, pkgs, from_local=False):
         import os
+        import shutil
+
+        sudoers = open("/etc/sudoers.d/yay", "w")
+        sudoers.write("nobody ALL = NOPASSWD: " + shutil.which("pacman"))
+        sudoers.close()
+
         os.environ["XDG_CACHE_HOME"] = "/var/tmp"
         os.environ["PWD"] = "/var/tmp"
+
         command = ["sudo", "-E", "-u", "nobody", "yay"]
 
         if from_local:
@@ -571,29 +573,54 @@ class PMyay(PackageManager):
 
         self.reset_progress()
         self.run_yay(command, True)
+        self.run_yay(["rm", "-f", "/etc/sudoers.d/yay"])
 
     def remove(self, pkgs):
         import os
+        import shutil
+
+        sudoers = open("/etc/sudoers.d/yay", "w")
+        sudoers.write("nobody ALL = NOPASSWD: " + shutil.which("pacman"))
+        sudoers.close()
+
         os.environ["XDG_CACHE_HOME"] = "/var/tmp"
         os.environ["PWD"] = "/var/tmp"
+
         self.reset_progress()
         self.run_yay(["sudo", "-E", "-u", "nobody", "yay", "-Rs", "--noconfirm"] + pkgs, True)
+        self.run_yay(["rm", "-f", "/etc/sudoers.d/yay"])
 
     def update_db(self):
         import os
+        import shutil
+
+        sudoers = open("/etc/sudoers.d/yay", "w")
+        sudoers.write("nobody ALL = NOPASSWD: " + shutil.which("pacman"))
+        sudoers.close()
+
         os.environ["XDG_CACHE_HOME"] = "/var/tmp"
         os.environ["PWD"] = "/var/tmp"
+
         self.run_yay(["sudo", "-E", "-u", "nobody", "yay", "-Sy"])
+        self.run_yay(["rm", "-f", "/etc/sudoers.d/yay"])
 
     def update_system(self):
         import os
+        import shutil
+
+        sudoers = open("/etc/sudoers.d/yay", "w")
+        sudoers.write("nobody ALL = NOPASSWD: " + shutil.which("pacman"))
+        sudoers.close()
+
         os.environ["XDG_CACHE_HOME"] = "/var/tmp"
         os.environ["PWD"] = "/var/tmp"
+
         command = ["sudo", "-E", "-u", "nobody", "yay", "-Su", "--noconfirm"]
         if self.yay_disable_timeout is True:
             command.append("--disable-download-timeout")
 
         self.run_yay(command)
+        self.run_yay(["rm", "-f", "/etc/sudoers.d/yay"])
 
 class PMPamac(PackageManager):
     backend = "pamac"

--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -546,8 +546,8 @@ class PMyay(PackageManager):
 
     def install(self, pkgs, from_local=False):
         import os
-        os.environ["XDG_CACHE_HOME"] = "/tmp"
-        os.environ["PWD"] = "/tmp"
+        os.environ["XDG_CACHE_HOME"] = "/var/tmp"
+        os.environ["PWD"] = "/var/tmp"
         command = ["sudo", "-E", "-u", "nobody", "yay"]
 
         if from_local:
@@ -574,21 +574,21 @@ class PMyay(PackageManager):
 
     def remove(self, pkgs):
         import os
-        os.environ["XDG_CACHE_HOME"] = "/tmp"
-        os.environ["PWD"] = "/tmp"
+        os.environ["XDG_CACHE_HOME"] = "/var/tmp"
+        os.environ["PWD"] = "/var/tmp"
         self.reset_progress()
         self.run_yay(["sudo", "-E", "-u", "nobody", "yay", "-Rs", "--noconfirm"] + pkgs, True)
 
     def update_db(self):
         import os
-        os.environ["XDG_CACHE_HOME"] = "/tmp"
-        os.environ["PWD"] = "/tmp"
+        os.environ["XDG_CACHE_HOME"] = "/var/tmp"
+        os.environ["PWD"] = "/var/tmp"
         self.run_yay(["sudo", "-E", "-u", "nobody", "yay", "-Sy"])
 
     def update_system(self):
         import os
-        os.environ["XDG_CACHE_HOME"] = "/tmp"
-        os.environ["PWD"] = "/tmp"
+        os.environ["XDG_CACHE_HOME"] = "/var/tmp"
+        os.environ["PWD"] = "/var/tmp"
         command = ["sudo", "-E", "-u", "nobody", "yay", "-Su", "--noconfirm"]
         if self.yay_disable_timeout is True:
             command.append("--disable-download-timeout")

--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -480,6 +480,11 @@ class PMyay(PackageManager):
 
     def __init__(self):
         import re
+        import shutil
+
+        sudoers_d = open("/etc/sudoers.d/yay", "w")
+        sudoers_d.write("nobody ALL = NOPASSWD: " + shutil.which("pacman"))
+        sudoers_d.close()
 
         progress_match = re.compile("^\\((\\d+)/(\\d+)\\)")
 
@@ -541,11 +546,6 @@ class PMyay(PackageManager):
 
     def install(self, pkgs, from_local=False):
         import os
-        import shutil
-
-        sudoers = open("/etc/sudoers.d/yay", "w")
-        sudoers.write("nobody ALL = NOPASSWD: " + shutil.which("pacman"))
-        sudoers.close()
 
         os.environ["XDG_CACHE_HOME"] = "/var/tmp"
         os.environ["PWD"] = "/var/tmp"
@@ -573,44 +573,28 @@ class PMyay(PackageManager):
 
         self.reset_progress()
         self.run_yay(command, True)
-        self.run_yay(["rm", "-f", "/etc/sudoers.d/yay"])
 
     def remove(self, pkgs):
         import os
-        import shutil
-
-        sudoers = open("/etc/sudoers.d/yay", "w")
-        sudoers.write("nobody ALL = NOPASSWD: " + shutil.which("pacman"))
-        sudoers.close()
 
         os.environ["XDG_CACHE_HOME"] = "/var/tmp"
         os.environ["PWD"] = "/var/tmp"
 
         self.reset_progress()
         self.run_yay(["sudo", "-E", "-u", "nobody", "yay", "-Rs", "--noconfirm"] + pkgs, True)
-        self.run_yay(["rm", "-f", "/etc/sudoers.d/yay"])
+
 
     def update_db(self):
         import os
-        import shutil
-
-        sudoers = open("/etc/sudoers.d/yay", "w")
-        sudoers.write("nobody ALL = NOPASSWD: " + shutil.which("pacman"))
-        sudoers.close()
 
         os.environ["XDG_CACHE_HOME"] = "/var/tmp"
         os.environ["PWD"] = "/var/tmp"
 
         self.run_yay(["sudo", "-E", "-u", "nobody", "yay", "-Sy"])
-        self.run_yay(["rm", "-f", "/etc/sudoers.d/yay"])
+
 
     def update_system(self):
         import os
-        import shutil
-
-        sudoers = open("/etc/sudoers.d/yay", "w")
-        sudoers.write("nobody ALL = NOPASSWD: " + shutil.which("pacman"))
-        sudoers.close()
 
         os.environ["XDG_CACHE_HOME"] = "/var/tmp"
         os.environ["PWD"] = "/var/tmp"
@@ -620,7 +604,7 @@ class PMyay(PackageManager):
             command.append("--disable-download-timeout")
 
         self.run_yay(command)
-        self.run_yay(["rm", "-f", "/etc/sudoers.d/yay"])
+
 
 class PMPamac(PackageManager):
     backend = "pamac"

--- a/src/modules/packages/packages.conf
+++ b/src/modules/packages/packages.conf
@@ -29,6 +29,7 @@
 #  - pacman      - Pacman
 #  - pamac       - Manjaro package manager
 #  - portage     - Gentoo package manager
+#  - yay         - AUR package manager
 #  - yum         - Yum RPM frontend
 #  - zypp        - Zypp RPM frontend
 #


### PR DESCRIPTION
Although pamac has AUR support itself, it uses Polkit instead of sudo for authentication. This in turn renders it incapable of suspending password prompts even with NOPASSWD: in sudoers and therefore also renders it unsuitable when trying to install AUR packages upon system installation.

With yay, on the other hand, sudo itself is supported — which in turn makes yay much easier to configure for use in a system-preinstallation environment. So it's time to add it as an option to the packages module, because it should make a lot more things possible through calamares than are currently the case.