### PR TITLE
Enable preferred-greeters with lightdm

### DIFF
--- a/src/modules/displaymanager/displaymanager.conf
+++ b/src/modules/displaymanager/displaymanager.conf
@@ -64,6 +64,12 @@ sysconfigSetup: false
 #
 # greetd has configurable user and group; the user and group is created if it
 # does not exist, and the user is set as default-session user.
+#
+# lightdm has a list of greeters to look for, preferring them in order if
+# they are installed (if not, picks the alphabetically first greeter that is installed).
+#
 greetd:
   greeter_user: "tom_bombadil"
   greeter_group: "wheel"
+lightdm:
+  preferred_greeters: ["lightdm-greeter.desktop", "slick-greeter.desktop"]

--- a/src/modules/displaymanager/displaymanager.schema.yaml
+++ b/src/modules/displaymanager/displaymanager.schema.yaml
@@ -26,4 +26,7 @@ properties:
             greeter_user: { type: string }
             greeter_group: { type: string }
         additionalProperties: false
-
+    lightdm:
+        type: object
+        properties:
+            preferred_greeters: { type: array, items: { type: string } }

--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -644,8 +644,22 @@ class DMlightdm(DisplayManager):
         None to indicate nothing-was-found.
         """
         greeters_dir = "usr/share/xgreeters"
-        greeter_path = os.path.join(self.root_mount_point, greeters_dir, "lightdm-greeter.desktop")
-        return greeter_path
+        greeters_target_path = os.path.join(self.root_mount_point, greeters_dir)
+        preferred_names = ("lightdm-greeter.desktop", )
+        available_names = os.listdir(greeters_target_path)
+        available_names.sort()
+        desktop_names = [n for n in preferred_names if n in available_names] # Preferred ones
+        if desktop_names:
+            return desktop_names[0]
+        desktop_names = [n for n in available_names if n.endswith(".desktop")] # .. otherwise any .desktop
+        if desktop_names:
+            return desktop_names[0]
+        desktop_names = [n for n in available_names if not n.startswith(".")] # .. otherwise any non-dot-file
+        if desktop_names:
+            return desktop_names[0]
+        if available_names: # Anything?
+            return available_names[0]
+        return None
 
 
     def greeter_setup(self):

--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -659,8 +659,6 @@ class DMlightdm(DisplayManager):
         desktop_names = [n for n in available_names if not n.startswith(".")] # .. otherwise any non-dot-file
         if desktop_names:
             return desktop_names[0]
-        if available_names: # Anything?
-            return available_names[0]
         return None
 
 
@@ -683,6 +681,10 @@ class DMlightdm(DisplayManager):
             )
             libcalamares.utils.debug("{!s} configured as greeter.".format(greeter))
         else:
+            if greeter_path is None:
+                libcalamares.utils.error("No greeter found at all, preferred {!s}".format(self.preferred_greeters))
+            else:
+                libcalamares.utils.error("Greeter {!s} selected but file does not exist".format(greeter_path))
             return (
                 _("Cannot configure LightDM"),
                 _("No LightDM greeter installed.")

--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -544,8 +544,10 @@ class DMlightdm(DisplayManager):
     name = "lightdm"
     executable = "lightdm"
 
-    # Can be overridden in the .conf file
-    preferred_greeters = ["lightdm-greeter.desktop"]
+    # Can be overridden in the .conf file. With no value it won't match any
+    # desktop file in the xgreeters directory and instead we end up picking
+    # the alphabetically first file there.
+    preferred_greeters = []
 
     def set_autologin(self, username, do_autologin, default_desktop_environment):
         # Systems with LightDM as Desktop Manager
@@ -654,9 +656,6 @@ class DMlightdm(DisplayManager):
         if desktop_names:
             return desktop_names[0]
         desktop_names = [n for n in available_names if n.endswith(".desktop")] # .. otherwise any .desktop
-        if desktop_names:
-            return desktop_names[0]
-        desktop_names = [n for n in available_names if not n.startswith(".")] # .. otherwise any non-dot-file
         if desktop_names:
             return desktop_names[0]
         return None

--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -640,34 +640,37 @@ class DMlightdm(DisplayManager):
 
         # configure lightdm-greeter
         greeter_path = os.path.join(
-            self.root_mount_point, "usr/share/xgreeters"
+            self.root_mount_point, "usr/share/xgreeters/lightdm-greeter.desktop"
+            # lightdm-greeter.desktop is typically a symlink managed
+            # by update-alternatives pointing to
+            # /etc/alternatives/lightdm-greeter which is also a
+            # symlink to a real .desktop file back in
+            # /usr/share/xgreeters/
             )
 
         if (os.path.exists(greeter_path)):
-            # configure first found lightdm-greeter
-            for entry in os.listdir(greeter_path):
-                if entry.endswith('.desktop'):
-                    greeter = entry.split('.')[0]
-                    libcalamares.utils.debug(
-                        "found greeter {!s}".format(greeter)
-                        )
-                    os.system(
-                        "sed -i -e \"s/^.*greeter-session=.*"
-                        "/greeter-session={!s}/\" {!s}".format(
-                            greeter,
-                            lightdm_conf_path
-                            )
-                        )
-                    libcalamares.utils.debug(
-                        "{!s} configured as greeter.".format(greeter)
-                        )
-                    break
-            else:
-                return (
-                    _("Cannot configure LightDM"),
-                    _("No LightDM greeter installed.")
+            # find the default lightdm-greeter
+            entry = os.path.basename(os.path.realpath(greeter_path))
+            if entry.endswith('.desktop'):
+                greeter = entry.split('.')[0]
+                libcalamares.utils.debug(
+                    "found greeter {!s}".format(greeter)
+                )
+                os.system(
+                    "sed -i -e \"s/^.*greeter-session=.*"
+                    "/greeter-session={!s}/\" {!s}".format(
+                        greeter,
+                        lightdm_conf_path
                     )
-
+                )
+                libcalamares.utils.debug(
+                    "{!s} configured as greeter.".format(greeter)
+                )
+        else:
+            return (
+                _("Cannot configure LightDM"),
+                _("No LightDM greeter installed.")
+            )
 
 class DMslim(DisplayManager):
     name = "slim"

--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -544,6 +544,9 @@ class DMlightdm(DisplayManager):
     name = "lightdm"
     executable = "lightdm"
 
+    # Can be overridden in the .conf file
+    preferred_greeters = ["lightdm-greeter.desktop"]
+
     def set_autologin(self, username, do_autologin, default_desktop_environment):
         # Systems with LightDM as Desktop Manager
         # Ideally, we should use configparser for the ini conf file,
@@ -645,10 +648,9 @@ class DMlightdm(DisplayManager):
         """
         greeters_dir = "usr/share/xgreeters"
         greeters_target_path = os.path.join(self.root_mount_point, greeters_dir)
