### PR TITLE
[bootloader] bootLoader GS is always empty for EFI

### DIFF
--- a/src/modules/bootloader/main.py
+++ b/src/modules/bootloader/main.py
@@ -798,12 +798,8 @@ def run():
 
     fw_type = libcalamares.globalstorage.value("firmwareType")
 
-    if libcalamares.globalstorage.value("bootLoader") is None:
-        # Don't want a bootloader, but do log that this has an effect:
-        if fw_type != "efi":
-            libcalamares.utils.warning( "Non-EFI system, and no bootloader is set." )
-        else:
-            libcalamares.utils.warning( "EFI system, and no bootloader is set." )
+    if (libcalamares.globalstorage.value("bootLoader") is None and fw_type != "efi"):
+        libcalamares.utils.warning( "Non-EFI system, and no bootloader is set." )
         return None
 
     partitions = libcalamares.globalstorage.value("partitions")


### PR DESCRIPTION
with https://github.com/calamares/calamares/commit/e15e57600e3df46ea2a14fff6a807fa354553ae1#diff-91818b0ce02fc61c3ff4b136101ee5f632a3a1febc46632dcd1dc4dc4ddc8594L801 the bootloader module will never run for EFI systems. Option to select to install or not install a bootloader is only visible on BIOS systems at this point.
Go back to only using bootLoader value for BIOS systems. This fixes https://github.com/calamares/calamares/issues/1990