### PR TITLE
Fix build error: ‘availableTranslations’ is not a member of ‘CalamaresUtils::Locale’ #2021

### DIFF
--- a/src/modules/packagechooser/ItemAppStream.cpp
+++ b/src/modules/packagechooser/ItemAppStream.cpp
@@ -72,7 +72,7 @@ fromComponent( AppStream::Component& component )
     map.insert( "name", en_name );
     map.insert( "description", en_description );
 
-    for ( const QString& locale : CalamaresUtils::Locale::availableTranslations()->localeIds() )
+    for ( const QString& locale : Calamares::Locale::availableTranslations()->localeIds() )
     {
         component.setActiveLocale( locale );
         QString name = component.name();


### PR DESCRIPTION
This PR fixes issue #2021.