### PR TITLE
users: Add support for crypt_gensalt for user passwords

### DIFF
--- a/src/modules/users/CMakeLists.txt
+++ b/src/modules/users/CMakeLists.txt
@@ -6,6 +6,16 @@
 find_package(${qtname} ${QT_VERSION} CONFIG REQUIRED Core DBus Network)
 find_package(Crypt REQUIRED)
 
+# Check for crypt_gensalt
+if(Crypt_FOUND)
+    list(APPEND CMAKE_REQUIRED_LIBRARIES crypt)
+    include(CheckSymbolExists)
+    check_symbol_exists(crypt_gensalt crypt.h HAS_CRYPT_GENSALT)
+    if(HAS_CRYPT_GENSALT)
+        add_definitions(-DHAVE_CRYPT_GENSALT)
+    endif()
+endif()
+
 # Add optional libraries here
 set(USER_EXTRA_LIB
     ${kfname}::CoreAddons
@@ -78,7 +88,9 @@ calamares_add_plugin(users
     SHARED_LIB
 )
 
-calamares_add_test(userspasswordtest SOURCES TestPasswordJob.cpp SetPasswordJob.cpp LIBRARIES ${CRYPT_LIBRARIES})
+if(NOT HAS_CRYPT_GENSALT)
+    calamares_add_test(userspasswordtest SOURCES TestPasswordJob.cpp SetPasswordJob.cpp LIBRARIES ${CRYPT_LIBRARIES})
+endif()
 
 calamares_add_test(
     usersgroupstest

--- a/src/modules/users/CMakeLists.txt
+++ b/src/modules/users/CMakeLists.txt
@@ -8,9 +8,11 @@ find_package(Crypt REQUIRED)
 
 # Check for crypt_gensalt
 if(Crypt_FOUND)
+    set(_old_CRL "${CMAKE_REQUIRED_LIBRARIES}")
     list(APPEND CMAKE_REQUIRED_LIBRARIES crypt)
     include(CheckSymbolExists)
     check_symbol_exists(crypt_gensalt crypt.h HAS_CRYPT_GENSALT)
+    set(CMAKE_REQUIRED_LIBRARIES "${_old_CRL}")
     if(HAS_CRYPT_GENSALT)
         add_definitions(-DHAVE_CRYPT_GENSALT)
     endif()

--- a/src/modules/users/SetPasswordJob.h
+++ b/src/modules/users/SetPasswordJob.h
@@ -22,8 +22,9 @@ public:
     QString prettyName() const override;
     QString prettyStatusMessage() const override;
     Calamares::JobResult exec() override;
-
+#ifndef HAVE_CRYPT_GENSALT
     static QString make_salt( int length );
+#endif /* HAVE_CRYPT_GENSALT */
 
 private:
     QString m_userName;


### PR DESCRIPTION
This attempts to locate the presense of the crypt_gensalt function in the crypto library in use. Many distributions have switched to libxcrypt, which provides this function. This means that Calamares can use the native library implementation instead of generating password salts itself, which, depending on the distro's configuration, may be more secure.

If the function can not be found, fallback to the current method of generating password salts.

Tested on Solus, which now uses libxcrypt and the yescrypt function by default.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
