### PR TITLE
greetd: Add custom CSS file path to gtkgreet

### DIFF
--- a/src/modules/displaymanager/displaymanager.conf
+++ b/src/modules/displaymanager/displaymanager.conf
@@ -65,11 +65,14 @@ sysconfigSetup: false
 # greetd has configurable user and group; the user and group is created if it
 # does not exist, and the user is set as default-session user.
 #
+# Some greeters for greetd (e.g gtkgreet or regreet) have support for a user's GTK CSS style to change appearance.
+#
 # lightdm has a list of greeters to look for, preferring them in order if
 # they are installed (if not, picks the alphabetically first greeter that is installed).
 #
 greetd:
   greeter_user: "tom_bombadil"
   greeter_group: "wheel"
+  greeter_css_location: "/etc/greetd/style.css"
 lightdm:
   preferred_greeters: ["lightdm-greeter.desktop", "slick-greeter.desktop"]

--- a/src/modules/displaymanager/displaymanager.schema.yaml
+++ b/src/modules/displaymanager/displaymanager.schema.yaml
@@ -25,6 +25,7 @@ properties:
         properties:
             greeter_user: { type: string }
             greeter_group: { type: string }
+            greeter_css_location: { type: string }
         additionalProperties: false
     lightdm:
         type: object

--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -782,6 +782,7 @@ class DMgreetd(DisplayManager):
     executable = "greetd"
     greeter_user = "greeter"
     greeter_group = "greetd"
+    greeter_css_location = None
     config_data = {}
 
     def os_path(self, path):
@@ -849,6 +850,8 @@ class DMgreetd(DisplayManager):
         de_command = default_desktop_environment.executable
         if os.path.exists(self.os_path("usr/bin/gtkgreet")) and os.path.exists(self.os_path("usr/bin/cage")):
             self.config_data['default_session']['command'] = "cage -d -s -- gtkgreet"
+            if self.greeter_css_location:
+                self.config_data['default_session']['command'] += f" -s {self.greeter_css_location}"
         elif os.path.exists(self.os_path("usr/bin/tuigreet")):
             tuigreet_base_cmd = "tuigreet --remember --time --issue --asterisks --cmd "
             self.config_data['default_session']['command'] = tuigreet_base_cmd + de_command


### PR DESCRIPTION
By default `gtkgreet` uses Adwaita GTK theme. This option adds the ability to apply a custom style to `gtkgreet`. If the `css` file is not present in this directory, `gtkgreet` will simply issue a warning and start with the Adwaita style. I think this is not the ideal solution, so I'll be glad to know if there is a better approach.