### PR TITLE
Update LuksBootKeyFileJob.cpp to check for unencrypted boot with encrypted root

### DIFF
--- a/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
+++ b/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
@@ -242,13 +242,6 @@ hasUnencryptedSeparateBoot()
         { return hasMountPoint( partition, QStringLiteral( "/boot" ) ) && !isEncrypted( partition ); } );
 }
 
-STATICTEST bool
-hasEncryptedRoot()
-{
-    return anyPartition( []( const QVariantMap& partition )
-                         { return hasMountPoint( partition, QStringLiteral( "/" ) ) && isEncrypted( partition ); } );
-}
-
 Calamares::JobResult
 LuksBootKeyFileJob::exec()
 {
@@ -300,7 +293,7 @@ LuksBootKeyFileJob::exec()
         cDebug() << Logger::SubEntry << "/boot partition is not encrypted, skipping keyfile creation.";
         return Calamares::JobResult::ok();
     }
-    
+
     if ( s.devices.first().passphrase.isEmpty() )
     {
         cDebug() << Logger::SubEntry << "No root passphrase.";

--- a/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
+++ b/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
@@ -294,22 +294,13 @@ LuksBootKeyFileJob::exec()
         return Calamares::JobResult::ok();
     }
 
-    if ( hasUnencryptedSeparateBoot() && !hasEncryptedRoot() )
+    if ( hasUnencryptedSeparateBoot() )
     {
-        // /boot partition is not encrypted, keyfile must not be used
-        // But only if root partition is not encrypted
+        // /boot partition is not encrypted, keyfile must not be used.
         cDebug() << Logger::SubEntry << "/boot partition is not encrypted, skipping keyfile creation.";
         return Calamares::JobResult::ok();
     }
-
-        if ( hasUnencryptedSeparateBoot() && hasEncryptedRoot() )
-    {
-        // /boot partition is not encrypted, keyfile must not be used
-        // But only if root partition is encrypted
-        cDebug() << Logger::SubEntry << "/boot partition is not encrypted, skipping keyfile creation.";
-        return Calamares::JobResult::ok();
-    }
-
+    
     if ( s.devices.first().passphrase.isEmpty() )
     {
         cDebug() << Logger::SubEntry << "No root passphrase.";

--- a/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
+++ b/src/modules/luksbootkeyfile/LuksBootKeyFileJob.cpp
@@ -302,6 +302,14 @@ LuksBootKeyFileJob::exec()
         return Calamares::JobResult::ok();
     }
 
+        if ( hasUnencryptedSeparateBoot() && hasEncryptedRoot() )
+    {
+        // /boot partition is not encrypted, keyfile must not be used
+        // But only if root partition is encrypted
+        cDebug() << Logger::SubEntry << "/boot partition is not encrypted, skipping keyfile creation.";
+        return Calamares::JobResult::ok();
+    }
+
     if ( s.devices.first().passphrase.isEmpty() )
     {
         cDebug() << Logger::SubEntry << "No root passphrase.";

--- a/src/modules/luksbootkeyfile/Tests.cpp
+++ b/src/modules/luksbootkeyfile/Tests.cpp
@@ -158,7 +158,6 @@ LuksBootKeyFileTests::testAnyPartition()
                             { return hasMountPoint( partdata, QStringLiteral( "/" ) ); } ) );
     QVERIFY( !anyPartition( []( const QVariantMap& partdata ) { return hasMountPoint( partdata, QString() ); } ) );
 
-    QVERIFY( !hasEncryptedRoot() );
     QVERIFY( hasUnencryptedSeparateBoot() );
 }
 


### PR DESCRIPTION
Check to not create luks keyfile with unencrypted boot and encrypted root.