### PR TITLE
Correct the comment description of the "Replace" partition behavior

### DIFF
--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -170,8 +170,8 @@ initialSwapChoice: none
 
 # Default filesystem type, used when a "new" partition is made.
 #
-# When replacing a partition, the existing filesystem inside the
-# partition is retained. In other cases, e.g. Erase and Alongside,
+# When replacing a partition, the new filesystem type will be from the 
+# defaultFileSystemType value. In other cases, e.g. Erase and Alongside,
 # as well as when using manual partitioning and creating a new
 # partition, this filesystem type is pre-selected. Note that
 # editing a partition in manual-creation mode will not automatically


### PR DESCRIPTION
The described behavior of the "Replace" option was incorrect, it does not keep the same filesystem type that the partition already had, rather it uses the `defaultFileSystemType` value. See: https://github.com/calamares/calamares/issues/1970