### PR TITLE
Add refind, bootloader selection and general improvements

### DIFF
--- a/src/modules/bootloader/bootloader.conf
+++ b/src/modules/bootloader/bootloader.conf
@@ -9,25 +9,31 @@
 # should specifically set *efiBootloaderId* to "debian" because that is
 # hard-coded in `grubx64.efi`.
 ---
+# A variable from global storage which overrides the value of efiBootLoader
+#efiBootLoaderVar: "packagechooser_bootloader"
+
 # Define which bootloader you want to use for EFI installations
 # Possible options are 'grub', 'sb-shim' and 'systemd-boot'.
 efiBootLoader: "grub"
 
-# systemd-boot configuration files settings, set kernel search path, kernel name
-# and amount of time before default selection boots
+# systemd-boot configuration files settings
+
+# kernelSearchPath is the path relative to the root of the install to search for kernels
+# A kernel is identified by finding files which match regular expression, kernelPattern
 kernelSearchPath: "/usr/lib/modules"
-kernelName: "vmlinuz"
-timeout: "10"
+kernelPattern: "^vmlinuz.*"
 
-# additionalInitrdFiles is a comma seperated list of file names
-additionalInitrdFiles:
-    - "/boot/amd-ucode"
-    - "/boot/intel-ucode"
+# loaderEntries is an array of options to add to loader.conf for systemd-boot
+# please note that the "default" option is added programmatically
+loaderEntries:
+  - "timeout 5"
+  - "console-mode keep"
 
-# Optionally set the menu entry name to use in systemd-boot.
-# If not specified here, these settings will be taken from branding.desc.
-#
-# bootloaderEntryName: "Generic GNU/Linux"
+# systemd-boot and refind support custom kernel params
+kernelParams: [ "quiet" ]
+
+# A list of kernel names that refind should accept as kernels
+#refindKernelList: [ "linux","linux-lts","linux-zen","linux-hardened" ]
 
 # GRUB 2 binary names and boot directory
 # Some distributions (e.g. Fedora) use grub2-* (resp. /boot/grub2/) names.

--- a/src/modules/bootloader/bootloader.conf
+++ b/src/modules/bootloader/bootloader.conf
@@ -13,7 +13,7 @@
 #efiBootLoaderVar: "packagechooser_bootloader"
 
 # Define which bootloader you want to use for EFI installations
-# Possible options are 'grub', 'sb-shim' and 'systemd-boot'.
+# Possible options are 'grub', 'sb-shim', 'refind` and 'systemd-boot'.
 efiBootLoader: "grub"
 
 # systemd-boot configuration files settings

--- a/src/modules/bootloader/bootloader.schema.yaml
+++ b/src/modules/bootloader/bootloader.schema.yaml
@@ -6,17 +6,13 @@ $id: https://calamares.io/schemas/bootloader
 additionalProperties: false
 type: object
 properties:
+    efiBootLoaderVar: { type: string }
     efiBootLoader: { type: string }
     kernelSearchPath:  { type: string }
     kernelName:  { type: string }
-    timeout:  { type: string }  # Inserted verbatim
-    additionalInitrdFiles:
-        type: array
-        items:
-            type: string
-    bootloaderEntryName:  { type: string }
-    kernelLine:  { type: string }
-    fallbackKernelLine:  { type: string }
+    kernelParams: { type: array, items: { type: string } }
+    loaderEntries: { type: array, items: { type: string } }
+    refindKernelList: { type: array, items: { type: string } }
 
     # Programs
     grubInstall:  { type: string }
@@ -27,12 +23,3 @@ properties:
 
     efiBootloaderId:  { type: string }
     installEFIFallback: { type: boolean }
-
-required:
-    - efiBootLoader
-    - kernelSearchPath
-    - kernelName
-    - grubInstall
-    - grubMkconfig
-    - grubCfg
-    - grubProbe


### PR DESCRIPTION
This PR represents several changes and improvements to the existing bootloader module
* Adds support for refind
* Modifies the kernel option building for systemd-boot and refind to be more in-line with the way options are built for grub
* Adds the ability to optionally select a bootloader dynamically via a global storage variable
* Changes the systemd-boot to call `kernel-install`, prior to this, it was installing in a kernel-install compatible fashion manually.  This has a number of implications:
	* It is much more distro agnostic as `kernel-install` will automatically do the right thing for the specific distro
	* It moves a few configuration items to systemd such as kernel names and entry names, this makes it further distro agnostic
	* It allows for the full suite of customization offered by `kernel-install`  in addition to what Calamares offers
	* It is more "future proof" as Calamares no longer needs to mirror changes in systemd(because `kernel-install` is part of systemd)
* Adds support for customization the `loader.conf` for systemd-boot
* Adds functionality for using flexibile kernel matching sematics for systemd-boot
* Adds support for configuring kernel options for systemd-boot and refind(this is already supported for grub)
* Fix zfs support for dracut

These changes have been tested extensively over the last 30 days.