### PR TITLE
Create key file for LUKS2 devices

### DIFF
--- a/src/modules/luksbootkeyfile/CMakeLists.txt
+++ b/src/modules/luksbootkeyfile/CMakeLists.txt
@@ -9,7 +9,6 @@ calamares_add_plugin(luksbootkeyfile
     SOURCES
         LuksBootKeyFileJob.cpp
     SHARED_LIB
-    NO_CONFIG
 )
 
 calamares_add_test(luksbootkeyfiletest SOURCES Tests.cpp LuksBootKeyFileJob.cpp)

--- a/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
+++ b/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
@@ -321,6 +321,12 @@ LuksBootKeyFileJob::exec()
 
     for ( const auto& d : s.devices )
     {
+        // Skip setupLuks for root partition if system has an unencrypted /boot
+        if ( d.isRoot && hasUnencryptedSeparateBoot() )
+        {
+            continue;
+        }
+
         if ( !setupLuks( d ) )
             return Calamares::JobResult::error(
                 tr( "Encryption setup error" ),

--- a/src/modules/luksbootkeyfile/LuksBootKeyFileJob.h
+++ b/src/modules/luksbootkeyfile/LuksBootKeyFileJob.h
@@ -30,6 +30,11 @@ public:
     QString prettyName() const override;
 
     Calamares::JobResult exec() override;
+
+    void setConfigurationMap( const QVariantMap& configurationMap ) override;
+
+private:
+    QString m_luks2Hash;
 };
 
 CALAMARES_PLUGIN_FACTORY_DECLARATION( LuksBootKeyFileJobFactory )

--- a/src/modules/luksbootkeyfile/luksbootkeyfile.conf
+++ b/src/modules/luksbootkeyfile/luksbootkeyfile.conf
@@ -5,6 +5,9 @@
 # LUKS encrypted devices.
 ---
 # Set Password-Based Key Derivation Function (PBKDF) algorithm
-# for LUKS keyslot. The PBKDF can be: pbkdf2, argon2i or argon2id.
-# Default: pbkdf2
-luks2Hash: pbkdf2
+# for LUKS keyslot.
+#
+# There are three usable values: pbkdf2, argon2i or argon2id.
+#
+# When not set, the cryptsetup default is used
+#luks2Hash: argon2id

--- a/src/modules/luksbootkeyfile/luksbootkeyfile.conf
+++ b/src/modules/luksbootkeyfile/luksbootkeyfile.conf
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: no
+# SPDX-License-Identifier: CC0-1.0
+#
+# Luksbootkeyfile configuration. A key file is created for the
+# LUKS encrypted devices.
+---
+# Set Password-Based Key Derivation Function (PBKDF) algorithm
+# for LUKS keyslot. The PBKDF can be: pbkdf2, argon2i or argon2id.
+# Default: pbkdf2
+luks2Hash: pbkdf2

--- a/src/modules/luksbootkeyfile/luksbootkeyfile.schema.yaml
+++ b/src/modules/luksbootkeyfile/luksbootkeyfile.schema.yaml
@@ -6,4 +6,4 @@ $id: https://calamares.io/schemas/luksbootkeyfile
 additionalProperties: false
 type: object
 properties:
-    luks2Hash: { type: string }
+    luks2Hash: { type: string, enum: [ pbkdf2, argon2i, argon2id ] }

--- a/src/modules/luksbootkeyfile/luksbootkeyfile.schema.yaml
+++ b/src/modules/luksbootkeyfile/luksbootkeyfile.schema.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2023 Arjen Balfoort <arjenbalfoort@hotmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+---
+$schema: https://json-schema.org/schema#
+$id: https://calamares.io/schemas/luksbootkeyfile
+additionalProperties: false
+type: object
+properties:
+    luks2Hash: { type: string }


### PR DESCRIPTION
This change will handle LUKS2 encrypted devices.

Five installation scenarios were used for testing:
[luks2_testing.tar.gz](https://github.com/calamares/calamares/files/11543424/luks2_testing.tar.gz)

Note:
Not tested with an encrypted boot because Grub2 cannot handle that yet.

To safely convert LUKS1 devices to LUKS2 devices I created a separate module that is run after the partition module: [partition-luks2](https://github.com/abalfoort/calamares-settings-solydxk/tree/master/calamares-modules/partition-luks2)

If this is something that should be implemented in the partition module, please let me know.

