### PR TITLE
gtkgreet: disable window decoration in Cage

### DIFF
--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -828,7 +828,7 @@ class DMgreetd(DisplayManager):
 
         de_command = default_desktop_environment.executable
         if os.path.exists(self.os_path("usr/bin/gtkgreet")) and os.path.exists(self.os_path("usr/bin/cage")):
-            self.config_data['default_session']['command'] = "cage -s -- gtkgreet"
+            self.config_data['default_session']['command'] = "cage -d -s -- gtkgreet"
         elif os.path.exists(self.os_path("usr/bin/tuigreet")):
             tuigreet_base_cmd = "tuigreet --remember --time --issue --asterisks --cmd "
             self.config_data['default_session']['command'] = tuigreet_base_cmd + de_command


### PR DESCRIPTION
Cage is lacking support for `wlr-layer-shell-unstable` protocol, so `gtkgreet` is run using `xdg-shell`. Howewer, `gtkgreet` has a window decoration, so passing a `-d` option to Cage disable it.

Before: 
![2023-02-06T17:17:49,523693719+04:00](https://user-images.githubusercontent.com/11344982/216981388-e6c2b8d3-e143-46dc-88d5-3d6523790ed9.png)

After: 
![2023-02-06T17:18:30,720512185+04:00](https://user-images.githubusercontent.com/11344982/216981518-67e37ec6-c9ae-49fa-bba5-8dcd500896cf.png)
