### PR TITLE
[welcome] Show welcome-image when all requirements are satisfied

### DIFF
--- a/lang/calamares_en.ts
+++ b/lang/calamares_en.ts
@@ -283,16 +283,16 @@
       <location filename="../src/libcalamares/modulesystem/RequirementsChecker.cpp" line="118"/>
       <source>Waiting for %n module(s).</source>
       <translation>
-        <numerusform>Waiting for %n module(s).</numerusform>
-        <numerusform>Waiting for %n module(s).</numerusform>
+        <numerusform>Waiting for %n module.</numerusform>
+        <numerusform>Waiting for %n modules.</numerusform>
       </translation>
     </message>
     <message numerus="yes">
       <location filename="../src/libcalamares/modulesystem/RequirementsChecker.cpp" line="119"/>
       <source>(%n second(s))</source>
       <translation>
-        <numerusform>(%n second(s))</numerusform>
-        <numerusform>(%n second(s))</numerusform>
+        <numerusform>(%n second)</numerusform>
+        <numerusform>(%n seconds)</numerusform>
       </translation>
     </message>
     <message>

--- a/src/libcalamares/modulesystem/RequirementsChecker.cpp
+++ b/src/libcalamares/modulesystem/RequirementsChecker.cpp
@@ -91,7 +91,7 @@ RequirementsChecker::addCheckedRequirements( Module* m )
         m_model->addRequirementsList( l );
     }
 
-    Q_EMIT requirementsProgress( tr( "Requirements checking for module <i>%1</i> is complete." ).arg( m->name() ) );
+    Q_EMIT requirementsProgress( tr( "Requirements checking for module '%1' is complete." ).arg( m->name() ) );
 }
 
 void

--- a/src/libcalamares/modulesystem/RequirementsChecker.cpp
+++ b/src/libcalamares/modulesystem/RequirementsChecker.cpp
@@ -91,7 +91,7 @@ RequirementsChecker::addCheckedRequirements( Module* m )
         m_model->addRequirementsList( l );
     }
 
-    requirementsProgress( tr( "Requirements checking for module <i>%1</i> is complete." ).arg( m->name() ) );
+    Q_EMIT requirementsProgress( tr( "Requirements checking for module <i>%1</i> is complete." ).arg( m->name() ) );
 }
 
 void
@@ -117,11 +117,11 @@ RequirementsChecker::reportProgress()
         unsigned int posInterval = ( m_progressTimer->interval() < 0 ) ? 1000 : uint( m_progressTimer->interval() );
         QString waiting = tr( "Waiting for %n module(s).", "", remaining );
         QString elapsed = tr( "(%n second(s))", "", m_progressTimeouts * posInterval / 1000 );
-        emit requirementsProgress( waiting + QString( " " ) + elapsed );
+        Q_EMIT requirementsProgress( waiting + QString( " " ) + elapsed );
     }
     else
     {
-        emit requirementsProgress( tr( "System-requirements checking is complete." ) );
+        Q_EMIT requirementsProgress( tr( "System-requirements checking is complete." ) );
     }
 }
 

--- a/src/libcalamaresui/widgets/WaitingWidget.h
+++ b/src/libcalamaresui/widgets/WaitingWidget.h
@@ -32,10 +32,10 @@ public:
     ~WaitingWidget() override;
 };
 
-/** @brief A spinner and a countdown next to it
+/** @brief A spinner and a countdown inside it
  *
  * The spinner is sized to the text-height and displays a
- * numeric countdown next to it. The countdown is updated
+ * numeric countdown iside the spinner. The countdown is updated
  * every second. The signal timeout() is sent every time
  * the countdown reaches 0.
  */

--- a/src/libcalamaresui/widgets/waitingspinnerwidget.h
+++ b/src/libcalamaresui/widgets/waitingspinnerwidget.h
@@ -81,6 +81,10 @@ public:
      * With AlignBottom, the text is displayed below the spinner,
      * centered horizontally relative to the spinner; any other alignment
      * will put the text in the middle of the spinner itself.
