### PR TITLE
Add support for systemd-machine-id variations

### DIFF
--- a/src/libcalamares/Job.h
+++ b/src/libcalamares/Job.h
@@ -76,7 +76,7 @@ public:
      * Pass in a suitable error code; using 0 (which would normally mean "ok") instead
      * gives you a GenericError code.
      */
-    static JobResult internalError( const QString&, const QString& details, int errorCode );
+    static JobResult internalError( const QString& message, const QString& details, int errorCode );
 
 protected:
     explicit JobResult( const QString& message, const QString& details, int errorCode );

--- a/src/modules/machineid/MachineIdJob.cpp
+++ b/src/modules/machineid/MachineIdJob.cpp
@@ -96,7 +96,7 @@ MachineIdJob::exec()
         {
             cWarning() << "Could not create systemd data-directory.";
         }
-        auto r = MachineId::createSystemdMachineId( root, target_systemd_machineid_file );
+        auto r = MachineId::createSystemdMachineId( m_systemd_style, root, target_systemd_machineid_file );
         if ( !r )
         {
             return r;

--- a/src/modules/machineid/MachineIdJob.cpp
+++ b/src/modules/machineid/MachineIdJob.cpp
@@ -14,6 +14,7 @@
 #include "Workers.h"
 
 #include "utils/Logger.h"
+#include "utils/NamedEnum.h"
 #include "utils/System.h"
 #include "utils/Variant.h"
 
@@ -21,6 +22,25 @@
 #include "JobQueue.h"
 
 #include <QFile>
+
+const NamedEnumTable< MachineId::SystemdMachineIdStyle >&
+styleNames()
+{
+    using T = MachineId::SystemdMachineIdStyle;
+    // *INDENT-OFF*
+    // clang-format off
+    static const NamedEnumTable< MachineId::SystemdMachineIdStyle > names {
+        { QStringLiteral( "none" ), T::Blank },
+        { QStringLiteral( "blank" ), T::Blank },
+        { QStringLiteral( "uuid" ), T::Uuid },
+        { QStringLiteral( "systemd" ), T::Uuid },
+        { QStringLiteral( "literal-uninitialized" ), T::Uninitialized },
+    };
+    // clang-format on
+    // *INDENT-ON*
+
+    return names;
+}
 
 MachineIdJob::MachineIdJob( QObject* parent )
     : Calamares::CppJob( parent )
@@ -133,6 +153,12 @@ void
 MachineIdJob::setConfigurationMap( const QVariantMap& map )
 {
     m_systemd = Calamares::getBool( map, "systemd", false );
+
+    const auto style = Calamares::getString( map, "systemd-style", QString() );
+    if ( !style.isEmpty() )
+    {
+        m_systemd_style = styleNames().find( style, MachineId::SystemdMachineIdStyle::Uuid );
+    }
 
     m_dbus = Calamares::getBool( map, "dbus", false );
     if ( map.contains( "dbus-symlink" ) )

--- a/src/modules/machineid/MachineIdJob.h
+++ b/src/modules/machineid/MachineIdJob.h
@@ -48,7 +48,7 @@ public:
 private:
     bool m_systemd = false;  ///< write systemd's files
 
-    MachineId::SystemdMachineIdStyle m_systemd_style = MachineId::SystemdMachineIdStyle::Blank;
+    MachineId::SystemdMachineIdStyle m_systemd_style = MachineId::SystemdMachineIdStyle::Uuid;
 
     bool m_dbus = false;  ///< write dbus files
     bool m_dbus_symlink = false;  ///< .. or just symlink to systemd

--- a/src/modules/machineid/MachineIdJob.h
+++ b/src/modules/machineid/MachineIdJob.h
@@ -10,15 +10,15 @@
 #ifndef MACHINEIDJOB_H
 #define MACHINEIDJOB_H
 
+#include "Workers.h"
+
+#include "CppJob.h"
+#include "DllMacro.h"
+#include "utils/PluginFactory.h"
+
 #include <QObject>
 #include <QStringList>
 #include <QVariantMap>
-
-#include "CppJob.h"
-
-#include "utils/PluginFactory.h"
-
-#include "DllMacro.h"
 
 /** @brief Write 'random' data: machine id, entropy, UUIDs
  *
@@ -47,6 +47,8 @@ public:
 
 private:
     bool m_systemd = false;  ///< write systemd's files
+
+    MachineId::SystemdMachineIdStyle m_systemd_style = MachineId::SystemdMachineIdStyle::Blank;
 
     bool m_dbus = false;  ///< write dbus files
     bool m_dbus_symlink = false;  ///< .. or just symlink to systemd

--- a/src/modules/machineid/Workers.cpp
+++ b/src/modules/machineid/Workers.cpp
@@ -157,21 +157,24 @@ createSystemdMachineId( SystemdMachineIdStyle style, const QString& rootMountPoi
 {
     Q_UNUSED( rootMountPoint )
     Q_UNUSED( fileName )
-    const QString machineIdFile = QStringLiteral("/etc/machine-id");
+    const QString machineIdFile = QStringLiteral( "/etc/machine-id" );
 
-    switch(style)
+    switch ( style )
     {
-        case SystemdMachineIdStyle::Uuid:
-            return runCmd( QStringList { QStringLiteral( "systemd-machine-id-setup" ) } );
-        case SystemdMachineIdStyle::Blank:
-            Calamares::System::instance()->createTargetFile(machineIdFile, QByteArray(), Calamares::System::WriteMode::Overwrite);
-            return Calamares::JobResult::ok();
-        case SystemdMachineIdStyle::Uninitialized:
-            Calamares::System::instance()->createTargetFile(machineIdFile, "uninitialized\n", Calamares::System::WriteMode::Overwrite);
-            return Calamares::JobResult::ok();
-
+    case SystemdMachineIdStyle::Uuid:
+        return runCmd( QStringList { QStringLiteral( "systemd-machine-id-setup" ) } );
+    case SystemdMachineIdStyle::Blank:
+        Calamares::System::instance()->createTargetFile(
+            machineIdFile, QByteArray(), Calamares::System::WriteMode::Overwrite );
+        return Calamares::JobResult::ok();
+    case SystemdMachineIdStyle::Uninitialized:
+        Calamares::System::instance()->createTargetFile(
+            machineIdFile, "uninitialized\n", Calamares::System::WriteMode::Overwrite );
+        return Calamares::JobResult::ok();
     }
-    return Calamares::JobResult::internalError(QStringLiteral("Invalid systemd-style"), QStringLiteral("Invalid value %1").arg(int(style)), Calamares::JobResult::InvalidConfiguration);
+    return Calamares::JobResult::internalError( QStringLiteral( "Invalid systemd-style" ),
+                                                QStringLiteral( "Invalid value %1" ).arg( int( style ) ),
+                                                Calamares::JobResult::InvalidConfiguration );
 }
 
 Calamares::JobResult

--- a/src/modules/machineid/Workers.cpp
+++ b/src/modules/machineid/Workers.cpp
@@ -155,10 +155,23 @@ runCmd( const QStringList& cmd )
 Calamares::JobResult
 createSystemdMachineId( SystemdMachineIdStyle style, const QString& rootMountPoint, const QString& fileName )
 {
-    Q_UNUSED( style )
     Q_UNUSED( rootMountPoint )
     Q_UNUSED( fileName )
-    return runCmd( QStringList { QStringLiteral( "systemd-machine-id-setup" ) } );
+    const QString machineIdFile = QStringLiteral("/etc/machine-id");
+
+    switch(style)
+    {
+        case SystemdMachineIdStyle::Uuid:
+            return runCmd( QStringList { QStringLiteral( "systemd-machine-id-setup" ) } );
+        case SystemdMachineIdStyle::Blank:
+            Calamares::System::instance()->createTargetFile(machineIdFile, QByteArray(), Calamares::System::WriteMode::Overwrite);
+            return Calamares::JobResult::ok();
+        case SystemdMachineIdStyle::Uninitialized:
+            Calamares::System::instance()->createTargetFile(machineIdFile, "uninitialized\n", Calamares::System::WriteMode::Overwrite);
+            return Calamares::JobResult::ok();
+
+    }
+    return Calamares::JobResult::internalError(QStringLiteral("Invalid systemd-style"), QStringLiteral("Invalid value %1").arg(int(style)), Calamares::JobResult::InvalidConfiguration);
 }
 
 Calamares::JobResult

--- a/src/modules/machineid/Workers.cpp
+++ b/src/modules/machineid/Workers.cpp
@@ -153,8 +153,9 @@ runCmd( const QStringList& cmd )
 }
 
 Calamares::JobResult
-createSystemdMachineId( const QString& rootMountPoint, const QString& fileName )
+createSystemdMachineId( SystemdMachineIdStyle style, const QString& rootMountPoint, const QString& fileName )
 {
+    Q_UNUSED( style )
     Q_UNUSED( rootMountPoint )
     Q_UNUSED( fileName )
     return runCmd( QStringList { QStringLiteral( "systemd-machine-id-setup" ) } );

--- a/src/modules/machineid/Workers.h
+++ b/src/modules/machineid/Workers.h
@@ -52,6 +52,7 @@ createEntropy( const EntropyGeneration kind, const QString& rootMountPoint, cons
  * Creating UUIDs for DBUS and SystemD.
  */
 
+
 /// @brief Create a new DBus UUID file
 Calamares::JobResult createDBusMachineId( const QString& rootMountPoint, const QString& fileName );
 
@@ -59,7 +60,15 @@ Calamares::JobResult createDBusMachineId( const QString& rootMountPoint, const Q
 Calamares::JobResult
 createDBusLink( const QString& rootMountPoint, const QString& fileName, const QString& systemdFileName );
 
-Calamares::JobResult createSystemdMachineId( const QString& rootMountPoint, const QString& fileName );
+enum class SystemdMachineIdStyle
+{
+    Uuid,
+    Blank,
+    Uninitialized
+};
+
+Calamares::JobResult
+createSystemdMachineId( SystemdMachineIdStyle style, const QString& rootMountPoint, const QString& fileName );
 
 
 }  // namespace MachineId

--- a/src/modules/machineid/machineid.conf
+++ b/src/modules/machineid/machineid.conf
@@ -15,7 +15,9 @@
 systemd: true
 # If systemd is true, the kind of /etc/machine-id to create in the target
 #  - uuid (default) generates a UUID
+#  - systemd alias of uuid
 #  - blank creates the file but leaves it empty at 0 bytes
+#  - none alias of blank (use `systemd: false` if you don't want one at all)
 #  - literal-uninitialized creates the file and writes the string "uninitialized\n"
 systemd-style: uuid
 

--- a/src/modules/machineid/machineid.conf
+++ b/src/modules/machineid/machineid.conf
@@ -13,6 +13,11 @@
 # Whether to create /etc/machine-id for systemd.
 # The default is *false*.
 systemd: true
+# If systemd is true, the kind of /etc/machine-id to create in the target
+#  - uuid (default) generates a UUID
+#  - blank creates the file but leaves it empty at 0 bytes
+#  - literal-uninitialized creates the file and writes the string "uninitialized\n"
+systemd-style: uuid
 
 # Whether to create /var/lib/dbus/machine-id for D-Bus.
 # The default is *false*.

--- a/src/modules/machineid/machineid.schema.yaml
+++ b/src/modules/machineid/machineid.schema.yaml
@@ -7,6 +7,7 @@ additionalProperties: false
 type: object
 properties:
     systemd: { type: boolean, default: false }
+    "systemd-style": { type: string, enum: [ uuid, blank, literal-uninitialized ] }
     dbus: { type: boolean, default: false }
     "dbus-symlink": { type: boolean, default: false }
     "entropy-copy": { type: boolean, default: false }


### PR DESCRIPTION
Closes #2225 . Allows blank, literal "uninitialized" and existing practice of writing a machine-id into the target system.