### PR TITLE
Quick vendor patch to add support for Netplan-based configs

### DIFF
--- a/src/modules/networkcfg/main.py
+++ b/src/modules/networkcfg/main.py
@@ -14,6 +14,7 @@
 #
 
 import os
+import glob
 import shutil
 
 import libcalamares
@@ -130,6 +131,21 @@ def run():
                     )
             except FileExistsError:
                 pass
+
+    # Also install netplan files
+    source_netplan = "/etc/netplan"
+    root_mount_point = libcalamares.globalstorage.value("rootMountPoint")
+    target_netplan = os.path.join(root_mount_point, source_netplan.lstrip('/'))
+
+    if os.path.exists(source_netplan) and os.path.exists(target_netplan):
+        for cfg in glob.glob(os.path.join(source_netplan, "90-NM-*")):
+            source_cfg = os.path.join(source_netplan, cfg)
+            target_cfg = os.path.join(target_netplan, os.path.basename(cfg))
+
+            if os.path.exists(target_cfg):
+                continue
+
+            shutil.copy(source_cfg, target_cfg)
 
     # We need to overwrite the default resolv.conf in the chroot.
     source_resolv, target_resolv = path_pair(root_mount_point, "etc/resolv.conf")


### PR DESCRIPTION
It was brought to my attention that all Ubuntu installers ([ubuntu-desktop-installer/subiquity](https://bugs.launchpad.net/ubuntu-desktop-installer/+bug/2036997), [ubiquity, calamares](https://bugs.launchpad.net/ubuntu/+source/ubiquity/+bug/2036999)) have not been installing network configuration correctly. This is due to [Network Manager using Netplan as a backend in Ubuntu now](https://ubuntu.com/blog/a-declarative-approach-to-linux-networking-with-netplan). I wrote this patch in a pinch [to get the release out](https://launchpad.net/ubuntu/+source/calamares/3.3.0-alpha2-0ubuntu6) with [plenty of testing](https://phab.lubuntu.me/w/release-team/testing-checklist/), but it does need some general de-duplication.

If anyone wants a small, "low-hanging fruit" task, you're more than welcome to jump in here.

Thanks in advance.