### PR TITLE
[zfs] make the zfs module require zfshostid

### DIFF
--- a/src/modules/zfs/CMakeLists.txt
+++ b/src/modules/zfs/CMakeLists.txt
@@ -9,4 +9,5 @@ calamares_add_plugin(zfs
     SOURCES
         ZfsJob.cpp
     SHARED_LIB
+    REQUIRES zfshostid
 )


### PR DESCRIPTION
with https://github.com/calamares/calamares/commit/1b96832bf7e60a849119975adcb5fa7959e05e3e a unique hostid is created, used during zpool creation, when that hostid file is not copied to the new install, the mismatch in hostid call will create boot issues, thus the zfshostid module is now required