### PR TITLE
[libcalamaresui] Fix color names

### DIFF
--- a/src/branding/default/branding.desc
+++ b/src/branding/default/branding.desc
@@ -170,20 +170,20 @@ images:
 
 # Colors for text and background components.
 #
-#  - sidebarBackground is the background of the sidebar
-#  - sidebarText is the (foreground) text color
-#  - sidebarTextHighlight sets the background of the selected (current) step.
+#  - SidebarBackground is the background of the sidebar
+#  - SidebarText is the (foreground) text color
+#  - SidebarBackgroundCurrent sets the background of the current step.
 #    Optional, and defaults to the application palette.
-#  - sidebarSelect is the text color of the selected step.
+#  - SidebarTextCurrent is the text color of the current step.
 #
 # These colors can **also** be set through the stylesheet, if the
 # branding component also ships a stylesheet.qss. Then they are
 # the corresponding CSS attributes of #sidebarApp.
 style:
-   sidebarBackground:    "#292F34"
-   sidebarText:          "#FFFFFF"
-   sidebarTextSelect:    "#292F34"
-   sidebarTextHighlight: "#D35400"
+   SidebarBackground:        "#292F34"
+   SidebarText:              "#FFFFFF"
+   SidebarTextCurrent:       "#292F34"
+   SidebarBackgroundCurrent: "#D35400"
 
 ### SLIDESHOW
 #

--- a/src/calamares/calamares-sidebar.qml
+++ b/src/calamares/calamares-sidebar.qml
@@ -66,7 +66,7 @@ Rectangle {
             Layout.fillWidth: true;
             height: 35
             Layout.alignment: Qt.AlignHCenter | Qt.AlignBottom
-            color: Branding.styleString( Branding.SidebarTextHighlight );
+            color: Branding.styleString( Branding.SidebarBackground );
             visible: true;
 
             Rectangle {
@@ -74,7 +74,7 @@ Rectangle {
                 height: 35
                 width: parent.width / 2;
                 anchors.left: parent.left
-                color: Branding.styleString( Branding.SidebarTextHighlight );
+                color: Branding.styleString( Branding.SidebarBackgroundCurrent );
                 visible: true;
 
                 MouseArea {
@@ -87,7 +87,7 @@ Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter;
                         x: parent.x + 4;
                         text: qsTr("About")
-                        color: Branding.styleString( Branding.SidebarTextSelect );
+                        color: Branding.styleString( Branding.SidebarTextCurrent );
                         font.pointSize : 9
                     }
 
@@ -100,7 +100,7 @@ Rectangle {
                 height: 35
                 width: parent.width / 2;
                 anchors.right: parent.right
-                color: Branding.styleString( Branding.SidebarTextHighlight );
+                color: Branding.styleString( Branding.SidebarBackgroundCurrent );
                 visible: debug.enabled
 
                 MouseArea {
@@ -113,7 +113,7 @@ Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter;
                         x: parent.x + 4;
                         text: qsTr("Debug")
-                        color: Branding.styleString( Branding.SidebarTextSelect );
+                        color: Branding.styleString( Branding.SidebarTextCurrent );
                         font.pointSize : 9
                     }
 

--- a/src/libcalamaresui/Branding.cpp
+++ b/src/libcalamaresui/Branding.cpp
@@ -95,6 +95,36 @@ const QStringList Branding::s_uploadServerStrings =
 // clang-format on
 // *INDENT-ON*
 
+/** @brief Check that all the entries in the @p style map make sense
+ *
+ * This will catch typo's in key names.
+ */
+static bool
+validateStyleEntries( const QMap< QString, QString >& style )
+{
+    using SE = Branding::StyleEntry;
+
+    Logger::Once o;
+    bool valid = true;
+
+    const auto meta = QMetaEnum::fromType< SE >();
+    QSet< QString > validNames;
+    for ( SE i : { SE::SidebarBackground, SE::SidebarBackgroundCurrent, SE::SidebarText, SE::SidebarTextCurrent } )
+    {
+        validNames.insert( meta.valueToKey( i ) );
+    }
+
+    for ( const auto& k : style.keys() )
+    {
+        if ( !validNames.contains( k ) )
+        {
+            cWarning() << o << "Unknown branding *style* entry" << k;
+            valid = false;
+        }
+    }
+
+    return valid;
+}
 
 const NamedEnumTable< Branding::WindowDimensionUnit >&
 Branding::WindowDimension::suffixes()
@@ -289,6 +319,7 @@ Branding::Branding( const QString& brandingFilePath, QObject* parent )
     {
         cDebug() << "Loaded branding component" << m_componentName;
     }
+    validateStyleEntries( m_style );
 }
 
 
@@ -310,8 +341,8 @@ Branding::string( Branding::StringEntry stringEntry ) const
 QString
 Branding::styleString( Branding::StyleEntry styleEntry ) const
 {
-    const auto meta = QMetaEnum::fromType<Branding::StyleEntry>();
-    return meta.valueToKey(styleEntry);
+    const auto meta = QMetaEnum::fromType< Branding::StyleEntry >();
+    return m_style.value( meta.valueToKey( styleEntry ) );
 }
 
 

--- a/src/libcalamaresui/Branding.cpp
+++ b/src/libcalamaresui/Branding.cpp
@@ -85,12 +85,17 @@ const QStringList Branding::s_imageEntryStrings =
     "productWelcome"
 };
 
-const QStringList Branding::s_styleEntryStrings =
+/** @brief Mapping of enum values to key names
+ *
+ * The key names can be found in `branding.desc` and need to match
+ * that (and the branding schema).
+ */
+static const QStringList s_styleEntryStrings =
 {
     "sidebarBackground",
     "sidebarText",
-    "sidebarTextSelect",
-    "sidebarTextHighlight"
+    "sidebarTextSelect",  // enum value TextCurrent
+    "sidebarTextHighlight",  // enum value BackgroundCurrent
 };
 
 const QStringList Branding::s_uploadServerStrings =

--- a/src/libcalamaresui/Branding.cpp
+++ b/src/libcalamaresui/Branding.cpp
@@ -24,6 +24,7 @@
 #include <QDir>
 #include <QFile>
 #include <QIcon>
+#include <QMetaEnum>
 #include <QPixmap>
 #include <QVariantMap>
 
@@ -83,19 +84,6 @@ const QStringList Branding::s_imageEntryStrings =
     "productLogo",
     "productWallpaper",
     "productWelcome"
-};
-
-/** @brief Mapping of enum values to key names
- *
- * The key names can be found in `branding.desc` and need to match
- * that (and the branding schema).
- */
-static const QStringList s_styleEntryStrings =
-{
-    "sidebarBackground",
-    "sidebarText",
-    "sidebarTextSelect",  // enum value TextCurrent
-    "sidebarTextHighlight",  // enum value BackgroundCurrent
 };
 
 const QStringList Branding::s_uploadServerStrings =
@@ -322,7 +310,8 @@ Branding::string( Branding::StringEntry stringEntry ) const
 QString
 Branding::styleString( Branding::StyleEntry styleEntry ) const
 {
-    return m_style.value( s_styleEntryStrings.value( styleEntry ) );
+    const auto meta = QMetaEnum::fromType<Branding::StyleEntry>();
+    return meta.valueToKey(styleEntry);
 }
 
 

--- a/src/libcalamaresui/Branding.h
+++ b/src/libcalamaresui/Branding.h
@@ -72,6 +72,12 @@ public:
     };
     Q_ENUM( ImageEntry )
 
