### PR TITLE
partitioning: Show/hide "Boot partition not encrypted" warning

### DIFF
--- a/src/modules/partition/Config.cpp
+++ b/src/modules/partition/Config.cpp
@@ -412,6 +412,7 @@ Config::setConfigurationMap( const QVariantMap& configurationMap )
     m_allowZfsEncryption = CalamaresUtils::getBool( configurationMap, "allowZfsEncryption", true );
 
     m_allowManualPartitioning = CalamaresUtils::getBool( configurationMap, "allowManualPartitioning", true );
+    m_showNotEncryptedBootMessage = CalamaresUtils::getBool( configurationMap, "showNotEncryptedBootMessage", true );
     m_requiredPartitionTableType = CalamaresUtils::getStringList( configurationMap, "requiredPartitionTableType" );
 
     Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();

--- a/src/modules/partition/Config.h
+++ b/src/modules/partition/Config.h
@@ -36,6 +36,8 @@ class Config : public QObject
 
     Q_PROPERTY( bool allowManualPartitioning READ allowManualPartitioning CONSTANT FINAL )
 
+    Q_PROPERTY( bool showNotEncryptedBootMessage READ showNotEncryptedBootMessage CONSTANT FINAL )
+
 public:
     Config( QObject* parent );
     ~Config() override = default;
@@ -146,6 +148,9 @@ public:
     /// @brief Is manual partitioning allowed (not explicitly disabled in the config file)?
     bool allowManualPartitioning() const { return m_allowManualPartitioning; }
 
