### PR TITLE
Don't install default settings.conf to CMAKE_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -585,9 +585,6 @@ install(
 ### Miscellaneous installs
 #
 #
-if( settings.conf IS_NEWER_THAN ${CMAKE_BINARY_DIR}/settings.conf )
-    install(FILES settings.conf DESTINATION ${CMAKE_BINARY_DIR})
-endif()
 
 if(INSTALL_POLKIT)
     install(FILES com.github.calamares.calamares.policy DESTINATION "${POLKITQT-1_POLICY_FILES_INSTALL_DIR}")


### PR DESCRIPTION
Installing a default `settings.conf` to `CMAKE_BINARY_DIR` causes packaging challenges.

I am proposing removing this because I don't have visibility into the situation that would require this.  If there is a need for this behavior, I think it should not be the default and require an option to enable it.

This fixes https://github.com/calamares/calamares/issues/2075.