### PR TITLE
[packagechooserq]: allow changing step name

### DIFF
--- a/src/modules/packagechooser/Config.cpp
+++ b/src/modules/packagechooser/Config.cpp
@@ -238,6 +238,12 @@ Config::setPackageChoice( const QString& packageChoice )
 }
 
 QString
+Config::prettyName() const
+{
+    return m_stepName ? m_stepName->get() : tr( "Packages" );
+}
+
+QString
 Config::prettyStatus() const
 {
     return tr( "Install option: <strong>%1</strong>" ).arg( m_packageChoice.value_or( tr( "None" ) ) );
@@ -341,6 +347,16 @@ Config::setConfigurationMap( const QVariantMap& configurationMap )
         if ( m_method != PackageChooserMethod::Legacy )
         {
             cWarning() << "Single-selection QML module must use 'Legacy' method.";
+        }
+    }
+
+    bool labels_ok = false;
+    auto labels = CalamaresUtils::getSubMap( configurationMap, "labels", labels_ok );
+    if ( labels_ok )
+    {
+        if ( labels.contains( "step" ) )
+        {
+            m_stepName = new CalamaresUtils::Locale::TranslatedString( labels, "step" );
         }
     }
 }

--- a/src/modules/packagechooser/Config.h
+++ b/src/modules/packagechooser/Config.h
@@ -98,6 +98,7 @@ public:
     QString packageChoice() const { return m_packageChoice.value_or( QString() ); }
     void setPackageChoice( const QString& packageChoice );
 
+    QString prettyName() const;
     QString prettyStatus() const;
 
 signals:
@@ -120,6 +121,7 @@ private:
      * Reading the property will return an empty QString.
      */
     std::optional< QString > m_packageChoice;
+    CalamaresUtils::Locale::TranslatedString* m_stepName;  // As it appears in the sidebar
 };
 
 

--- a/src/modules/packagechooser/PackageChooserViewStep.cpp
+++ b/src/modules/packagechooser/PackageChooserViewStep.cpp
@@ -29,7 +29,6 @@ PackageChooserViewStep::PackageChooserViewStep( QObject* parent )
     : Calamares::ViewStep( parent )
     , m_config( new Config( this ) )
     , m_widget( nullptr )
-    , m_stepName( nullptr )
 {
     emit nextStatusChanged( false );
 }
@@ -41,14 +40,13 @@ PackageChooserViewStep::~PackageChooserViewStep()
     {
         m_widget->deleteLater();
     }
-    delete m_stepName;
 }
 
 
 QString
 PackageChooserViewStep::prettyName() const
 {
-    return m_stepName ? m_stepName->get() : tr( "Packages" );
+    return m_config->prettyName();
 }
 
 
@@ -138,16 +136,6 @@ PackageChooserViewStep::setConfigurationMap( const QVariantMap& configurationMap
 {
     m_config->setDefaultId( moduleInstanceKey() );
     m_config->setConfigurationMap( configurationMap );
-
-    bool labels_ok = false;
-    auto labels = CalamaresUtils::getSubMap( configurationMap, "labels", labels_ok );
-    if ( labels_ok )
-    {
-        if ( labels.contains( "step" ) )
-        {
-            m_stepName = new CalamaresUtils::Locale::TranslatedString( labels, "step" );
-        }
-    }
 
     if ( m_widget )
     {

--- a/src/modules/packagechooser/PackageChooserViewStep.h
+++ b/src/modules/packagechooser/PackageChooserViewStep.h
@@ -50,7 +50,6 @@ private:
 
     Config* m_config;
     PackageChooserPage* m_widget;
-    CalamaresUtils::Locale::TranslatedString* m_stepName;  // As it appears in the sidebar
 };
 
 CALAMARES_PLUGIN_FACTORY_DECLARATION( PackageChooserViewStepFactory )

--- a/src/modules/packagechooserq/PackageChooserQmlViewStep.cpp
+++ b/src/modules/packagechooserq/PackageChooserQmlViewStep.cpp
@@ -29,7 +29,7 @@ PackageChooserQmlViewStep::PackageChooserQmlViewStep( QObject* parent )
 QString
 PackageChooserQmlViewStep::prettyName() const
 {
-    return tr( "Packages" );
+    return m_config->prettyName();
 }
 
 QString

--- a/src/modules/packagechooserq/packagechooserq.conf
+++ b/src/modules/packagechooserq/packagechooserq.conf
@@ -42,6 +42,19 @@
 #
 method: legacy
 
+# Human-visible strings in this module. These are all optional.
+# The following translated keys are used:
+#  - *step*, used in the overall progress view (left-hand pane)
+#
+# Each key can have a [locale] added to it, which is used as
+# the translated string for that locale. For the strings
+# associated with the "no-selection" item, see *items*, below
+# with the explicit item-*id* "".
+#
+labels:
+    step: "Packages"
+    step[nl]: "Pakketten"
+
 # The *packageChoice* value is used for setting the default selection
 # in the QML view; this should match one of the keys used in the QML
 # module for package names.


### PR DESCRIPTION
Adds a configurable step name to the `packagechooserq` module, similar to the `packagechooser` module.