### PR TITLE
[dracut] Change image name terminology to match dracut

### DIFF
--- a/src/modules/dracut/dracut.conf
+++ b/src/modules/dracut/dracut.conf
@@ -5,6 +5,6 @@
 ---
 # Dracut defaults to setting initramfs-<kernel-version>.img
 # If you want to specify another filename for the resulting image,
-# set a custom kernel name, including the path
+# set a custom name, including the path
 #
-# kernelName: /boot/initramfs-linux.img
+# initramfsName: /boot/initramfs-linux.img

--- a/src/modules/dracut/dracut.schema.yaml
+++ b/src/modules/dracut/dracut.schema.yaml
@@ -6,4 +6,4 @@ $id: https://calamares.io/schemas/dracut
 additionalProperties: false
 type: object
 properties:
-    kernelName: { type: string }
+    initramfsName: { type: string }

--- a/src/modules/dracut/main.py
+++ b/src/modules/dracut/main.py
@@ -42,11 +42,13 @@ def run_dracut():
         try:
             target_env_process_output(['dracut', '-f'])
         except subprocess.CalledProcessError as cpe:
-            return cpe.returncode, cpe.output
+            libcalamares.utils.warning(f"Dracut failed with output: {cpe.output}")
+            return cpe.returncode
     except subprocess.CalledProcessError as cpe:
-        return cpe.returncode, cpe.output
+        libcalamares.utils.warning(f"Dracut failed with output: {cpe.output}")
+        return cpe.returncode
 
-    return 0, None
+    return 0
 
 
 def run():
@@ -56,8 +58,7 @@ def run():
 
     :return:
     """
-    return_code, output = run_dracut()
+    return_code = run_dracut()
     if return_code != 0:
-        libcalamares.utils.warning(f"Dracut failed with output: {output}")
         return (_("Failed to run dracut"),
-                _(f"Dracut failed with on the target with return code: {return_code}"))
+                _(f"Dracut failed to run on the target with return code: {return_code}"))

--- a/src/modules/dracut/main.py
+++ b/src/modules/dracut/main.py
@@ -34,12 +34,12 @@ def run_dracut():
 
     :return:
     """
-    kernelName = libcalamares.job.configuration['kernelName']
+    initramfs_name = libcalamares.job.configuration['initramfsName']
 
-    if not kernelName:
+    if not initramfs_name:
         return check_target_env_call(['dracut', '-f'])
     else:
-        return check_target_env_call(['dracut', '-f', '{}'.format(kernelName)])
+        return check_target_env_call(['dracut', '-f', initramfs_name])
 
 
 def run():
@@ -53,4 +53,4 @@ def run():
 
     if return_code != 0:
         return (_("Failed to run dracut on the target"),
-                _("The exit code was {}").format(return_code))
+                _(f"The exit code was {return_code}"))


### PR DESCRIPTION
A recently introduced change to the dracut module added a config option named `kernelName`.  However, what it represented was not the name of the kernel, but the name of the output image.

This PR changes the terminology to match what dracut uses, "initramfs".