### PR TITLE
Update services-systemd.conf

### DIFF
--- a/src/modules/services-systemd/services-systemd.conf
+++ b/src/modules/services-systemd/services-systemd.conf
@@ -37,7 +37,8 @@
 #
 #   - name: "cups.socket"
 #     action: "disable" 
-#     mandatory: false
+#     # The property "mandatory" is taken to be false by default here
+#     # because it is not specified
 #
 #   - name: "graphical"
 #     action: "enable" 


### PR DESCRIPTION
removing mandatory: false from example for cups-socket as it is default same as for the other two (could confuse about may disable needs to set it? )