### PR TITLE
[partition] Restore encryption option to alongside and replace options

### DIFF
--- a/src/modules/partition/gui/ChoicePage.cpp
+++ b/src/modules/partition/gui/ChoicePage.cpp
@@ -1741,5 +1741,7 @@ ChoicePage::shouldShowEncryptWidget( Config::InstallChoice choice ) const
     // If there are any choices for FS, check it's not ZFS because that doesn't
     // support the kind of encryption we enable here.
     const bool suitableFS = m_eraseFsTypesChoiceComboBox ? m_eraseFsTypesChoiceComboBox->currentText() != "zfs" : true;
-    return ( choice == InstallChoice::Erase ) && m_enableEncryptionWidget && suitableFS;
+    const bool suitableChoice
+        = choice == InstallChoice::Erase || choice == InstallChoice::Alongside || choice == InstallChoice::Replace;
+    return suitableChoice && m_enableEncryptionWidget && suitableFS;
 }


### PR DESCRIPTION
The option to encrypt was inadvertently removed for replace partition and install alongside in a previous PR.

This restores those options.