### PR TITLE
[keyboard] Fix locale1 support for alternate layouts

### DIFF
--- a/src/modules/keyboard/Config.cpp
+++ b/src/modules/keyboard/Config.cpp
@@ -238,7 +238,7 @@ Config::locale1Apply()
     if ( !m_additionalLayoutInfo.additionalLayout.isEmpty() )
     {
         layout = m_additionalLayoutInfo.additionalLayout + "," + layout;
-        variant = m_additionalLayoutInfo.additionalVariant + "," + layout;
+        variant = m_additionalLayoutInfo.additionalVariant + "," + variant;
         option = m_additionalLayoutInfo.groupSwitcher;
     }
 


### PR DESCRIPTION
Copy&paste error caused setting the layout to fail for non-ASCII layouts with an alternate layout/variant.

Fixes: 812d86130 (\"[keyboard] Add support for setting the layout via locale1\")