### PR TITLE
[CMake] use KPMCore version to select Qt6

### DIFF
--- a/CMakeModules/KPMcoreHelper.cmake
+++ b/CMakeModules/KPMcoreHelper.cmake
@@ -15,18 +15,19 @@ if(NOT TARGET calapmcore)
     find_package(${kfname}I18n CONFIG)
     find_package(${kfname}WidgetsAddons CONFIG)
 
-    if(NOT WITH_QT6)
-        # TODO: Qt6 how to detect the version of Qt that KPMCore needs?
+    if( WITH_QT6)
+        find_package(KPMcore 24.01.75)
+    else()
         find_package(KPMcore 20.04.0)
-        set_package_properties(
-            KPMcore
-            PROPERTIES
-            URL "https://invent.kde.org/kde/kpmcore"
-            DESCRIPTION "KDE Partitioning library"
-            TYPE RECOMMENDED
-            PURPOSE "For disk partitioning support"
-        )
     endif()
+    set_package_properties(
+        KPMcore
+        PROPERTIES
+        URL "https://invent.kde.org/kde/kpmcore"
+        DESCRIPTION "KDE Partitioning library"
+        TYPE RECOMMENDED
+        PURPOSE "For disk partitioning support"
+    )
 
     # Create an internal Calamares interface to KPMcore
     # and give it a nice alias name. If kpmcore is not found,

--- a/src/modules/summaryq/CMakeLists.txt
+++ b/src/modules/summaryq/CMakeLists.txt
@@ -23,4 +23,5 @@ calamares_add_plugin(summaryq
     LINK_PRIVATE_LIBRARIES
         calamaresui
     SHARED_LIB
+    NO_CONFIG
 )


### PR DESCRIPTION
with https://invent.kde.org/system/kpmcore/-/commit/2588d1e796442409a8f95f1777b4f1d89086028a KPMCore is Qt6 only, so any version from 24.01.75 on is Qt6, no need to check for Qt version this way add missing NO_CONFIG to summaryq