### PR TITLE
[libcalamares] Fix file-reading from target system

### DIFF
--- a/src/libcalamares/utils/CalamaresUtilsSystem.cpp
+++ b/src/libcalamares/utils/CalamaresUtilsSystem.cpp
@@ -169,7 +169,7 @@ System::readTargetFile( const QString& path ) const
 
     QTextStream in( &f );
     QStringList l;
-    while ( !f.atEnd() )
+    while ( !in.atEnd() )
     {
         l << in.readLine();
     }

--- a/src/libcalamares/utils/Tests.cpp
+++ b/src/libcalamares/utils/Tests.cpp
@@ -1043,7 +1043,7 @@ file_setup( const QTemporaryDir& tempRoot )
 void
 LibCalamaresTests::testReadWriteFile()
 {
-    static const QByteArray otherContents( "derp\n" );
+    static const QByteArray otherContents( "first\nsecond\n" );
 
     QTemporaryDir tempRoot( QDir::tempPath() + QStringLiteral( "/test-job-XXXXXX" ) );
     auto* ss = file_setup( tempRoot );
@@ -1080,15 +1080,16 @@ LibCalamaresTests::testReadWriteFile()
         QFileInfo fi( fullPath.path() );
         QVERIFY( fi.exists() );
         QVERIFY( fi.isFile() );
-        QCOMPARE( fi.size(), 5 );
+        QCOMPARE( fi.size(), 13 );
     }
 
     // Now it's been written, we can read it, too
     {
         auto contents = ss->readTargetFile( "test0" );
         QVERIFY( !contents.isEmpty() );
-        QCOMPARE( contents.count(), 1 );
-        QCOMPARE( contents[ 0 ], QStringLiteral( "derp" ) );  // No trailing \n
+        QCOMPARE( contents.count(), 2 );
+        QCOMPARE( contents[ 0 ], QStringLiteral( "first" ) );  // No trailing \n
+        QCOMPARE( contents[ 1 ], QStringLiteral( "second" ) );  // No trailing \n
     }
 }
 


### PR DESCRIPTION
`readTargetFile` was not fully reading files because of an incorrect
EOF check. This could cause /etc/openswap.conf files to be
truncated and hibernation to fail on installed systems.

Here's one external bug report about the issue:
- https://forum.manjaro.org/t/empty-etc-openswap-conf-manjaro-xfce-gnome-21-2-4-5-minimal-220301-linux515-iso-default-install-fde-nohibernation-on-efi-baremetal-or-kvm-boot-device-does-not-exists/106452