### PR TITLE
[calamares] Improve "about" and "debug" buttons

### DIFF
--- a/src/calamares/CalamaresWindow.cpp
+++ b/src/calamares/CalamaresWindow.cpp
@@ -144,6 +144,8 @@ getWidgetSidebar( Calamares::DebugWindowManager* debug,
                                                              2 * QSize( defaultFontHeight, defaultFontHeight ) ) );
         CALAMARES_RETRANSLATE_FOR(
             aboutDialog,
+            aboutDialog->setText(
+                QCoreApplication::translate( CalamaresWindow::staticMetaObject.className(), "About" ) );
             aboutDialog->setToolTip( QCoreApplication::translate( CalamaresWindow::staticMetaObject.className(),
                                                                   "Show information about Calamares" ) ); );
         extraButtons->addWidget( aboutDialog );
@@ -158,6 +160,8 @@ getWidgetSidebar( Calamares::DebugWindowManager* debug,
         debugWindowBtn->setIcon( CalamaresUtils::defaultPixmap(
             CalamaresUtils::Bugs, CalamaresUtils::Original, 2 * QSize( defaultFontHeight, defaultFontHeight ) ) );
         CALAMARES_RETRANSLATE_FOR( debugWindowBtn,
+                                   debugWindowBtn->setText( QCoreApplication::translate(
+                                       CalamaresWindow::staticMetaObject.className(), "Debug" ) );
                                    debugWindowBtn->setToolTip( QCoreApplication::translate(
                                        CalamaresWindow::staticMetaObject.className(), "Show debug information" ) ); );
         extraButtons->addWidget( debugWindowBtn );

--- a/src/calamares/CalamaresWindow.cpp
+++ b/src/calamares/CalamaresWindow.cpp
@@ -138,7 +138,7 @@ getWidgetSidebar( Calamares::DebugWindowManager* debug,
     if ( /* About-Calamares Button enabled */ true )
     {
         QPushButton* aboutDialog = new QPushButton;
-        aboutDialog->setObjectName( "aboutDialogButton" );
+        aboutDialog->setObjectName( "aboutButton" );
         aboutDialog->setIcon( CalamaresUtils::defaultPixmap( CalamaresUtils::Information,
                                                              CalamaresUtils::Original,
                                                              2 * QSize( defaultFontHeight, defaultFontHeight ) ) );


### PR DESCRIPTION
This does two things:
- restores the text on the "special" buttons for About and Debug
- renames the object for the About button to "aboutButton" instead of "aboutDialogButton" so the name is consistent with the other button there.

This branch could also be merged back / cherry-picked to 3.2-stable.