### PR TITLE
CI: Switch Fedora Qt 6 builds to Fedora Linux 40

### DIFF
--- a/.github/workflows/nightly-fedora-qt6.yml
+++ b/.github/workflows/nightly-fedora-qt6.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: docker://fedora:39
+      image: docker://registry.fedoraproject.org/fedora:40
       options: --tmpfs /build:rw --user 0:0
     steps:
       - name: "prepare git"

--- a/ci/deps-fedora-qt6.sh
+++ b/ci/deps-fedora-qt6.sh
@@ -3,10 +3,6 @@
 # Install dependencies for the nightly-fedora-qt6 build
 #
 
-# Add the KF6 repo
-dnf install -y 'dnf-command(copr)'
-dnf copr enable -y @kdesig/kde-nightly-qt6
-
 yum install -y bison flex git make cmake gcc-c++ ninja-build
 yum install -y yaml-cpp-devel libpwquality-devel parted-devel python-devel gettext gettext-devel
 yum install -y libicu-devel libatasmart-devel


### PR DESCRIPTION
Fedora Linux 40 has the necessary components as part of upgrading to KDE Plasma 6.