### PR TITLE
packages: Added remove_deps and try_remove_deps operations for pacman class

### DIFF
--- a/src/modules/packages/packages.conf
+++ b/src/modules/packages/packages.conf
@@ -106,7 +106,7 @@ pacman:
 #       useful if you have a static package archive on the install media.
 #       The *pacman* package manager is the only one to specially support
 #       this operation (all others treat this the same as *install*).
-# - *remove*, *try_remove*: will call the package manager to
+# - *remove*, *remove_deps*, *try_remove*, *try_remove_deps*: will call the package manager to
 #       remove one or more packages. The remove target will
 #       abort the whole installation if package-removal fails,
 #       while try_remove carries on. Packages may be listed as

--- a/src/modules/packages/packages.conf
+++ b/src/modules/packages/packages.conf
@@ -106,11 +106,16 @@ pacman:
 #       useful if you have a static package archive on the install media.
 #       The *pacman* package manager is the only one to specially support
 #       this operation (all others treat this the same as *install*).
-# - *remove*, *remove_deps*, *try_remove*, *try_remove_deps*: will call the package manager to
+# - *remove*, *try_remove*: will call the package manager to
 #       remove one or more packages. The remove target will
 #       abort the whole installation if package-removal fails,
 #       while try_remove carries on. Packages may be listed as
 #       (localized) names.
+# - *remove_with_deps*, *try_remove_with_deps*: will call the package
+#       manager to remove one or more packages and all their dependencies.
+#       The remove_with_deps target will abort the whole installation
+#       if package-removal fails, while try_remove_with_deps carries on.
+#        Packages may be listed as (localized) names.
 # One additional key is recognized, to help netinstall out:
 # - *source*: ignored, does get logged
 # Any other key is ignored, and logged as a warning.

--- a/src/modules/packages/packages.schema.yaml
+++ b/src/modules/packages/packages.schema.yaml
@@ -44,10 +44,10 @@ properties:
                 #       need their own little schema.
                 install: { type: array }
                 remove: { type: array }
-                remove_deps: { type: array }
+                remove_with_deps: { type: array }
                 try_install: { type: array }
                 try_remove: { type: array }
-                try_remove_deps: { type: array }
+                try_remove_with_deps: { type: array }
                 localInstall: { type: array }
                 source: { type: string }
 

--- a/src/modules/packages/packages.schema.yaml
+++ b/src/modules/packages/packages.schema.yaml
@@ -44,8 +44,10 @@ properties:
                 #       need their own little schema.
                 install: { type: array }
                 remove: { type: array }
+                remove_deps: { type: array }
                 try_install: { type: array }
                 try_remove: { type: array }
+                try_remove_deps: { type: array }
                 localInstall: { type: array }
                 source: { type: string }
 


### PR DESCRIPTION
Added `remove_deps` and `try_remove_deps` operations in `packages` module for Pacman class in order to have an operation to remove a package and all its dependencies. Useful for OS Calamares configuration that would like to allow the user to set a "No Desktop" environment by removing the current DE like, for example, `gnome` group package.

Currently this action could be by writing a `pacman -Rcns` command on `shellprocess` module, but having this kind of operation in `packages` module could provide immediate action for the user.