### PR TITLE
During installation, if a swap partition exists, enable swap.

### DIFF
--- a/src/modules/unpackfs/main.py
+++ b/src/modules/unpackfs/main.py
@@ -492,6 +492,11 @@ def run():
 
         is_first = False
 
+    # swap
+    swap_enabled=subprocess.call(["sh", "-c", 'F=$(swapon --show) && [[ "$F" == "" ]]'])
+    if ( swap_enabled == 0 ):
+        subprocess.call(["sh", "-c", "SWAP=$(lsblk -l -f -n -p | awk '{if ($2==\"swap\") print $1}') && ( echo $SWAP && sudo swapon $SWAP || ( sudo mkswap $SWAP & sudo swapon $SWAP))"])
+
     repair_root_permissions(root_mount_point)
     try:
         unpackop = UnpackOperation(unpack)


### PR DESCRIPTION
If there is no swap at all when the partition of the installation destination device is mounted, if a Swap partition exists, enable swap. target_env_call cannot be used because it is before the files are copied to the installation destination. host_env_process_output cannot be used because the return value cannot be obtained. To avoid reinventing the wheel as much as possible, use subprocess.check_output.