### PR TITLE
[users] add fullname to global storage

### DIFF
--- a/src/modules/users/Config.cpp
+++ b/src/modules/users/Config.cpp
@@ -445,6 +445,15 @@ Config::setFullName( const QString& name )
     if ( name != m_fullName )
     {
         m_fullName = name;
+        Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
+        if ( name.isEmpty() )
+        {
+            gs->remove( "fullname" );
+        }
+        else
+        {
+            gs->insert( "fullname", name );
+        }
         emit fullNameChanged( name );
 
         // Build login and hostname, if needed


### PR DESCRIPTION
Adds fullname variable from `users` module to global storage. This allows for other modules to interact with the fullname, in my case setting up users using nix instead of the `users` job.