### PR TITLE
[umount] Change default config for emergency to true

### DIFF
--- a/src/modules/umount/umount.conf
+++ b/src/modules/umount/umount.conf
@@ -11,4 +11,4 @@
 ---
 # Setting emergency to true will make it so this module is still run
 # when a prior module fails
-emergency: false
+emergency: true


### PR DESCRIPTION
When the umount module was rewritten to C++ the default state of emergency was switched from true to false.

The umount module should really be emergency by default since in 99% of cases you would want it to run in that scenario.