### PR TITLE
Add "kms" hook to initcpiocfg

### DIFF
--- a/src/modules/initcpiocfg/main.py
+++ b/src/modules/initcpiocfg/main.py
@@ -146,8 +146,8 @@ def find_initcpio_features(partitions, root_mount_point):
     hooks = [
         "base",
         "udev",
-        "kms",
         "autodetect",
+        "kms",
         "modconf",
         "block",
         "keyboard",

--- a/src/modules/initcpiocfg/main.py
+++ b/src/modules/initcpiocfg/main.py
@@ -146,6 +146,7 @@ def find_initcpio_features(partitions, root_mount_point):
     hooks = [
         "base",
         "udev",
+        "kms",
         "autodetect",
         "modconf",
         "block",


### PR DESCRIPTION
The "kms" hook got added with commit¹ to the default hooks array. Follow the archlinux defaults and add it also.

1. https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/commit/b99eb1c0d5704ed0a0d220d0abcbbbeec10a3b76

Signed-off-by: Peter Jung <admin@ptr1337.dev>