### PR TITLE
Remove unneeded emits

### DIFF
--- a/src/libcalamares/modulesystem/RequirementsModel.cpp
+++ b/src/libcalamares/modulesystem/RequirementsModel.cpp
@@ -19,10 +19,10 @@ void
 RequirementsModel::addRequirementsList( const Calamares::RequirementsList& requirements )
 {
     QMutexLocker l( &m_addLock );
-    emit beginResetModel();
+    beginResetModel();
     m_requirements.append( requirements );
     changeRequirementsList();
-    emit endResetModel();
+    endResetModel();
 }
 
 void

--- a/src/modules/netinstall/PackageModel.cpp
+++ b/src/modules/netinstall/PackageModel.cpp
@@ -349,11 +349,11 @@ PackageModel::setupModelData( const QVariantList& groupList, PackageTreeItem* pa
 void
 PackageModel::setupModelData( const QVariantList& l )
 {
-    Q_EMIT beginResetModel();
+    beginResetModel();
     delete m_rootItem;
     m_rootItem = new PackageTreeItem();
     setupModelData( l, m_rootItem );
-    Q_EMIT endResetModel();
+    endResetModel();
 }
 
 void
@@ -361,7 +361,7 @@ PackageModel::appendModelData( const QVariantList& groupList )
 {
     if ( m_rootItem )
     {
-        Q_EMIT beginResetModel();
+        beginResetModel();
 
         const QStringList sources = collectSources( groupList );
 
@@ -386,6 +386,6 @@ PackageModel::appendModelData( const QVariantList& groupList )
         // Add the new data to the model
         setupModelData( groupList, m_rootItem );
 
-        Q_EMIT endResetModel();
+        endResetModel();
     }
 }

--- a/src/modules/summary/Config.cpp
+++ b/src/modules/summary/Config.cpp
@@ -61,7 +61,7 @@ SummaryModel::rowCount( const QModelIndex& ) const
 void
 SummaryModel::setSummaryList( const Calamares::ViewStepList& steps, bool withWidgets )
 {
-    Q_EMIT beginResetModel();
+    beginResetModel();
     m_summary.clear();
 
     for ( Calamares::ViewStep* step : steps )
@@ -76,7 +76,7 @@ SummaryModel::setSummaryList( const Calamares::ViewStepList& steps, bool withWid
 
         m_summary << StepSummary { step->prettyName(), text, widget };
     }
-    Q_EMIT endResetModel();
+    endResetModel();
 }
 
 Config::Config( QObject* parent )


### PR DESCRIPTION
`beginResetModel()` and `endResetModel()` are not signals.  They are protected functions that emit signals.

There is no reason to emit() them.