### PR TITLE
keyboard: Do the autodetection stuff after setConfigurationMap

### DIFF
--- a/src/modules/keyboard/Config.h
+++ b/src/modules/keyboard/Config.h
@@ -111,8 +111,8 @@ private:
     QString m_xOrgConfFileName;
     QString m_convertedKeymapPath;
     bool m_writeEtcDefaultKeyboard = true;
-    bool m_useLocale1;
-    bool m_guessLayout;
+    bool m_useLocale1 = false;
+    bool m_guessLayout = false;
 
     // The state determines whether we guess settings or preserve them:
     // - Initial -> Guessing

--- a/src/modules/keyboard/KeyboardViewStep.cpp
+++ b/src/modules/keyboard/KeyboardViewStep.cpp
@@ -22,7 +22,6 @@ KeyboardViewStep::KeyboardViewStep( QObject* parent )
     , m_config( new Config( this ) )
     , m_widget( new KeyboardPage( m_config ) )
 {
-    m_config->detectCurrentKeyboardLayout();
     emit nextStatusChanged( true );
 }
 
@@ -110,4 +109,5 @@ void
 KeyboardViewStep::setConfigurationMap( const QVariantMap& configurationMap )
 {
     m_config->setConfigurationMap( configurationMap );
+    m_config->detectCurrentKeyboardLayout();
 }


### PR DESCRIPTION
Since we now rely on the layout1 mode being set from the config, we need to defer the initial keymap detection until after that's initialized.