### PR TITLE
keyboard: Add locale1 support & option to keep defaults

### DIFF
--- a/src/modules/keyboard/CMakeLists.txt
+++ b/src/modules/keyboard/CMakeLists.txt
@@ -3,6 +3,9 @@
 #   SPDX-FileCopyrightText: 2020 Adriaan de Groot <groot@kde.org>
 #   SPDX-License-Identifier: BSD-2-Clause
 #
+
+find_package(Qt5 ${QT_VERSION} CONFIG REQUIRED Core DBus)
+
 calamares_add_plugin(keyboard
     TYPE viewmodule
     EXPORT_MACRO PLUGINDLLEXPORT_PRO
@@ -19,6 +22,8 @@ calamares_add_plugin(keyboard
     RESOURCES
         keyboard.qrc
     SHARED_LIB
+    LINK_LIBRARIES
+        Qt5::DBus
 )
 
 calamares_add_test(keyboardtest SOURCES Tests.cpp SetKeyboardLayoutJob.cpp RESOURCES keyboard.qrc)

--- a/src/modules/keyboard/Config.cpp
+++ b/src/modules/keyboard/Config.cpp
@@ -516,7 +516,7 @@ guessLayout( const QStringList& langParts, KeyboardLayoutModel* layouts, Keyboar
 void
 Config::guessLocaleKeyboardLayout()
 {
-    if ( m_state != State::Initial )
+    if ( m_state != State::Initial || !m_guessLayout )
     {
         return;
     }
@@ -658,6 +658,7 @@ Config::setConfigurationMap( const QVariantMap& configurationMap )
     m_convertedKeymapPath = getString( configurationMap, "convertedKeymapPath" );
     m_writeEtcDefaultKeyboard = getBool( configurationMap, "writeEtcDefaultKeyboard", true );
     m_useLocale1 = getBool( configurationMap, "useLocale1", !isX11 );
+    m_guessLayout = getBool( configurationMap, "guessLayout", true );
 }
 
 void

--- a/src/modules/keyboard/Config.cpp
+++ b/src/modules/keyboard/Config.cpp
@@ -466,7 +466,8 @@ Config::createJobs()
                                                   m_additionalLayoutInfo,
                                                   m_xOrgConfFileName,
                                                   m_convertedKeymapPath,
-                                                  m_writeEtcDefaultKeyboard );
+                                                  m_writeEtcDefaultKeyboard,
+                                                  m_useLocale1 );
     list.append( Calamares::job_ptr( j ) );
 
     return list;

--- a/src/modules/keyboard/Config.h
+++ b/src/modules/keyboard/Config.h
@@ -112,6 +112,7 @@ private:
     QString m_convertedKeymapPath;
     bool m_writeEtcDefaultKeyboard = true;
     bool m_useLocale1;
+    bool m_guessLayout;
 
     // The state determines whether we guess settings or preserve them:
     // - Initial -> Guessing

--- a/src/modules/keyboard/Config.h
+++ b/src/modules/keyboard/Config.h
@@ -91,6 +91,9 @@ private:
     void xkbApply();
     void locale1Apply();
 
+    void getCurrentKeyboardLayoutXkb( QString& currentLayout, QString& currentVariant );
+    void getCurrentKeyboardLayoutLocale1( QString& currentLayout, QString& currentVariant );
+
     KeyboardModelsModel* m_keyboardModelsModel;
     KeyboardLayoutModel* m_keyboardLayoutsModel;
     KeyboardVariantsModel* m_keyboardVariantsModel;

--- a/src/modules/keyboard/Config.h
+++ b/src/modules/keyboard/Config.h
@@ -91,8 +91,8 @@ private:
     void xkbApply();
     void locale1Apply();
 
-    void getCurrentKeyboardLayoutXkb( QString& currentLayout, QString& currentVariant );
-    void getCurrentKeyboardLayoutLocale1( QString& currentLayout, QString& currentVariant );
+    void getCurrentKeyboardLayoutXkb( QString& currentLayout, QString& currentVariant, QString& currentModel );
+    void getCurrentKeyboardLayoutLocale1( QString& currentLayout, QString& currentVariant, QString& currentModel );
 
     KeyboardModelsModel* m_keyboardModelsModel;
     KeyboardLayoutModel* m_keyboardLayoutsModel;

--- a/src/modules/keyboard/Config.h
+++ b/src/modules/keyboard/Config.h
@@ -89,6 +89,7 @@ private:
      */
     void xkbChanged( int index );
     void xkbApply();
+    void locale1Apply();
 
     KeyboardModelsModel* m_keyboardModelsModel;
     KeyboardLayoutModel* m_keyboardLayoutsModel;
