### PR TITLE
[users] Use usermod to disable passwords

### DIFF
--- a/src/modules/users/SetPasswordJob.cpp
+++ b/src/modules/users/SetPasswordJob.cpp
@@ -83,10 +83,10 @@ SetPasswordJob::exec()
 
     if ( m_userName == "root" && m_newPassword.isEmpty() )  //special case for disabling root account
     {
-        int ec = CalamaresUtils::System::instance()->targetEnvCall( { "passwd", "-dl", m_userName } );
+        int ec = CalamaresUtils::System::instance()->targetEnvCall( { "usermod", "-p", "!", m_userName } );
         if ( ec )
             return Calamares::JobResult::error( tr( "Cannot disable root account." ),
-                                                tr( "passwd terminated with error code %1." ).arg( ec ) );
+                                                tr( "usermod terminated with error code %1." ).arg( ec ) );
         return Calamares::JobResult::ok();
     }
 


### PR DESCRIPTION
On Fedora 38 (and probably others), this step fails with:

passwd -dl root
passwd: Only one of -l, -u, -d, -S may be specified.

Use usermod to wipe and disable the root password instead, which should work properly. We use '!' (opinions seem to differ on how to mark disabled/unused accounts, but all of '*' '!' '!!' should have the same effect in practice).