+    /// @brief Show "Boot partition not encrypted" warning (not explicitly disabled in the config file)?
+    bool showNotEncryptedBootMessage() const { return m_showNotEncryptedBootMessage; }
+
     /** @brief Will @p tableType be ok?
      *
      * If no required types are specified, it's ok, otherwise the
@@ -194,6 +199,7 @@ private:
     QStringList m_requiredPartitionTableType;
     bool m_allowZfsEncryption = true;
     bool m_allowManualPartitioning = true;
+    bool m_showNotEncryptedBootMessage = true;
 };
 
 /** @brief Given a set of swap choices, return a sensible value from it.

--- a/src/modules/partition/PartitionViewStep.cpp
+++ b/src/modules/partition/PartitionViewStep.cpp
@@ -615,27 +615,32 @@ PartitionViewStep::onLeave()
 
             // If the root partition is encrypted, and there's a separate boot
             // partition which is not encrypted
-            if ( ( root_p->fileSystem().type() == FileSystem::Luks && boot_p->fileSystem().type() != FileSystem::Luks )
-                 || ( root_p->fileSystem().type() == FileSystem::Luks2
-                      && boot_p->fileSystem().type() != FileSystem::Luks2 ) )
+            if ( m_config->showNotEncryptedBootMessage() )
             {
-                message = tr( "Boot partition not encrypted" );
-                description = tr( "A separate boot partition was set up together with "
-                                  "an encrypted root partition, but the boot partition "
-                                  "is not encrypted."
-                                  "<br/><br/>"
-                                  "There are security concerns with this kind of "
-                                  "setup, because important system files are kept "
-                                  "on an unencrypted partition.<br/>"
-                                  "You may continue if you wish, but filesystem "
-                                  "unlocking will happen later during system startup."
-                                  "<br/>To encrypt the boot partition, go back and "
-                                  "recreate it, selecting <strong>Encrypt</strong> "
-                                  "in the partition creation window." );
+                if ( ( root_p->fileSystem().type() == FileSystem::Luks
+                       && boot_p->fileSystem().type() != FileSystem::Luks )
+                     || ( root_p->fileSystem().type() == FileSystem::Luks2
+                          && boot_p->fileSystem().type() != FileSystem::Luks2 ) )
+                {
+                    message = tr( "Boot partition not encrypted" );
+                    description = tr( "A separate boot partition was set up together with "
+                                      "an encrypted root partition, but the boot partition "
+                                      "is not encrypted."
+                                      "<br/><br/>"
+                                      "There are security concerns with this kind of "
+                                      "setup, because important system files are kept "
+                                      "on an unencrypted partition.<br/>"
+                                      "You may continue if you wish, but filesystem "
+                                      "unlocking will happen later during system startup."
+                                      "<br/>To encrypt the boot partition, go back and "
+                                      "recreate it, selecting <strong>Encrypt</strong> "
+                                      "in the partition creation window." );
 
-                QMessageBox mb( QMessageBox::Warning, message, description, QMessageBox::Ok, m_manualPartitionPage );
-                Calamares::fixButtonLabels( &mb );
-                mb.exec();
+                    QMessageBox mb(
+                        QMessageBox::Warning, message, description, QMessageBox::Ok, m_manualPartitionPage );
+                    Calamares::fixButtonLabels( &mb );
+                    mb.exec();
+                }
             }
         }
     }

--- a/src/modules/partition/PartitionViewStep.cpp
+++ b/src/modules/partition/PartitionViewStep.cpp
@@ -491,6 +491,28 @@ shouldWarnForGPTOnBIOS( const PartitionCoreModule* core )
     return true;
 }
 
+static bool
+shouldWarnForNotEncryptedBoot( const Config* config, const PartitionCoreModule* core)
+{
+    if ( config->showNotEncryptedBootMessage() )
+    {
+        Partition* root_p = core->findPartitionByMountPoint( "/" );
+        Partition* boot_p = core->findPartitionByMountPoint( "/boot" );
+
+        if ( root_p and boot_p )
+        {
+            if ( ( root_p->fileSystem().type() == FileSystem::Luks
+                   && boot_p->fileSystem().type() != FileSystem::Luks )
+                 || ( root_p->fileSystem().type() == FileSystem::Luks2
+                      && boot_p->fileSystem().type() != FileSystem::Luks2 ) )
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 void
 PartitionViewStep::onLeave()
 {
@@ -605,47 +627,29 @@ PartitionViewStep::onLeave()
             }
         }
 
-        Partition* root_p = m_core->findPartitionByMountPoint( "/" );
-        Partition* boot_p = m_core->findPartitionByMountPoint( "/boot" );
-
-        if ( root_p and boot_p )
+        if ( shouldWarnForNotEncryptedBoot( m_config, m_core ) )
         {
-            QString message;
-            QString description;
+            QString message = tr( "Boot partition not encrypted" );
+            QString description = tr( "A separate boot partition was set up together with "
+                                         "an encrypted root partition, but the boot partition "
+                                         "is not encrypted."
+                                         "<br/><br/>"
+                                         "There are security concerns with this kind of "
+                                         "setup, because important system files are kept "
+                                         "on an unencrypted partition.<br/>"
+                                         "You may continue if you wish, but filesystem "
+                                         "unlocking will happen later during system startup."
+                                         "<br/>To encrypt the boot partition, go back and "
+                                         "recreate it, selecting <strong>Encrypt</strong> "
+                                         "in the partition creation window." );
 
-            // If the root partition is encrypted, and there's a separate boot
-            // partition which is not encrypted
-            if ( m_config->showNotEncryptedBootMessage() )
-            {
-                if ( ( root_p->fileSystem().type() == FileSystem::Luks
-                       && boot_p->fileSystem().type() != FileSystem::Luks )
-                     || ( root_p->fileSystem().type() == FileSystem::Luks2
-                          && boot_p->fileSystem().type() != FileSystem::Luks2 ) )
-                {
-                    message = tr( "Boot partition not encrypted" );
-                    description = tr( "A separate boot partition was set up together with "
-                                      "an encrypted root partition, but the boot partition "
-                                      "is not encrypted."
-                                      "<br/><br/>"
-                                      "There are security concerns with this kind of "
-                                      "setup, because important system files are kept "
-                                      "on an unencrypted partition.<br/>"
-                                      "You may continue if you wish, but filesystem "
-                                      "unlocking will happen later during system startup."
-                                      "<br/>To encrypt the boot partition, go back and "
-                                      "recreate it, selecting <strong>Encrypt</strong> "
-                                      "in the partition creation window." );
-
-                    QMessageBox mb(
-                        QMessageBox::Warning, message, description, QMessageBox::Ok, m_manualPartitionPage );
-                    Calamares::fixButtonLabels( &mb );
-                    mb.exec();
-                }
-            }
+            QMessageBox mb(
+                QMessageBox::Warning, message, description, QMessageBox::Ok, m_manualPartitionPage );
+            Calamares::fixButtonLabels( &mb );
+            mb.exec();
         }
     }
 }
-
 
 void
 PartitionViewStep::setConfigurationMap( const QVariantMap& configurationMap )

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -104,6 +104,15 @@ alwaysShowPartitionLabels: true
 # If nothing is specified, manual partitioning is enabled.
 #allowManualPartitioning:   true
 
+# Show not encrypted boot partition warning.
+#
+# When set to false, this option does not show the
+# "Boot partition not encrypted" warning when encrypting the
+# root partition but not /boot partition.
+#
+# If nothing is specified, the warning is shown.
+#showNotEncryptedBootMessage:   true
+
 # Initial selection on the Choice page
 #
 # There are four radio buttons (in principle: erase, replace, alongside, manual),

--- a/src/modules/partition/partition.schema.yaml
+++ b/src/modules/partition/partition.schema.yaml
@@ -26,6 +26,7 @@ properties:
     enableLuksAutomatedPartitioning: { type: boolean, default: false }
 
     allowManualPartitioning: { type: boolean, default: true }
+    showNotEncryptedBootMessage: { type: boolean, default: true }
     partitionLayout: { type: array }  # TODO: specify items
     initialPartitioningChoice: { type: string, enum: [ none, erase, replace, alongside, manual ] }
     initialSwapChoice: { type: string, enum: [ none, small, suspend, reuse, file ] }


### PR DESCRIPTION
This change will make showing or hiding the "Boot partition not encrypted" warning configurable.

Default is the current behavior: show the warning when a non-encrypted boot partition is found while encrypting the root partition.