### PR TITLE
Fixed typo in initcpiocfg module

### DIFF
--- a/src/modules/initcpiocfg/main.py
+++ b/src/modules/initcpiocfg/main.py
@@ -164,7 +164,7 @@ def find_initcpio_features(partitions, root_mount_point):
         "keyboard",
     ]
 
-    systemd_hook_allowed = libcalamares.job.configuration.get("useSystemdHook", False)
+    systemd_hook_allowed = libcalamares.job.configuration.get("useSystemdHook", True)
 
     use_systemd = systemd_hook_allowed and target_env_call(["sh", "-c", "which systemd-cat"]) == 0
 


### PR DESCRIPTION
If useSystemdHook is true, then the person wants to use systemd hook respectively the variable systemd_hook_allowed should be 
```libcalamares.job.configuration.get("useSystemdHook", True)```