### PR TITLE
Add options in services-systemd module to enable systemd sockets and paths

### DIFF
--- a/src/modules/services-systemd/main.py
+++ b/src/modules/services-systemd/main.py
@@ -61,6 +61,10 @@ def systemctl(targets, command, suffix):
 
                 if command == "enable" and suffix == ".service":
                     description = _("Cannot enable systemd service <code>{name!s}</code>.")
+                elif command == "enable" and suffix == ".socket":
+                    description = _("Cannot enable systemd socket <code>{name!s}</code>.")
+                elif command == "enable" and suffix == ".path":
+                    description = _("Cannot enable systemd path <code>{name!s}</code>.")
                 elif command == "enable" and suffix == ".target":
                     description = _("Cannot enable systemd target <code>{name!s}</code>.")
                 elif command == "enable" and suffix == ".timer":
@@ -92,6 +96,14 @@ def run():
     # http://0pointer.de/blog/projects/changing-roots.html
 
     r = systemctl(cfg.get("services", []), "enable", ".service")
+    if r is not None:
+        return r
+
+    r = systemctl(cfg.get("sockets", []), "enable", ".socket")
+    if r is not None:
+        return r
+
+    r = systemctl(cfg.get("paths", []), "enable", ".path")
     if r is not None:
         return r
 

--- a/src/modules/services-systemd/services-systemd.conf
+++ b/src/modules/services-systemd/services-systemd.conf
@@ -41,6 +41,16 @@
 #   - name: "cups"
 #     mandatory: false
 #
+# # Enables <name>.socket
+# sockets:
+#   - name: "cups"
+#     mandatory: true
+#
+# # Enables <name>.path
+# paths:
+#   - name: "example"
+#     mandatory: true
+#
 # # Enables <name>.target
 # targets:
 #   - name: "graphical"
@@ -72,6 +82,8 @@
 
 # By default, no changes are made.
 services: []
+sockets: []
+paths: []
 targets: []
 timers: []
 disable: []

--- a/src/modules/services-systemd/services-systemd.schema.yaml
+++ b/src/modules/services-systemd/services-systemd.schema.yaml
@@ -18,6 +18,8 @@ additionalProperties: false
 type: object
 properties:
     services: { type: array, items: { $ref: 'definitions/service' } }
+    sockets: { type: array, items: { $ref: 'definitions/service' } }
+    paths: { type: array, items: { $ref: 'definitions/service' } }
     targets: { type: array, items: { $ref: 'definitions/service' } }
     timers: { type: array, items: { $ref: 'definitions/service' } }
     disable: { type: array, items: { $ref: 'definitions/service' } }


### PR DESCRIPTION
Currently the `services-systemd` module does not allow enabling of sockets and paths because suffixes are pre-determined. This PR will not change the existing functionality of the module. It will only add support for enabling sockets and paths.