### PR TITLE
libcalamares: add compat and packages headers to be installed;

### DIFF
--- a/src/libcalamares/CMakeLists.txt
+++ b/src/libcalamares/CMakeLists.txt
@@ -190,7 +190,7 @@ install(
     DESTINATION include/libcalamares
 )
 # Install each subdir-worth of header files
-foreach(subdir geoip locale modulesystem network partition utils)
+foreach(subdir geoip locale modulesystem network partition utils compat packages)
     file(GLOB subdir_headers "${subdir}/*.h")
     install(FILES ${subdir_headers} DESTINATION include/libcalamares/${subdir})
 endforeach()


### PR DESCRIPTION
Use case would be customization of default modules, eg packagechooser requires compat/Variant.h and packages/Globals.h to compile in the calamares-extension repo