### PR TITLE
fix initcpiocfg filesystems loop

### DIFF
--- a/src/modules/initcpiocfg/main.py
+++ b/src/modules/initcpiocfg/main.py
@@ -169,8 +169,6 @@ def find_initcpio_features(partitions, root_mount_point):
         hooks.append("plymouth")
 
     for partition in partitions:
-        hooks.extend(["filesystems"])
-
         if partition["fs"] == "linuxswap" and not partition.get("claimed", None):
             # Skip foreign swap
             continue
@@ -218,9 +216,11 @@ def find_initcpio_features(partitions, root_mount_point):
         hooks.append("zfs")
 
     if swap_uuid != "":
-        hooks.extend(["resume"])
         if encrypt_hook and openswap_hook:
             hooks.extend(["openswap"])
+        hooks.extend(["resume", "filesystems"])
+    else:
+        hooks.extend(["filesystems"])
 
     if uses_btrfs:
         modules.append("crc32c-intel" if cpuinfo().is_intel else "crc32c")


### PR DESCRIPTION
Fixes current issue, that initcpiocfg does add several filesystems into mkinitcpio.conf

Signed-off-by: Peter Jung <admin@ptr1337.dev>