@@ -107,6 +108,7 @@ private:
     QString m_xOrgConfFileName;
     QString m_convertedKeymapPath;
     bool m_writeEtcDefaultKeyboard = true;
+    bool m_useLocale1;
 
     // The state determines whether we guess settings or preserve them:
     // - Initial -> Guessing

--- a/src/modules/keyboard/KeyboardLayoutModel.h
+++ b/src/modules/keyboard/KeyboardLayoutModel.h
@@ -86,6 +86,7 @@ public:
 
     /// @brief Set the index back to PC105 (the default physical model)
     void setCurrentIndex() { XKBListModel::setCurrentIndex( m_defaultPC105 ); }
+    using XKBListModel::setCurrentIndex;
 
 private:
     int m_defaultPC105 = -1;  ///< The index of pc105, if there is one

--- a/src/modules/keyboard/SetKeyboardLayoutJob.h
+++ b/src/modules/keyboard/SetKeyboardLayoutJob.h
@@ -25,7 +25,8 @@ public:
                           const AdditionalLayoutInfo& additionaLayoutInfo,
                           const QString& xOrgConfFileName,
                           const QString& convertedKeymapPath,
-                          bool writeEtcDefaultKeyboard );
+                          bool writeEtcDefaultKeyboard,
+                          bool skipIfNoRoot );
 
     QString prettyName() const override;
     Calamares::JobResult exec() override;
@@ -44,6 +45,7 @@ private:
     QString m_xOrgConfFileName;
     QString m_convertedKeymapPath;
     const bool m_writeEtcDefaultKeyboard;
+    const bool m_skipIfNoRoot;
 };
 
 #endif /* SETKEYBOARDLAYOUTJOB_H */

--- a/src/modules/keyboard/keyboard.conf
+++ b/src/modules/keyboard/keyboard.conf
@@ -21,3 +21,9 @@ convertedKeymapPath: "/lib/kbd/keymaps/xkb"
 # found on Debian-related systems.
 # Defaults to true if nothing is set.
 #writeEtcDefaultKeyboard:   true
+
+# Use the Locale1 service instead of directly managing configuration files.
+# This is the modern mechanism for configuring the systemwide keyboard layout,
+# and works on Wayland compositors to set the current layout.
+# Defaults to false on X11 and true otherwise.
+#useLocale1: true

--- a/src/modules/keyboard/keyboard.conf
+++ b/src/modules/keyboard/keyboard.conf
@@ -27,3 +27,7 @@ convertedKeymapPath: "/lib/kbd/keymaps/xkb"
 # and works on Wayland compositors to set the current layout.
 # Defaults to false on X11 and true otherwise.
 #useLocale1: true
+
+# Guess the default layout from the user locale. If false, keeps the current
+# OS keyboard layout as the default (useful if the layout is pre-configured).
+#guessLayout: true

--- a/src/modules/keyboardq/CMakeLists.txt
+++ b/src/modules/keyboardq/CMakeLists.txt
@@ -8,6 +8,8 @@ if(NOT WITH_QML)
     return()
 endif()
 
+find_package(Qt5 ${QT_VERSION} CONFIG REQUIRED Core DBus)
+
 set(_keyboard ${CMAKE_CURRENT_SOURCE_DIR}/../keyboard)
 
 include_directories(${_keyboard})
@@ -24,4 +26,6 @@ calamares_add_plugin(keyboardq
     RESOURCES
         keyboardq.qrc
     SHARED_LIB
+    LINK_LIBRARIES
+        Qt5::DBus
 )


### PR DESCRIPTION
On non-X11 systems, setxkbmap & friends can't work (it sort of works in XWayland, but not if Calamares is running in Wayland mode, and not properly). The "modern" way to control systemwide keyboard layouts is using the locale1 DBus interface.

This PR implements locale1 support as an alternative to setxkbmap, which is enabled by default on non-X11 platforms. Since the locale daemon already alters systemwide keyboard configs, this also disables actually writing out the config files if there is no explicit root directory set (changing the current layout and committing it to the config files are the same operation in this model).

To use this with Calamares running under standalone kwin_wayland, the latter has to be started with the `--locale1` option.

In addition, this PR also adds support for keeping the currently set keyboard layout, variant, and model instead of guessing/forcing defaults. This allows system implementers to pre-configure the layout if a sensible default is known on any given platform.

Note that the locale1 stuff itself uses `/etc/X11/xorg.conf.d/00-keyboard.conf` to store the XKB settings (yes, really, even on systems without X), so it truly is redundant to try to write out that file. In addition, we request conversion from XKB to VConsole keymaps from the locale1 API, so the VConsole keymap guessing code is also not used in this case. This is why the config write step is redundant in this case, except for the `/etc/default/keyboard` codepath (which is still available if enabled).