### PR TITLE
[users] Handle Device Tree platforms (e.g. Apple Silicon) for guessing the product name

### DIFF
--- a/src/modules/users/Config.cpp
+++ b/src/modules/users/Config.cpp
@@ -321,7 +321,7 @@ Config::hostnameStatus() const
 static QString
 cleanupForHostname( const QString& s )
 {
-    QRegExp dmirx( "[^a-zA-Z0-9]", Qt::CaseInsensitive );
+    QRegExp dmirx( "(^Apple|\\(.*\\)|[^a-zA-Z0-9])", Qt::CaseInsensitive );
     return s.toLower().replace( dmirx, " " ).remove( ' ' );
 }
 

--- a/src/modules/users/Config.cpp
+++ b/src/modules/users/Config.cpp
@@ -339,15 +339,30 @@ guessProductName()
     if ( !tried )
     {
         QFile dmiFile( QStringLiteral( "/sys/devices/virtual/dmi/id/product_name" ) );
+        QFile modelFile( QStringLiteral( "/proc/device-tree/model" ) );
 
         if ( dmiFile.exists() && dmiFile.open( QIODevice::ReadOnly ) )
         {
             dmiProduct = cleanupForHostname( QString::fromLocal8Bit( dmiFile.readAll().simplified().data() ) );
+            if ( !dmiProduct.isEmpty() )
+            {
+                tried = true;
+                return dmiProduct;
+            }
         }
-        if ( dmiProduct.isEmpty() )
+
+        if ( modelFile.exists() && modelFile.open( QIODevice::ReadOnly ) )
         {
-            dmiProduct = QStringLiteral( "pc" );
+            dmiProduct
+                = cleanupForHostname( QString::fromLocal8Bit( modelFile.readAll().chopped( 1 ).simplified().data() ) );
+            if ( !dmiProduct.isEmpty() )
+            {
+                tried = true;
+                return dmiProduct;
+            }
         }
+
+        dmiProduct = QStringLiteral( "pc" );
         tried = true;
     }
     return dmiProduct;


### PR DESCRIPTION
DT platforms have the product name in the device tree, not DMI data. Handle this, so the default host name is set properly on these platforms.

Also clean up the model name more, so the default hostname is more reasonable for complex human-readable product names (as is common for DT models).