### PR TITLE
keyboard: Allow passing in default layout via environment vars

### DIFF
--- a/src/modules/keyboard/Config.cpp
+++ b/src/modules/keyboard/Config.cpp
@@ -331,6 +331,14 @@ Config::detectCurrentKeyboardLayout()
         }
     }
 
+    QString default_layout = qgetenv("DEFAULT_XKBLAYOUT");
+    QString default_variant = qgetenv("DEFAULT_XKBVARIANT");
+
+    if (default_layout != "") {
+        currentLayout = default_layout;
+        currentVariant = default_variant;
+    }
+
     //### Layouts and Variants
     QPersistentModelIndex currentLayoutItem = findLayout( m_keyboardLayoutsModel, currentLayout );
     if ( !currentLayoutItem.isValid() && ( ( currentLayout == "latin" ) || ( currentLayout == "pc" ) ) )
@@ -434,6 +442,10 @@ Config::guessLocaleKeyboardLayout()
     {
         return;
     }
+    QString default_layout = qgetenv("DEFAULT_XKBLAYOUT");
+    if (default_layout != "")
+        return;
+
     cScopedAssignment returnToIntial( &m_state, State::Initial );
     m_state = State::Guessing;
 

--- a/src/modules/keyboard/KeyboardLayoutModel.cpp
+++ b/src/modules/keyboard/KeyboardLayoutModel.cpp
@@ -120,6 +120,10 @@ KeyboardModelsModel::KeyboardModelsModel( QObject* parent )
     : XKBListModel( parent )
 {
     m_contextname = "kb_models";
+    QString default_model = qgetenv("DEFAULT_XKBMODEL");
+
+    if (default_model == "")
+        default_model = "pc105";
 
     // The models map is from human-readable names (!) to xkb identifier
     const auto models = KeyboardGlobal::getKeyboardModels();
@@ -130,7 +134,7 @@ KeyboardModelsModel::KeyboardModelsModel( QObject* parent )
         // So here *key* is the key in the map, which is the human-readable thing,
         //   while the struct fields are xkb-id, and human-readable
         m_list << ModelInfo { models[ key ], key };
-        if ( models[ key ] == "pc105" )
+        if ( models[ key ] == default_model )
         {
             m_defaultPC105 = index;
         }


### PR DESCRIPTION
This allows pre-selecting the keyboard layout, for platforms (laptops) where this information is available from firmware.

There is no standard mechanism for this, so let's use environment variables and leave it up to the launching script / tooling to populate them.