### PR TITLE
Allow overriding greetd user/group

### DIFF
--- a/src/modules/displaymanager/displaymanager.conf
+++ b/src/modules/displaymanager/displaymanager.conf
@@ -59,3 +59,11 @@ basicSetup: false
 # *displaymanagers* list (as the only one).
 #
 sysconfigSetup: false
+
+# Some DMs have specific settings. These can be customized here.
+#
+# greetd has configurable user and group; the user and group is created if it
+# does not exist, and the user is set as default-session user.
+greetd:
+  greeter_user: "tom_bombadil"
+  greeter_group: "wheel"

--- a/src/modules/displaymanager/displaymanager.schema.yaml
+++ b/src/modules/displaymanager/displaymanager.schema.yaml
@@ -20,3 +20,10 @@ properties:
         required: [ executable, desktopFile ]
     basicSetup: { type: boolean, default: false }
     sysconfigSetup: { type: boolean, default: false }
+    greetd:
+        type: object
+        properties:
+            greeter_user: { type: string }
+            greeter_group: { type: string }
+        additionalProperties: false
+

--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -983,6 +983,11 @@ def run():
     # Do the actual configuration and collect messages
     dm_setup_message = []
     for dm in dm_impl:
+        dm_specific_configuration = libcalamares.job.configuration.get(dm.name, None)
+        if dm_specific_configuration and isinstance(dm_specific_configuration, dict):
+            for k, v in dm_specific_configuration.items():
+                if hasattr(dm, k):
+                    setattr(dm, k, v)
         dm_message = None
         if enable_basic_setup:
             dm_message = dm.basic_setup()


### PR DESCRIPTION
See #2090 

This is a general mechanism: any DM-field internally may be overwritten. The schema constrains this to be sensible, but the code right now allows anything (e.g. `sddm: basic_setup: 1` will replace the setup function with an integer, which will explode at runtime).