### PR TITLE
Consider setting SONAME to major.minor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
 set(CALAMARES_VERSION 3.3.0-alpha1)
+set(CALAMARES_SOVERSION 3.3)
 set(CALAMARES_RELEASE_MODE ON) # Set to ON during a release
 
 if(CMAKE_SCRIPT_MODE_FILE)

--- a/src/libcalamares/CMakeLists.txt
+++ b/src/libcalamares/CMakeLists.txt
@@ -79,7 +79,7 @@ set_target_properties(
     calamares
     PROPERTIES
         VERSION ${CALAMARES_VERSION_SHORT}
-        SOVERSION ${CALAMARES_VERSION_SHORT}
+        SOVERSION ${CALAMARES_SOVERSION}
         INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_INSTALL_FULL_INCLUDEDIR}/libcalamares
 )
 target_link_libraries(calamares LINK_PUBLIC yamlcpp::yamlcpp Qt5::Core KF5::CoreAddons)
@@ -159,7 +159,7 @@ install(
     CODE
         "
     file( MAKE_DIRECTORY \"\$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_LIBDIR}/calamares\" )
-    execute_process( COMMAND \"${CMAKE_COMMAND}\" -E create_symlink ../libcalamares.so.${CALAMARES_VERSION_SHORT} libcalamares.so WORKING_DIRECTORY \"\$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_LIBDIR}/calamares\" )
+    execute_process( COMMAND \"${CMAKE_COMMAND}\" -E create_symlink ../libcalamares.so.${CALAMARES_SOVERSION} libcalamares.so WORKING_DIRECTORY \"\$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_LIBDIR}/calamares\" )
 "
 )
 


### PR DESCRIPTION
This allows Calamares extensions built against a patch version to be run against another patch version. It fixes the mobile (and similar) modules silently breaking when Calamares is independently updated.

Specifically, this should help mitigate issues like https://gitlab.com/mobian1/issues/-/issues/438, where an update from Debian's Calamares breaks all usage of Calamares extensions. Right now we see this issue crop up most months as Calamares and Calamares Extensions are maintained by separate people. 

The commit in this PR implements this, but I'm opening the PR more as a discussion on whether we could make this change in libcalamares than as a preferred way of doing it.

Thanks for considering.