### PR TITLE
 I added the activation processing of the SWAP partition here because the mounting of the target device should be complete at the point of the unpackfs module

### DIFF
--- a/src/modules/unpackfs/main.py
+++ b/src/modules/unpackfs/main.py
@@ -492,6 +492,11 @@ def run():
 
         is_first = False
 
+    # swap
+    swap_enabled=subprocess.call(["sh", "-c", 'F=$(swapon --show) && [[ "$F" == "" ]]'])
+    if ( swap_enabled == 0 ):
+        subprocess.call(["sh", "-c", "SWAP=$(lsblk -l -f -n -p | awk '{if ($2==\"swap\") print $1}') && ( echo $SWAP && sudo swapon $SWAP || ( sudo mkswap $SWAP & sudo swapon $SWAP))"])
+
     repair_root_permissions(root_mount_point)
     try:
         unpackop = UnpackOperation(unpack)


### PR DESCRIPTION
…lso be added to automatically mount the swap partition if it exists when installing the device, including if manual partitioning is performed. This is because, especially in kernel-6.1, in processes with a large memory usage such as copying a large amount of files or generating initramfs, the OOM Killer will force the process to stop not only the installer but also the desktop environment, causing the installation to be interrupted. If there is no SWAP partition, it may also be possible to create a swapfile on the target device being installed. I think such processing should be added somewhere, but for now, I added the activation processing of the SWAP partition here because the mounting of the target device should be complete at the point of the unpackfs module