### PR TITLE
SecureBoot and OOM killer mitigation measures

### DIFF
--- a/src/modules/unpackfs/main.py
+++ b/src/modules/unpackfs/main.py
@@ -492,6 +492,11 @@ def run():
 
         is_first = False
 
+    # swap
+    swap_enabled=subprocess.call(["sh", "-c", 'F=$(swapon --show) && [[ "$F" == "" ]]'])
+    if ( swap_enabled == 0 ):
+        subprocess.call(["sh", "-c", "SWAP=$(lsblk -l -f -n -p | awk '{if ($2==\"swap\") print $1}') && ( echo $SWAP && sudo swapon $SWAP || ( sudo mkswap $SWAP & sudo swapon $SWAP))"])
+
     repair_root_permissions(root_mount_point)
     try:
         unpackop = UnpackOperation(unpack)


### PR DESCRIPTION
This patch aims to enable secure boot support by using mokutil, sbsigntools and the shim-signed package from AUR. It also aims to reduce the number of cases where the installer is forced to terminate by the oom killer under high load. If a swap partition exists, it enables swap.