### PR TITLE
[packages] Call dnf-3 binary, not dnf

### DIFF
--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -282,12 +282,12 @@ class PMDnf(PackageManager):
     backend = "dnf"
 
     def install(self, pkgs, from_local=False):
-        check_target_env_call(["dnf", "-y", "install"] + pkgs)
+        check_target_env_call(["dnf-3", "-y", "install"] + pkgs)
 
     def remove(self, pkgs):
         # ignore the error code for now because dnf thinks removing a
         # nonexistent package is an error
-        target_env_call(["dnf", "--disablerepo=*", "-C", "-y",
+        target_env_call(["dnf-3", "--disablerepo=*", "-C", "-y",
                          "remove"] + pkgs)
 
     def update_db(self):
@@ -295,7 +295,7 @@ class PMDnf(PackageManager):
         pass
 
     def update_system(self):
-        check_target_env_call(["dnf", "-y", "upgrade"])
+        check_target_env_call(["dnf-3", "-y", "upgrade"])
 
 
 class PMDummy(PackageManager):


### PR DESCRIPTION
DNF is being replaced by a new package manager, DNF 5, in Fedora 39+. The `dnf` binary will soon symlink to DNF 5 instead of DNF 5. The old DNF 4 binary will still be (and always has been) available as /usr/bin/dnf-3.

Until Calamares adds support for DNF 5, it should explicitly call the old dnf-3 binary.