### PR TITLE
[libcalamaresui] Provide a new API to add widgets to navigation panel

### DIFF
--- a/src/calamares/CalamaresWindow.cpp
+++ b/src/calamares/CalamaresWindow.cpp
@@ -166,10 +166,6 @@ getWidgetNavigation( Calamares::DebugWindowManager*,
                       bottomLayout,
                       [ bottomLayout ]( QWidget* wgt )
                       {
-                          if ( !bottomLayout )
-                          {
-                              return;
-                          }
                           auto prevWgt = bottomLayout->parentWidget()->findChild< QWidget* >( "view-custom-item" );
 
                           if ( prevWgt )

--- a/src/calamares/CalamaresWindow.cpp
+++ b/src/calamares/CalamaresWindow.cpp
@@ -161,6 +161,31 @@ getWidgetNavigation( Calamares::DebugWindowManager*,
     QBoxLayout* bottomLayout = new QHBoxLayout;
     bottomLayout->addStretch();
 
+    QObject::connect( viewManager,
+                      &Calamares::ViewManager::navigationPanelWidgetChanged,
+                      bottomLayout,
+                      [ bottomLayout ]( QWidget* wgt )
+                      {
+                          if ( !bottomLayout )
+                          {
+                              return;
+                          }
+                          auto prevWgt = bottomLayout->parentWidget()->findChild< QWidget* >( "view-custom-item" );
+
+                          if ( prevWgt )
+                          {
+                              prevWgt->setObjectName( "" );
+                              prevWgt->setParent( nullptr );
+                              bottomLayout->removeWidget( prevWgt );
+                          }
+
+                          if ( wgt )
+                          {
+                              wgt->setObjectName( "view-custom-item" );
+                              bottomLayout->insertWidget( 0, wgt );
+                          }
+                      } );
+
     // Create buttons and sets an initial icon; the icons may change
     {
         auto* back

--- a/src/calamares/CalamaresWindow.cpp
+++ b/src/calamares/CalamaresWindow.cpp
@@ -164,21 +164,22 @@ getWidgetNavigation( Calamares::DebugWindowManager*,
     QObject::connect( viewManager,
                       &Calamares::ViewManager::navigationPanelWidgetChanged,
                       bottomLayout,
-                      [ bottomLayout ]( QWidget* wgt )
+                      [ bottomLayout ]( QWidget* widget )
                       {
-                          auto prevWgt = bottomLayout->parentWidget()->findChild< QWidget* >( "view-custom-item" );
+                          auto* previousCustomWidget
+                              = bottomLayout->parentWidget()->findChild< QWidget* >( "view-custom-item" );
 
-                          if ( prevWgt )
+                          if ( previousCustomWidget )
                           {
-                              prevWgt->setObjectName( "" );
-                              prevWgt->setParent( nullptr );
-                              bottomLayout->removeWidget( prevWgt );
+                              previousCustomWidget->setObjectName( QString() );
+                              previousCustomWidget->setParent( nullptr );
+                              bottomLayout->removeWidget( previousCustomWidget );
                           }
 
-                          if ( wgt )
+                          if ( widget )
                           {
-                              wgt->setObjectName( "view-custom-item" );
-                              bottomLayout->insertWidget( 0, wgt );
+                              widget->setObjectName( QStringLiteral( "view-custom-item" ) );
+                              bottomLayout->insertWidget( 0, widget );
                           }
                       } );
 

--- a/src/libcalamaresui/ViewManager.cpp
+++ b/src/libcalamaresui/ViewManager.cpp
@@ -218,6 +218,7 @@ ViewManager::onInitComplete()
     if ( m_steps.count() > 0 )
     {
         m_steps.first()->onActivate();
+        Q_EMIT navigationPanelWidgetChanged( m_steps.first()->navigationPanelWidget() );
     }
 
     emit currentStepChanged();
@@ -341,6 +342,8 @@ ViewManager::next()
         if ( m_currentStep < m_steps.count() )
         {
             m_steps.at( m_currentStep )->onActivate();
+            Q_EMIT navigationPanelWidgetChanged( m_steps.at( m_currentStep )->navigationPanelWidget() );
+
             executing = qobject_cast< ExecutionViewStep* >( m_steps.at( m_currentStep ) ) != nullptr;
             emit currentStepChanged();
         }
@@ -440,6 +443,7 @@ ViewManager::back()
         m_stack->setCurrentIndex( m_currentStep );
         step->onLeave();
         m_steps.at( m_currentStep )->onActivate();
+        Q_EMIT navigationPanelWidgetChanged( m_steps.at( m_currentStep )->navigationPanelWidget() );
         emit currentStepChanged();
     }
     else if ( !step->isAtBeginning() )

--- a/src/libcalamaresui/ViewManager.h
+++ b/src/libcalamaresui/ViewManager.h
@@ -231,7 +231,8 @@ signals:
     void quitIconChanged( QString ) const;
     void quitVisibleChanged( bool ) const;
     void quitTooltipChanged( QString ) const;
-
+    
+    /// @brief Emits when a custom navigation panel widget changed (e.g. on step change)
     void navigationPanelWidgetChanged( QWidget* );
 
 private:

--- a/src/libcalamaresui/ViewManager.h
+++ b/src/libcalamaresui/ViewManager.h
@@ -232,6 +232,8 @@ signals:
     void quitVisibleChanged( bool ) const;
     void quitTooltipChanged( QString ) const;
 
+    void navigationPanelWidgetChanged( QWidget* );
+
 private:
     explicit ViewManager( QObject* parent = nullptr );
     ~ViewManager() override;

--- a/src/libcalamaresui/viewpages/ViewStep.cpp
+++ b/src/libcalamaresui/viewpages/ViewStep.cpp
@@ -37,6 +37,12 @@ ViewStep::createSummaryWidget() const
     return nullptr;
 }
 
+QWidget*
+ViewStep::navigationPanelWidget()
+{
+    return nullptr;
+}
+
 void
 ViewStep::onActivate()
 {

--- a/src/libcalamaresui/viewpages/ViewStep.h
+++ b/src/libcalamaresui/viewpages/ViewStep.h
@@ -83,6 +83,8 @@ public:
      */
     virtual QWidget* widget() = 0;
 
+    virtual QWidget* navigationPanelWidget();
+
     /** @brief Get margins for this widget
      *
      * This is called by the layout manager to find the desired

--- a/src/libcalamaresui/viewpages/ViewStep.h
+++ b/src/libcalamaresui/viewpages/ViewStep.h
@@ -83,6 +83,14 @@ public:
      */
     virtual QWidget* widget() = 0;
 
+    /** @brief Get the navigation panel widget for this view step
+     *
+     * Optional. This widget will be put to the navigation panel 
+     * (where back/next and quit buttons located) empty space, 
+     * usually the bottom-left corner of the window.
+     *
+     * All ViewStep::widget() rules apply here.
+     */
     virtual QWidget* navigationPanelWidget();
 
     /** @brief Get margins for this widget

--- a/src/modules/welcome/WelcomePage.cpp
+++ b/src/modules/welcome/WelcomePage.cpp
@@ -35,6 +35,8 @@
 #include <QFocusEvent>
 #include <QLabel>
 #include <QMessageBox>
+#include <QToolButton>
+
 
 WelcomePage::WelcomePage( Config* config, QWidget* parent )
     : QWidget( parent )
@@ -47,8 +49,6 @@ WelcomePage::WelcomePage( Config* config, QWidget* parent )
 
     const int defaultFontHeight = CalamaresUtils::defaultFontHeight();
     ui->setupUi( this );
-    ui->aboutButton->setIcon( CalamaresUtils::defaultPixmap(
-        CalamaresUtils::Information, CalamaresUtils::Original, 2 * QSize( defaultFontHeight, defaultFontHeight ) ) );
 
     // insert system-check widget below welcome text
     const int welcome_text_idx = ui->verticalLayout->indexOf( ui->mainText );
@@ -73,11 +73,36 @@ WelcomePage::WelcomePage( Config* config, QWidget* parent )
         }
     }
 
+    {
+        m_aboutWidget = new QWidget;
+
+        auto layout = new QHBoxLayout;
+
+        m_aboutWidget->setLayout( layout );
+
+        auto poweredbyLabel = new QLabel( tr( "Powered by Calamares" ) );
+        poweredbyLabel->setEnabled( false );
+
+        layout->addWidget( poweredbyLabel );
+
+        auto aboutButton = new QToolButton;
+
+        aboutButton->setAutoRaise( true );
+
+        aboutButton->setIcon( CalamaresUtils::defaultPixmap( CalamaresUtils::Information,
+                                                             CalamaresUtils::Original,
+                                                             2 * QSize( defaultFontHeight, defaultFontHeight ) ) );
+
+        connect( aboutButton, &QPushButton::clicked, this, &WelcomePage::showAboutBox );
+
+        layout->addWidget( aboutButton );
+    }
+
     initLanguages();
 
     CALAMARES_RETRANSLATE_SLOT( &WelcomePage::retranslate );
 
-    connect( ui->aboutButton, &QPushButton::clicked, this, &WelcomePage::showAboutBox );
+
     connect( Calamares::ModuleManager::instance(),
              &Calamares::ModuleManager::requirementsComplete,
              m_checkingWidget,
@@ -121,6 +146,12 @@ WelcomePage::initLanguages()
              static_cast< void ( QComboBox::* )( int ) >( &QComboBox::currentIndexChanged ),
              m_conf,
              &Config::setLocaleIndex );
+}
+
+QWidget*
+WelcomePage::aboutWidget() const
+{
+    return m_aboutWidget;
 }
 
 void

--- a/src/modules/welcome/WelcomePage.h
+++ b/src/modules/welcome/WelcomePage.h
@@ -51,6 +51,8 @@ public:
 
     void init();
 
+    QWidget* aboutWidget() const;
+
 public slots:
     void retranslate();
     void showAboutBox();
@@ -67,6 +69,8 @@ private:
     CalamaresUtils::Locale::TranslationsModel* m_languages;
 
     Config* m_conf;
+
+    QWidget* m_aboutWidget;
 };
 
 /** @brief Delegate to display language information in two columns.

--- a/src/modules/welcome/WelcomePage.ui
+++ b/src/modules/welcome/WelcomePage.ui
@@ -135,16 +135,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
-          <widget class="QPushButton" name="aboutButton">
-           <property name="text">
-            <string>&amp;About</string>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
           <widget class="QPushButton" name="donateButton">
            <property name="toolTip">
             <string>Open donations website</string>

--- a/src/modules/welcome/WelcomeViewStep.cpp
+++ b/src/modules/welcome/WelcomeViewStep.cpp
@@ -103,3 +103,9 @@ WelcomeViewStep::checkRequirements()
 {
     return m_conf->checkRequirements();
 }
+
+QWidget*
+WelcomeViewStep::navigationPanelWidget()
+{
+    return m_widget->aboutWidget();
+}

--- a/src/modules/welcome/WelcomeViewStep.h
+++ b/src/modules/welcome/WelcomeViewStep.h
@@ -63,6 +63,8 @@ public:
 
     Calamares::RequirementsList checkRequirements() override;
 
+    QWidget* navigationPanelWidget() override;
+
 private:
     Config* m_conf;
     WelcomePage* m_widget;


### PR DESCRIPTION
* Adds a new ViewStep property for exposing it's extra navigation widget to ViewManager
* Connected CalamaresWindow to ViewManager's signal to update navbar layout on widget change
* `nullptr` means no widget is exposed, this is default behavior
* As an example About button in [welcome] was moved to navigation area module as https://github.com/calamares/calamares/issues/1922 suggests

![image](https://user-images.githubusercontent.com/7955026/164895408-be178085-017c-4cee-86ff-1958c43bb590.png)