### PR TITLE
Initcipiocfg fixes for non x86 cpus and add armInstall option to the partition.conf

### DIFF
--- a/src/modules/initcpiocfg/main.py
+++ b/src/modules/initcpiocfg/main.py
@@ -54,8 +54,9 @@ class cpuinfo(object):
         self.number_of_cores = 0
 
         cpu = self._cpuinfo()
-        self.is_intel = cpu['proc0']['vendor_id'].lower() == "genuineintel"
-        self.is_amd = cpu['proc0']['vendor_id'].lower() == "authenticamd"
+        if 'vendor_id' in cpu['proc0']:
+            self.is_intel = cpu['proc0']['vendor_id'].lower() == "genuineintel"
+            self.is_amd = cpu['proc0']['vendor_id'].lower() == "authenticamd"
         self.number_of_cores = len(cpu)
 
     @staticmethod

--- a/src/modules/partition/Config.cpp
+++ b/src/modules/partition/Config.cpp
@@ -415,6 +415,7 @@ Config::setConfigurationMap( const QVariantMap& configurationMap )
     m_requiredPartitionTableType = CalamaresUtils::getStringList( configurationMap, "requiredPartitionTableType" );
 
     Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
+    gs->insert( "armInstall", CalamaresUtils::getBool( configurationMap, "armInstall", false ) );
     fillGSConfigurationEFI( gs, configurationMap );
     fillConfigurationFSTypes( configurationMap );
 }

--- a/src/modules/partition/core/PartUtils.cpp
+++ b/src/modules/partition/core/PartUtils.cpp
@@ -443,7 +443,15 @@ runOsprober( DeviceModel* dm )
 bool
 isEfiSystem()
 {
-    return QDir( "/sys/firmware/efi/efivars" ).exists();
+    Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
+    if ( gs->contains( "armInstall" ) && gs->value( "armInstall" ).toBool() )
+    {
+        return true;
+    }
+    else
+    {
+        return QDir( "/sys/firmware/efi/efivars" ).exists();
+    }
 }
 
 bool

--- a/src/modules/partition/core/PartitionActions.cpp
+++ b/src/modules/partition/core/PartitionActions.cpp
@@ -95,8 +95,16 @@ doAutopartition( PartitionCoreModule* core, Device* dev, Choices::AutoPartitionO
     // the logical sector size (usually 512B). EFI starts with 2MiB
     // empty and a EFI boot partition, while BIOS starts at
     // the 1MiB boundary (usually sector 2048).
-    int empty_space_sizeB = isEfi ? 2_MiB : 1_MiB;
-
+    // ARM empty sectors are 16 MiB in size.
+    int empty_space_sizeB;
+    if ( gs->contains( "armInstall" ) && gs->value( "armInstall" ).toBool() )
+    {
+        empty_space_sizeB = 16_MiB;
+    }
+    else
+    {
+        empty_space_sizeB = isEfi ? 2_MiB : 1_MiB;
+    }
     // Since sectors count from 0, if the space is 2048 sectors in size,
     // the first free sector has number 2048 (and there are 2048 sectors
     // before that one, numbered 0..2047).

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -124,6 +124,13 @@ initialPartitioningChoice: none
 # one of the items from the options.
 initialSwapChoice: none
 
+# armInstall
+#
+# Leaves 16MB empty at the start of a drive when partitioning
+# where usually the u-boot loader goes
+#
+# armInstall: false
+
 # Default partition table type, used when a "erase" disk is made.
 #
 # When erasing a disk, a new partition table is created on disk.

--- a/src/modules/partition/partition.schema.yaml
+++ b/src/modules/partition/partition.schema.yaml
@@ -14,6 +14,7 @@ properties:
     userSwapChoices: { type: array, items: { type: string, enum: [ none, reuse, small, suspend, file ] } }
     # ensureSuspendToDisk: { type: boolean, default: true }  # Legacy
     # neverCreateSwap: { type: boolean, default: false }  # Legacy
+    armInstall: { type: boolean, default: false }
 
     allowZfsEncryption: { type: boolean, default: true }
     drawNestedPartitions: { type: boolean, default: false }


### PR DESCRIPTION
ARM cpus don't have a vendor tag so the initcpicfg module fails this fix just makes it so if there is a vendor tag to check

armInstall leaves 16M at the start of the disk in automatic partitioning theres usually uboot there