### PR TITLE
WIP: Add luks generation selection

### DIFF
--- a/src/modules/partition/Config.cpp
+++ b/src/modules/partition/Config.cpp
@@ -46,7 +46,7 @@ Config::swapChoiceNames()
     return names;
 }
 
-const NamedEnumTable< Config::LuksGeneration >&
+const NamedEnumTable< Config::LuksGenerationChoice >&
 Config::luksGenerationChoiceNames()
 {
     static const NamedEnumTable< LuksGenerationChoice > names { { QStringLiteral( "luks1" ), LuksGenerationChoice::Luks1 },
@@ -193,7 +193,7 @@ Config::setInstallChoice( InstallChoice c )
     {
         m_installChoice = c;
         Q_EMIT installChoiceChanged( c );
-        ::updateGlobalStorage( c, m_swapChoice );
+        ::updateGlobalStorage( c, m_swapChoice, m_luksGenerationChoice );
     }
 }
 
@@ -215,17 +215,17 @@ Config::setSwapChoice( Config::SwapChoice c )
     {
         m_swapChoice = c;
         Q_EMIT swapChoiceChanged( c );
-        ::updateGlobalStorage( m_installChoice, c );
+        ::updateGlobalStorage( m_installChoice, c, m_luksGenerationChoice );
     }
 }
 
 void
 Config::setLuksGenerationChoice( int c )
 {
-    if ( ( c < LuksGenerationChoice::Luks1 ) || ( c > LuksGenerationChoice::Luks2 ) )
+    if ( ( c != LuksGenerationChoice::Luks1 ) && ( c != LuksGenerationChoice::Luks2 ) )
     {
         cWarning() << "Invalid luks generation choice (int)" << c;
-        c = SwapChoice::Luks1;
+        c = LuksGenerationChoice::Luks1;
     }
     setLuksGenerationChoice( static_cast< LuksGenerationChoice >( c ) );
 }

--- a/src/modules/partition/Config.cpp
+++ b/src/modules/partition/Config.cpp
@@ -163,7 +163,7 @@ getSwapChoices( const QVariantMap& configurationMap )
 }
 
 void
-updateGlobalStorage( Config::InstallChoice installChoice, Config::SwapChoice swapChoice )
+updateGlobalStorage( Config::InstallChoice installChoice, Config::SwapChoice swapChoice, Config::LuksGenerationChoice luksGenerationChoice )
 {
     auto* gs = Calamares::JobQueue::instance() ? Calamares::JobQueue::instance()->globalStorage() : nullptr;
     if ( gs )
@@ -238,7 +238,7 @@ Config::setLuksGenerationChoice( Config::LuksGenerationChoice c )
         m_luksGenerationChoice = c;
         Q_EMIT luksGenerationChoiceChanged( c );
         // TODO(Artur): This doesn't seem right but is also done at line 217
-        ::updateGlobalStorage( m_installChoice, c );
+        ::updateGlobalStorage( m_installChoice, m_swapChoice, c );
     }
 }
 

--- a/src/modules/partition/Config.h
+++ b/src/modules/partition/Config.h
@@ -63,6 +63,15 @@ public:
 
     using EraseFsTypesSet = QStringList;
 
+    /** @brief Choice of luks disk encryption generation */
+
+    enum class LuksGenerationChoice {
+        Luks1,
+        Luks2
+    }
+    Q_ENUM( LuksGenerationChoice )
+    static const NamedEnumTable< LuksGeneration >& luksGenerationeChoiceNames();
+
     void setConfigurationMap( const QVariantMap& );
     /** @brief Set GS values where other modules configuration has priority
      *
@@ -112,6 +121,21 @@ public:
      */
     SwapChoice swapChoice() const { return m_swapChoice; }
 
+
+    /** @brief What kind of swap selection is requested **initially**?
+     *
+     * @return The swap choice (may be @c NoSwap )
+     */
+    LuksGenerationChoice initialLuksGenerationChoice() const { return m_initialLuksGenerationChoice; }
+
+    /** @brief What kind of swap selection is requested **now**?
+     *
+     * A choice of swap only makes sense when install choice Erase is made.
+     *
+     * @return The swap choice (may be @c NoSwap).
+     */
+    LuksGenerationChoice luksGenerationChoice() const { return m_luksGenerationChoice; }
+
     /** @brief Get the list of configured FS types to use with *erase* mode
      *
      * This list is not empty.
@@ -145,11 +169,14 @@ public Q_SLOTS:
     void setInstallChoice( InstallChoice );
     void setSwapChoice( int );  ///< Translates a button ID or so to SwapChoice
     void setSwapChoice( SwapChoice );
+    void setLuksGenerationChoice( int );  ///< Translates a button ID or so to SwapChoice
+    void setLuksGenerationChoice( LuksGenerationChoice );
     void setEraseFsTypeChoice( const QString& filesystemName );  ///< See property eraseModeFilesystem
 
 Q_SIGNALS:
     void installChoiceChanged( InstallChoice );
     void swapChoiceChanged( SwapChoice );
+    void luksGenerationChoiceChanged( LuksGenerationChoice );
     void eraseModeFilesystemChanged( const QString& );
 
 private:
@@ -162,6 +189,8 @@ private:
     SwapChoiceSet m_swapChoices;
     SwapChoice m_initialSwapChoice = NoSwap;
     SwapChoice m_swapChoice = NoSwap;
+    LuksGenerationChoice m_luksGenerationChoice = LuksGenerationChoice::Luks1;
+    LuksGenerationChoice m_initialLuksGenerationChoice = LuksGenerationChoice::Luks1;
     InstallChoice m_initialInstallChoice = NoChoice;
     InstallChoice m_installChoice = NoChoice;
     qreal m_requiredStorageGiB = 0.0;  // May duplicate setting in the welcome module

--- a/src/modules/partition/Config.h
+++ b/src/modules/partition/Config.h
@@ -65,12 +65,12 @@ public:
 
     /** @brief Choice of luks disk encryption generation */
 
