### PR TITLE
[dracut][zfs] adding hostid

### DIFF
--- a/CHANGES-3.3
+++ b/CHANGES-3.3
@@ -29,13 +29,15 @@ This release contains contributions from (alphabetically by first name):
 
 ## Modules ##
  - *dracut* added a configurable kernel name. (thanks Anke)
+ - *dracut* copies hostid file, when ZFS is in use.
  - *initcpiocfg* orders hookds slightly differently. (thanks Peter)
  - *localeq* moved to using Drawer instead of ComboBox in UI. (thanks Anke)
  - *keyboardq* moved to using Drawer instead of ComboBox in UI. (thanks Anke)
  - *netinstall* now has a new *noncheckable* option for groups, which prevent
    it a group from being checked/uncheckd as a whole. You can still check
    individual items **in** the group though. (thanks Shivanand)
-- *partition* can now pick LUKS or LUKS2. (thanks Jeremy)
+ - *partition* can now pick LUKS or LUKS2. (thanks Jeremy)
+ - *zfs* creates a hostid through zgenhostid.
 
 
 # 3.3.0-alpha2 (2022-08-23)

--- a/src/modules/dracut/main.py
+++ b/src/modules/dracut/main.py
@@ -13,6 +13,8 @@
 #   Calamares is Free Software: see the License-Identifier above.
 #
 
+import os
+import shutil
 import libcalamares
 from libcalamares.utils import check_target_env_call
 
@@ -35,6 +37,19 @@ def run_dracut():
     :return:
     """
     kernelName = libcalamares.job.configuration['kernelName']
+    zfs = libcalamares.globalstorage.value("zfsDatasets")
+    root_mount_point = libcalamares.globalstorage.value("rootMountPoint")
+
+    if zfs:
+        hostid_source = '/etc/hostid'
+        hostid_destination = '{!s}/etc/hostid'.format(root_mount_point)
+
+        # copy hostid before kernel image creation with zfs
+        if os.path.exists(hostid_source):
+            try:
+                shutil.copy2(hostid_source, hostid_destination)
+            except Exception as e:
+                libcalamares.utils.warning("Could not copy hostid")
 
     if not kernelName:
         return check_target_env_call(['dracut', '-f'])

--- a/src/modules/zfs/ZfsJob.cpp
+++ b/src/modules/zfs/ZfsJob.cpp
@@ -241,6 +241,13 @@ ZfsJob::exec()
             }
         }
 
+        // Generate the zfs hostid file
+        auto i = system->runCommand( { "zgenhostid" }, std::chrono::seconds( 3 ) );
+        if ( i.getExitCode() != 0 )
+        {
+            cWarning() << "Failed to create /etc/hostid";
+        }
+
         // Create the zpool
         ZfsResult zfsResult;
         if ( encrypt )


### PR DESCRIPTION
using ZFS in combination with dracut exposed a bug on system updates hostid from the Live session does not match hostid installed, thus zpool id no longer matches id created by dracut in the kernel img
to work around this, the zfs module now uses zgenhostid to create a hostid, which is later copied, using the dracut module.
if this issue is never encountered using mkinitcpio, it might be best to close this PR otherwise, a better place to copy /etc/hostid need to be found.