+     *
+     * TODO: this does not support rich text. Rich text could be done
+     *       through a QStaticText, or an HTML document. However, then
+     *       we need to do more alignment calculations ourselves.
      */
     void setText( const QString& text );
     /** @brief Sets the alignment of text for the spinner

--- a/src/modules/welcome/checker/CheckerContainer.cpp
+++ b/src/modules/welcome/checker/CheckerContainer.cpp
@@ -71,7 +71,11 @@ CheckerContainer::requirementsComplete( bool ok )
         m_waitingWidget->deleteLater();
         m_waitingWidget = nullptr;  // Don't delete in destructor
     }
-    if ( !m_checkerWidget )
+    if ( m_checkerWidget )
+    {
+        m_checkerWidget->requirementsComplete();
+    }
+    else
     {
         m_checkerWidget = new ResultsListWidget( m_config, this );
         m_checkerWidget->setObjectName( "requirementsChecker" );

--- a/src/modules/welcome/checker/CheckerContainer.cpp
+++ b/src/modules/welcome/checker/CheckerContainer.cpp
@@ -71,16 +71,13 @@ CheckerContainer::requirementsComplete( bool ok )
         m_waitingWidget->deleteLater();
         m_waitingWidget = nullptr;  // Don't delete in destructor
     }
-    if ( m_checkerWidget )
-    {
-        m_checkerWidget->requirementsComplete();
-    }
-    else
+    if ( !m_checkerWidget )
     {
         m_checkerWidget = new ResultsListWidget( m_config, this );
         m_checkerWidget->setObjectName( "requirementsChecker" );
         layout()->addWidget( m_checkerWidget );
     }
+    m_checkerWidget->requirementsComplete();
 
     m_verdict = ok;
 }

--- a/src/modules/welcome/checker/GeneralRequirements.cpp
+++ b/src/modules/welcome/checker/GeneralRequirements.cpp
@@ -228,11 +228,29 @@ GeneralRequirements::checkRequirements()
                                    false,
                                    required } );
         }
+        if ( entry == "slow-false" )
+        {
+            sleep(3);
+            checkEntries.append( { entry,
+                                   [] { return tr( "is always false (slowly)" ); },
+                                   [] { return tr( "The computer says no (slowly)." ); },
+                                   false,
+                                   required } );
+        }
         if ( entry == "true" )
         {
             checkEntries.append( { entry,
                                    [] { return tr( "is always true" ); },
                                    [] { return tr( "The computer says yes." ); },
+                                   true,
+                                   required } );
+        }
+        if ( entry == "slow-true" )
+        {
+            sleep(3);
+            checkEntries.append( { entry,
+                                   [] { return tr( "is always true (slowly)" ); },
+                                   [] { return tr( "The computer says yes (slowly)." ); },
                                    true,
                                    required } );
         }

--- a/src/modules/welcome/checker/ResultsListWidget.cpp
+++ b/src/modules/welcome/checker/ResultsListWidget.cpp
@@ -67,18 +67,25 @@ ResultsListWidget::ResultsListWidget( Config* config, QWidget* parent )
 }
 
 void
-ResultsListWidget::requirementsChanged()
+ResultsListWidget::requirementsComplete()
 {
-    // Check that all are satisfied (gives warnings if not) and
-    // all *mandatory* entries are satisfied (gives errors if not).
-
+    // Check that the satisfaction of the requirements:
+    // - if everything is satisfied, show the welcome image
+    // - otherwise, if all the mandatory ones are satisfied,
+    //   we won't be re-checking (see ModuleManager::checkRequirements)
+    //   so hide the countdown,
+    // - otherwise we have unsatisfied mandatory requirements,
+    //   so keep the countdown and the list of problems.
     const bool requirementsSatisfied = m_config->requirementsModel()->satisfiedRequirements();
+    const bool mandatoryRequirementsSatisfied = m_config->requirementsModel()->satisfiedMandatory();
 
-    if ( requirementsSatisfied )
+    if ( mandatoryRequirementsSatisfied )
     {
         m_countdown->stop();
         m_countdown->hide();
-
+    }
+    if ( requirementsSatisfied )
+    {
         delete m_centralWidget;
         m_centralWidget = nullptr;
 

--- a/src/modules/welcome/checker/ResultsListWidget.h
+++ b/src/modules/welcome/checker/ResultsListWidget.h
@@ -26,10 +26,10 @@ class ResultsListWidget : public QWidget
 public:
     explicit ResultsListWidget( Config* config, QWidget* parent );
 
-private:
-    /// @brief The model of requirements changed
-    void requirementsChanged();
+    /// @brief The model of requirements has finished a round of checking
+    void requirementsComplete();
 
+private:
     Config* m_config = nullptr;
 
     // UI parts, which need updating when the model changes

--- a/src/modules/welcome/welcome.conf
+++ b/src/modules/welcome/welcome.conf
@@ -67,9 +67,13 @@ requirements:
     #
     # Note that the last three checks are for testing-purposes only,
     # and shouldn't be used in production (they are only available
-    # when building Calamares in development mode):
+    # when building Calamares in development mode). There are five
+    # special checks:
     # - *false* is a check that is always false (unsatisfied)
     # - *true* is a check that is always true (satisfied)
+    # - *slow-false* takes 3 seconds, and then is false; use this one to
+    #   show off the waiting-spinner before the first results come in
+    # - *slow-true* takes 3 seconds, and then is true
     # - *snark* is a check that is only satisfied once it has been checked
     #   at least three times ("what I tell you three times is true").
     check:

--- a/src/modules/welcome/welcome.schema.yaml
+++ b/src/modules/welcome/welcome.schema.yaml
@@ -21,10 +21,10 @@ properties:
             internetCheckUrl: { type: string }
             check:
                 type: array
-                items: { type: string, enum: [storage, ram, power, internet, root, screen], unique: true }
+                items: { type: string, enum: [storage, ram, power, internet, root, screen, "false", "true", "slow-false", "slow-true", snark], unique: true }
             required:  # Key-name in the config-file
                 type: array
-                items: { type: string, enum: [storage, ram, power, internet, root, screen], unique: true }
+                items: { type: string, enum: [storage, ram, power, internet, root, screen, "false", "true", "slow-false", "slow-true", snark], unique: true }
         required: [ requiredStorage, requiredRam, check ]  # Schema keyword
 
     # TODO: refactor, this is reused in locale


### PR DESCRIPTION
There was a missing call to update the requirements-list widget when the requirements are done checking. While here, stop the countdown when we know the requirements are not going to be checked again.

FIXES #1974