-        preferred_names = ("lightdm-greeter.desktop", )
         available_names = os.listdir(greeters_target_path)
         available_names.sort()
-        desktop_names = [n for n in preferred_names if n in available_names] # Preferred ones
+        desktop_names = [n for n in self.preferred_greeters if n in available_names] # Preferred ones
         if desktop_names:
             return desktop_names[0]
         desktop_names = [n for n in available_names if n.endswith(".desktop")] # .. otherwise any .desktop

--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -633,39 +633,39 @@ class DMlightdm(DisplayManager):
                 )
             )
 
+    def find_preferred_greeter(self, greeters_dir):
+        """
+        On Debian, lightdm-greeter.desktop is typically a symlink managed
+        by update-alternatives pointing to /etc/alternatives/lightdm-greeter
+        which is also a symlink to a real .desktop file back in /usr/share/xgreeters/
+
+        Returns a path *into the mounted target* of the preferred greeter -- usually
+        a .desktop file that specifies where the actual executable is. May return
+        None to indicate nothing-was-found.
+        """
+        greeters_dir = "usr/share/xgreeters"
+        greeter_path = os.path.join(self.root_mount_point, greeters_dir, "lightdm-greeter.desktop")
+        return greeter_path
+
+
     def greeter_setup(self):
-        lightdm_conf_path = os.path.join(
-            self.root_mount_point, "etc/lightdm/lightdm.conf"
-            )
+        lightdm_conf_path = os.path.join(self.root_mount_point, "etc/lightdm/lightdm.conf")
+        greeter_path = self.find_preferred_greeter()
 
-        # configure lightdm-greeter
-        greeter_path = os.path.join(
-            self.root_mount_point, "usr/share/xgreeters/lightdm-greeter.desktop"
-            # lightdm-greeter.desktop is typically a symlink managed
-            # by update-alternatives pointing to
-            # /etc/alternatives/lightdm-greeter which is also a
-            # symlink to a real .desktop file back in
-            # /usr/share/xgreeters/
-            )
+        if greeter_path is not None and os.path.exists(greeter_path):
+            greeter = os.path.basename(os.path.realpath(greeter_path)) # Follow symlinks, hope they are not absolute
+            if greeter.endswith('.desktop'):
+                greeter = greeter[:-8] # Remove ".desktop" from end
 
-        if (os.path.exists(greeter_path)):
-            # find the default lightdm-greeter
-            entry = os.path.basename(os.path.realpath(greeter_path))
-            if entry.endswith('.desktop'):
-                greeter = entry.split('.')[0]
-                libcalamares.utils.debug(
-                    "found greeter {!s}".format(greeter)
+            libcalamares.utils.debug("found greeter {!s}".format(greeter))
+            os.system(
+                "sed -i -e \"s/^.*greeter-session=.*"
+                "/greeter-session={!s}/\" {!s}".format(
+                    greeter,
+                    lightdm_conf_path
                 )
-                os.system(
-                    "sed -i -e \"s/^.*greeter-session=.*"
-                    "/greeter-session={!s}/\" {!s}".format(
-                        greeter,
-                        lightdm_conf_path
-                    )
-                )
-                libcalamares.utils.debug(
-                    "{!s} configured as greeter.".format(greeter)
-                )
+            )
+            libcalamares.utils.debug("{!s} configured as greeter.".format(greeter))
         else:
             return (
                 _("Cannot configure LightDM"),


### PR DESCRIPTION
This builds on @paolodongilli PR and makes things configurable, while improving the code that is looking for the greeter a little bit. Since we have support for per-DM configuration now, it's relatively simple to add this to the configuration file.