-    enum class LuksGenerationChoice {
+    enum LuksGenerationChoice {
         Luks1,
         Luks2
-    }
+    };
     Q_ENUM( LuksGenerationChoice )
-    static const NamedEnumTable< LuksGeneration >& luksGenerationeChoiceNames();
+    static const NamedEnumTable< LuksGenerationChoice >& luksGenerationChoiceNames();
 
     void setConfigurationMap( const QVariantMap& );
     /** @brief Set GS values where other modules configuration has priority

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -64,6 +64,16 @@ userSwapChoices:
 # ensureSuspendToDisk:    true
 # neverCreateSwap:        false
 
+# This setting specifies the luks generation (i.e luks1, luks2) used internally by cryptsetup
+# when creating an encrypted partition
+#
+# This option is set to luks1 by default, as grub doesn't support luks2 + argon2id currently.
+# On the other hand grub does support luks2 with pbkdf2 and could therefore be also set to luks2
+#
+# Choices: luks1, luks2
+#
+luksGeneration: luks1
+
 # Correctly draw nested (e.g. logical) partitions as such.
 drawNestedPartitions:   false
 

--- a/src/modules/partition/partition.schema.yaml
+++ b/src/modules/partition/partition.schema.yaml
@@ -6,27 +6,33 @@ $id: https://calamares.io/schemas/partition
 additionalProperties: false
 type: object
 properties:
-    efiSystemPartition: { type: string }  # Mount point
-    efiSystemPartitionSize: { type: string }
-    efiSystemPartitionName: { type: string }
+  efiSystemPartition: { type: string } # Mount point
+  efiSystemPartitionSize: { type: string }
+  efiSystemPartitionName: { type: string }
 
-    userSwapChoices: { type: array, items: { type: string, enum: [ none, reuse, small, suspend, file ] } }
-    # ensureSuspendToDisk: { type: boolean, default: true }  # Legacy
-    # neverCreateSwap: { type: boolean, default: false }  # Legacy
+  userSwapChoices:
+    {
+      type: array,
+      items: { type: string, enum: [none, reuse, small, suspend, file] },
+    }
+  luksGeneration: { type: string, enum: [luks1, luks2] }
+  # ensureSuspendToDisk: { type: boolean, default: true }  # Legacy
+  # neverCreateSwap: { type: boolean, default: false }  # Legacy
 
-    drawNestedPartitions: { type: boolean, default: false }
-    alwaysShowPartitionLabels: { type: boolean, default: true }
+  drawNestedPartitions: { type: boolean, default: false }
+  alwaysShowPartitionLabels: { type: boolean, default: true }
 
-    defaultFileSystemType: { type: string }
-    availableFileSystemTypes: { type: array, items: { type: string } }
+  defaultFileSystemType: { type: string }
+  availableFileSystemTypes: { type: array, items: { type: string } }
 
-    enableLuksAutomatedPartitioning: { type: boolean, default: false }
-    allowManualPartitioning: { type: boolean, default: true }
-    partitionLayout: { type: array }  # TODO: specify items
-    initialPartitioningChoice: { type: string, enum: [ none, erase, replace, alongside, manual ] }
-    initialSwapChoice: { type: string, enum: [ none, small, suspend, reuse, file ] }
+  enableLuksAutomatedPartitioning: { type: boolean, default: false }
+  allowManualPartitioning: { type: boolean, default: true }
+  partitionLayout: { type: array } # TODO: specify items
+  initialPartitioningChoice:
+    { type: string, enum: [none, erase, replace, alongside, manual] }
+  initialSwapChoice: { type: string, enum: [none, small, suspend, reuse, file] }
 
-    requiredStorage: { type: number }
+  requiredStorage: { type: number }
 required:
-    - efiSystemPartition
-    - userSwapChoices
+  - efiSystemPartition
+  - userSwapChoices


### PR DESCRIPTION
Hey,

as described in https://github.com/calamares/calamares/issues/1643 the installer automatically creates `luks1` partitions, if system encryption is enabled. This is currently done as `grub` only supports `luks2 + pbkdf2`.
Other bootloaders, i.e systemdboot and lilo, do support `luks2 + argon2` and are able to **fully** handle `luks2`.
With this PR an option to manually configure `cryptsetup --type` argument and therefore enable the user to manually use `luks2` is added.

I have already done the necessary modifications to `partition/Config` but haven't finished to actually pass the selected option down to `FileSystemFactory::create`. https://github.com/calamares/calamares/blob/72f25f24ef8c0969f97759338ac0641fa00f8add/src/modules/partition/core/KPMHelpers.cpp#L91

As of now I am not sure if all changes, i.e `luksGenerationChoiceChanged`, are really required but I still included them. Secondly I am currently not sure how the whole qt thing is working, that's why I have updated the signature of `updateGlobalStorage( Config::InstallChoice installChoice, Config::SwapChoice swapChoice, Config::LuksGenerationChoice luksGenerationChoice )` but haven't used the argument there.
Should I just add `luks generation` to `partitionChoices` as it is somehow related to partitioning?

Thanks.

Regards,
Artur