### PR TITLE
Remove suffix-based grouping in services-systemd

### DIFF
--- a/src/modules/services-systemd/main.py
+++ b/src/modules/services-systemd/main.py
@@ -7,6 +7,7 @@
 #   SPDX-FileCopyrightText: 2014 Teo Mrnjavac <teo@kde.org>
 #   SPDX-FileCopyrightText: 2017 Alf Gaida <agaida@siduction.org>
 #   SPDX-FileCopyrightText: 2018-2019 Adriaan de Groot <groot@kde.org>
+#   SPDX-FileCopyrightText: 2022 shivanandvp <shivanandvp@rebornos.org>
 #   SPDX-License-Identifier: GPL-3.0-or-later
 #
 #   Calamares is Free Software: see the License-Identifier above.
@@ -23,66 +24,59 @@ _ = gettext.translation("calamares-python",
 
 
 def pretty_name():
-    return _("Configure systemd services")
+    return _("Configure systemd units")
 
 
-def systemctl(targets, command, suffix):
+def systemctl(command, units):
     """
-    For each entry in @p targets, run "systemctl <command> <thing>",
-    where <thing> is the entry's name plus the given @p suffix.
-    (No dot is added between name and suffix; suffix may be empty)
+    For each entry in @p units, run "systemctl <command> <thing>",
+    where <thing> is the entry's full name.
 
     Returns a failure message, or None if this was successful.
-    Services that are not mandatory have their failures suppressed
+    Units that are not mandatory have their failures suppressed
     silently.
     """
-    for svc in targets:
-        if isinstance(svc, str):
-            name = svc
+    for unit in units:
+        if isinstance(unit, str):
+            name = unit
             mandatory = False
         else:
-            name = svc["name"]
-            mandatory = svc.get("mandatory", False)
+            name = unit["name"]
+            mandatory = unit.get("mandatory", False)
 
-        ec = libcalamares.utils.target_env_call(
-            ['systemctl', command, "{}{}".format(name, suffix)]
+        exit_code = libcalamares.utils.target_env_call(
+            ['systemctl', command, name]
             )
 
-        if ec != 0:
+        if exit_code != 0:
             libcalamares.utils.warning(
-                "Cannot {} systemd {} {}".format(command, suffix, name)
+                "Cannot {} systemd unit {}".format(command, name)
                 )
             libcalamares.utils.warning(
-                "systemctl {} call in chroot returned error code {}".format(command, ec)
+                "systemctl {} call in chroot returned error code {}".format(command, exit_code)
                 )
             if mandatory:
-                title = _("Cannot modify service")
-                diagnostic = _("<code>systemctl {arg!s}</code> call in chroot returned error code {num!s}.").format(arg=command, num=ec)
+                title = _("Cannot modify unit")
+                diagnostic = _("<code>systemctl {arg!s}</code> call in chroot returned error code {num!s}.").format(arg=command, num=exit_code)
 
-                if command == "enable" and suffix == ".service":
-                    description = _("Cannot enable systemd service <code>{name!s}</code>.")
-                elif command == "enable" and suffix == ".target":
-                    description = _("Cannot enable systemd target <code>{name!s}</code>.")
-                elif command == "enable" and suffix == ".timer":
-                    description = _("Cannot enable systemd timer <code>{name!s}</code>.")
-                elif command == "disable" and suffix == ".service":
-                    description = _("Cannot enable systemd service <code>{name!s}</code>.")
-                elif command == "disable" and suffix == ".target":
-                    description = _("Cannot disable systemd target <code>{name!s}</code>.")
+                if command == "enable":
+                    description = _("Cannot enable systemd unit <code>{name!s}</code>.")
+                elif command == "disable":
+                    description = _("Cannot disable systemd unit <code>{name!s}</code>.")
                 elif command == "mask":
                     description = _("Cannot mask systemd unit <code>{name!s}</code>.")
                 else:
-                    description = _("Unknown systemd commands <code>{command!s}</code> and <code>{suffix!s}</code> for unit {name!s}.")
+                    description = _("Unknown systemd commands <code>{command!s}</code> for unit {name!s}.")
 
                 return (title,
-                        description.format(name=name, command=command, suffix=suffix) + " " + diagnostic
+                        description.format(name=name, command=command) + " " + diagnostic
                         )
     return None
 
 
 def run():
     """
-    Setup systemd services
+    Setup systemd units
     """
     cfg = libcalamares.job.configuration
 
@@ -91,27 +85,15 @@ def run():
     # that support that, see:
     # http://0pointer.de/blog/projects/changing-roots.html
 
-    r = systemctl(cfg.get("services", []), "enable", ".service")
+    r = systemctl("enable", cfg.get("enable", []))
     if r is not None:
         return r
 
-    r = systemctl(cfg.get("targets", []), "enable", ".target")
+    r = systemctl("disable", cfg.get("disable", []))
     if r is not None:
         return r
 
-    r = systemctl(cfg.get("timers", []), "enable", ".timer")
-    if r is not None:
-        return r
-
-    r = systemctl(cfg.get("disable", []), "disable", ".service")
-    if r is not None:
-        return r
-
-    r = systemctl(cfg.get("disable-targets", []), "disable", ".target")
-    if r is not None:
-        return r
-
-    r = systemctl(cfg.get("mask", []), "mask", "")
+    r = systemctl("mask", cfg.get("mask", []))
     if r is not None:
         return r
 

--- a/src/modules/services-systemd/services-systemd.conf
+++ b/src/modules/services-systemd/services-systemd.conf
@@ -3,20 +3,20 @@
 #
 # Systemd services manipulation.
 #
-# This module can enable services, timers and targets for systemd
-# (if packaging doesn't already do that). It can also
-# disable services and targets as well as mask units.
+# This module can enable units (like services, sockets, paths, etc.) for
+# systemd (if packaging doesn't already do that). It can also disable or mask
+# units.
 #
-# The order of operations is fixed.  Enable services, enable targets,
-# enable timers, disable services, disable targets and finally apply masks.
+# The order of operations is fixed. Enable units, disable units, and finally
+# apply masks.
 ---
 
-# There are several configuration keys for this module:
-# *services*, *targets*, *timers*, *disable*, *disable-targets* and *mask*.
+# There are three configuration keys for this module:
+# *enable*, *disable*, and *mask*.
 # The value of each key is a list of entries. Each entry has two keys:
-#   - *name* is the (string) name of the service or target that is being
-#     changed. Use quotes. Don't include unit suffix in the name. For
-#     example, it should be "NetworkManager", not "NetworkManager.service"
+#   - *name* is the (string) name of the unit that is being changed.
+#     Use quotes. Please include unit suffix in the name. For example,
+#     it should be "NetworkManager.service", not "NetworkManager".
 #   - *mandatory* is a boolean option, which states whether the change
 #     must be done successfully. If systemd reports an error while changing
 #     a mandatory entry, the installation will fail. When mandatory is false,
@@ -29,51 +29,26 @@
 #
 # Use [] to express an empty list.
 
-# # This example enables NetworkManager (and fails if it can't),
-# # disables cups (and ignores failure). Then it enables the
-# # graphical target (e.g. so that SDDM runs for login), and
-# # finally disables pacman-init (an ArchLinux-only service).
+# # This example enables the NetworkManager service (and fails if it can't),
+# # enables cups socket (and ignores failure), disables pacman-init
+# # (an ArchLinux-only service), and finally masks bluetooth.service.
 # #
-# # Enables <name>.service
-# services:
-#   - name: "NetworkManager"
+# enable:
+#   - name: "NetworkManager.service"
 #     mandatory: true
-#   - name: "cups"
+#   - name: "cups.socket"
 #     mandatory: false
 #
-# # Enables <name>.target
-# targets:
-#   - name: "graphical"
-#     mandatory: true
-#
-# # Enables <name>.timer
-# timers:
-#   - name: "fstrim"
-#     mandatory: false
-#
-# # Disables <name>.service
 # disable:
-#   - name: "pacman-init"
+#   - name: "pacman-init.service"
 #     mandatory: false
 #
-# # Disables <name>.target
-# #     .. this shows how to use just the name
-# disable-targets:
-#   - graphical
-#
-# # Masks (stronger version of disable). This section
-# # is unusual because you **must** include the suffix
-# # (e.g. ".service") as part of the name, so, e.g. to mask
-# # NetworkManager (rather than just disable it) you must
-# # specify "NetworkManager.service" as name.
+# # Masks (stronger version of disable). 
 # mask:
-#  - name: "NetworkManager.service"
-#  - mandatory: true
+#   - name: "bluetooth.service"
+#     mandatory: true
 
 # By default, no changes are made.
-services: []
-targets: []
-timers: []
+enable: []
 disable: []
-disable-targets: []
 mask: []

--- a/src/modules/services-systemd/services-systemd.schema.yaml
+++ b/src/modules/services-systemd/services-systemd.schema.yaml
@@ -4,8 +4,8 @@
 $schema: https://json-schema.org/schema#
 $id: https://calamares.io/schemas/services-systemd
 definitions:
-    service:
-        $id: 'definitions/service'
+    unit:
+        $id: 'definitions/unit'
         type: object
         description: a name and a flag for services, targets, and others
         additionalProperties: false
@@ -17,9 +17,6 @@ definitions:
 additionalProperties: false
 type: object
 properties:
-    services: { type: array, items: { $ref: 'definitions/service' } }
-    targets: { type: array, items: { $ref: 'definitions/service' } }
-    timers: { type: array, items: { $ref: 'definitions/service' } }
-    disable: { type: array, items: { $ref: 'definitions/service' } }
-    disable-targets: { type: array, items: { $ref: 'definitions/service' } }
-    mask: { type: array, items: { $ref: 'definitions/service' } }
+    enable: { type: array, items: { $ref: 'definitions/unit' } }
+    disable: { type: array, items: { $ref: 'definitions/unit' } }
+    mask: { type: array, items: { $ref: 'definitions/unit' } }


### PR DESCRIPTION
The explicit grouping of *systemd* units by **suffix** in the `services-systemd` module gave rise to the problems of 
- Proliferation of configuration options per suffix
- The need to manually add unit types (like systemd sockets and paths) per suffix

This pull request intends to eliminate *suffix-based* grouping altogether so that in the configuration file, users can just group units by `enable`, `disable`, or `mask`. `mask` is an existing example of such a suffix-less group and the rest of the actions (namely `enable`, and `disable`) follow the conventions used in the implementation of `mask`. The corresponding log messages, schema file, and configuration file (along with the documentation) are also modified.

In addition to the above main goal, there are other minor changes such as renaming the multiple names that units were referred by (some example terms used in main.py are `svcs`, and `targets` in the systemctl function parameter list), to a uniform term: *units*. This is distinct from the earlier *suffix* (also named `target`) that is already obsoleted. And the parameter list of the `systemctl` function is re-ordered to mirror command invocation in a shell: `systemctl <action> <unit>` -> `systemctl(command, units)` to prevent potential errors due to the unintuitive ordering