### PR TITLE
Initcipiocfg fix for non x86 cpus 

### DIFF
--- a/src/modules/initcpiocfg/main.py
+++ b/src/modules/initcpiocfg/main.py
@@ -54,8 +54,9 @@ class cpuinfo(object):
         self.number_of_cores = 0
 
         cpu = self._cpuinfo()
-        self.is_intel = cpu['proc0']['vendor_id'].lower() == "genuineintel"
-        self.is_amd = cpu['proc0']['vendor_id'].lower() == "authenticamd"
+        if 'vendor_id' in cpu['proc0']:
+            self.is_intel = cpu['proc0']['vendor_id'].lower() == "genuineintel"
+            self.is_amd = cpu['proc0']['vendor_id'].lower() == "authenticamd"
         self.number_of_cores = len(cpu)
 
     @staticmethod


### PR DESCRIPTION
ARM cpus dont have vendor tag in /proc/cpuinfo