+    /** @brief Names of style entries, for use in code
+     *
+     * These names are mapped to names in the branding.desc file through
+     * an internal table s_styleEntryStrings, which defines which names
+     * in `branding.desc` key *style* are used for which entry.
+     */
     enum StyleEntry : short
     {
         SidebarBackground,
@@ -256,6 +262,12 @@ public slots:
     QString shortProductName() const { return string( ShortProductName ); }
     QString shortVersionedName() const { return string( ShortVersionedName ); }
 
+    /** @brief Map an enum-value to the entry from the *style* key.
+     *
+     * e.g. StyleEntry::SidebarTextCurrent maps to the corresponding
+     * *style* entry, which is (confusingly) named "sidebarTextSelect"
+     * in the branding file.
+     */
     QString styleString( StyleEntry styleEntry ) const;
     QString imagePath( ImageEntry imageEntry ) const;
 
@@ -267,7 +279,6 @@ private:
 
     static const QStringList s_stringEntryStrings;
     static const QStringList s_imageEntryStrings;
-    static const QStringList s_styleEntryStrings;
     static const QStringList s_uploadServerStrings;
 
     QString m_descriptorPath;  // Path to descriptor (e.g. "/etc/calamares/default/branding.desc")


### PR DESCRIPTION
This is related to #1968 , but fixes the underlying problem of mismatched names in a different way. It also adds a validation step that checks that the `branding.desc` doesn't name styles (settings for a color) that are not named in code as well.