### PR TITLE
[netinstall] "Noncheckable" option for netinstall package groups

### DIFF
--- a/src/modules/netinstall/PackageModel.cpp
+++ b/src/modules/netinstall/PackageModel.cpp
@@ -188,7 +188,7 @@ PackageModel::flags( const QModelIndex& index ) const
     if ( index.column() == NameColumn )
     {
         PackageTreeItem* item = static_cast< PackageTreeItem* >( index.internalPointer() );
-        if ( item->isImmutable() )
+        if ( item->isImmutable() || item->isNoncheckable() )
         {
             return QAbstractItemModel::flags( index );  //Qt::NoItemFlags;
         }

--- a/src/modules/netinstall/PackageTreeItem.cpp
+++ b/src/modules/netinstall/PackageTreeItem.cpp
@@ -49,6 +49,7 @@ PackageTreeItem::PackageTreeItem( const QString& packageName, PackageTreeItem* p
     , m_isGroup( false )
     , m_isCritical( parent ? parent->isCritical() : false )
     , m_showReadOnly( parent ? parent->isImmutable() : false )
+    , m_showNoncheckable( false )
 {
 }
 
@@ -60,6 +61,7 @@ PackageTreeItem::PackageTreeItem( const QVariantMap& groupData, PackageTag&& par
     , m_isGroup( false )
     , m_isCritical( parent.parent ? parent.parent->isCritical() : false )
     , m_showReadOnly( parent.parent ? parent.parent->isImmutable() : false )
+    , m_showNoncheckable( false )
 {
 }
 
@@ -75,6 +77,7 @@ PackageTreeItem::PackageTreeItem( const QVariantMap& groupData, GroupTag&& paren
     , m_isCritical( parentCriticality( groupData, parent.parent ) )
     , m_isHidden( CalamaresUtils::getBool( groupData, "hidden", false ) )
     , m_showReadOnly( CalamaresUtils::getBool( groupData, "immutable", false ) )
+    , m_showNoncheckable( CalamaresUtils::getBool( groupData, "noncheckable", false ) )
     , m_startExpanded( CalamaresUtils::getBool( groupData, "expanded", false ) )
 {
 }

--- a/src/modules/netinstall/PackageTreeItem.h
+++ b/src/modules/netinstall/PackageTreeItem.h
@@ -109,6 +109,13 @@ public:
      */
     bool isImmutable() const { return m_showReadOnly; }
 
+    /** @brief Is this a non-checkable item?
+     *
+     * Groups can be non-checkable: then you can't toggle the selected
+     * state of the group. This does not affect subgroups or packages.
+     */
+    bool isNoncheckable() const { return m_showNoncheckable; }
+
     /** @brief is this item selected?
      *
      * Groups may be partially selected; packages are only on or off.
@@ -165,6 +172,7 @@ private:
     bool m_isCritical = false;
     bool m_isHidden = false;
     bool m_showReadOnly = false;
+    bool m_showNoncheckable = false;
     bool m_startExpanded = false;
 };
 

--- a/src/modules/netinstall/netinstall.conf
+++ b/src/modules/netinstall/netinstall.conf
@@ -183,6 +183,9 @@ label:
 #    really only makes sense in combination with *selected* set to true,
 #    so that the packages will be installed. (Setting a group to immutable
 #    can be seen as removing it from the user-interface.)
+#  - *noncheckable*: if true, the entire group cannot be selected or
+#    deselected by a single click. This does not affect any subgroups 
+#    or child packages 
 #  - *expanded*: if true, the group is shown in an expanded form (that is,
 #    not-collapsed) in the treeview on start. This only affects the user-
 #    interface. Only top-level groups are show expanded-initially.

--- a/src/modules/netinstall/netinstall.schema.yaml
+++ b/src/modules/netinstall/netinstall.schema.yaml
@@ -33,6 +33,7 @@ definitions:
             selected: { type: boolean }
             critical: { type: boolean, default: false }
             immutable: { type: boolean }
+            noncheckable: { type: boolean }
             expanded: { type: boolean }
             subgroups:
                 type: array


### PR DESCRIPTION
The "Noncheckable" option, when true prevents a user from checking the whole group. This does not affect whether any child subgroups or packages can be selected or not

No breaking changes