### PR TITLE
greetd: Change environments entry from desktopFile to desktopExecutable

### DIFF
--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -837,7 +837,7 @@ class DMgreetd(DisplayManager):
 
     def desktop_environment_setup(self, default_desktop_environment):
         with open(self.environments_path(), 'w') as envs_file:
-            envs_file.write(default_desktop_environment.desktop_file)
+            envs_file.write(default_desktop_environment.executable)
             envs_file.write("\n")
 
     def greeter_setup(self):


### PR DESCRIPTION
The `/etc/greetd/environments` file must contain the run command, not the desktop filename