### PR TITLE
Encourage, not enforce, following NIST password guidelines

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Calamares maintainers through the years:
 Calamares has received contributions of code, documentation, artwork
 and moral support from (alphabetically by first name or nickname):
 
+ - Alberto Salvia Novella
  - Alf Gaida
  - aliveafter1000
  - Allen Welkie
@@ -73,5 +74,3 @@ and moral support from (alphabetically by first name or nickname):
  - vtriolet
  - Walter Lapchynski
  - Waneon Kim
-
- > This list was updated to revision 6e8d820737dea0f3e08f12b10768facef19be684 on May 28th 2022.

--- a/AUTHORS
+++ b/AUTHORS
@@ -74,3 +74,5 @@ and moral support from (alphabetically by first name or nickname):
  - vtriolet
  - Walter Lapchynski
  - Waneon Kim
+
+ > This list was updated to revision 6e8d820737dea0f3e08f12b10768facef19be684 on May 28th 2022.

--- a/src/modules/users/Config.cpp
+++ b/src/modules/users/Config.cpp
@@ -940,7 +940,7 @@ Config::setConfigurationMap( const QVariantMap& configurationMap )
 
     m_reuseUserPasswordForRoot = Calamares::getBool( configurationMap, "doReusePassword", false );
 
-    m_permitWeakPasswords = Calamares::getBool( configurationMap, "allowWeakPasswords", false );
+    m_permitWeakPasswords = Calamares::getBool( configurationMap, "allowWeakPasswords", true );
     m_requireStrongPasswords
         = !m_permitWeakPasswords || !Calamares::getBool( configurationMap, "allowWeakPasswordsDefault", false );
 

--- a/src/modules/users/Tests.cpp
+++ b/src/modules/users/Tests.cpp
@@ -372,7 +372,7 @@ UserTests::testUserPassword()
         Config c;
 
         QVariantMap m;
-        m.insert( "allowWeakPasswords", true );
+        m.insert( "allowWeakPasswords", false );
         m.insert( "allowWeakPasswordsDefault", true );
         m.insert( "defaultGroups", QStringList { "wheel" } );
 

--- a/src/modules/users/users-proposed.conf
+++ b/src/modules/users/users-proposed.conf
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: no
+# SPDX-License-Identifier: CC0-1.0
+
+
+### GROUPS
+
+defaultGroups:
+    - name: users
+      must_exist: true
+      system: true
+    - lp
+    - video
+    - network
+    - storage
+    - name: wheel
+      must_exist: false
+      system: true
+    - audio
+# Sets the groups for the created user.
+# Shall match the target distro defaults.
+# If "must_exist: true", a missing group aborts the install.
+# Otherwise it is created.
+# If "system: true", its GID is set <1000.
+# Otherwise it is >=1000.
+
+sudoersGroup: wheel
+# Sets which group can use sudo at "/etc/sudoers.d/10-installer".
+# Must be a group in "defaultGroups".
+# Check that your distro already doesn't do this through a package.
+
+autologinGroup: autologin
+# Group needed only by some distros for autologin to work.
+# Only users in this group can log directly into the desktop without typing
+# their password.
+
+
+### ADMINS
+
+sudoersConfigureWithGroup: false
+# Sets if an admin can execute "sudo" as another group.
+
+setRootPassword: true
+# Allows setting a root password during install.
+# If "false" the root account is disabled.
+
+doReusePassword: true
+# Sets the initial state of the checkbox "reuse password for root".
+# Uses the same password for root than the created user.
+# Requires "setRootPassword: true".
+
+
+### AUTHENTICATION
+
+doAutologin: false
+# Sets the initial state of the autologin checkbox. The user can change it.
+# Autologin logs the user into the desktop without asking for their password.
+# The password is still asked when performing administrative tasks.
+
+passwordRequirements:
+    minLength: 8
+    maxLength: 64
+    libpwquality:
+        - minlen=6
+        - maxrepeat=3
+        - maxsequence=3
+        - usersubstr=4
+        - badwords=user password linux
+# Setting "minLength" or "maxLength" to "-1" disables these checks.
+#
+# The "libpwquality" checks only work if "libpwquality" is installed.
+# Statements supported by "libpwquality" at "man pwquality.conf".
+# Additional statements may be implemented in "CheckPWQuality.cpp".
+# And wired into "UsersPage.cpp".
+#
+# These defaults follow NIST password guidelines.
+# Lesser requirements may expose the system to priviledge escalation.
+# Strict requirements may be annoying, making most users keep their passwords
+# at glance.
+
+allowWeakPasswords: true
+# Shows the checkbox "require strong password".
+# Otherwise the password must always satisfy the requirements.
+
+allowWeakPasswordsDefault: false
+# Sets if the checkbox "require strong password" is unchecked by default.
+# When unchecked the user is only warned that they are using a weak password.
+
+user:
+  shell: /bin/bash
+  forbidden_names: [ root nobody ]
+# "shell: empty" relies on the shell at "/etc/default/useradd".
+# "forbidden_names" reserves user names for special purposes, like "video" or
+# "mysql".
+
+hostname:
+  location: Etc
+  writeHostsFile: true
+  template: "${product}"
+  forbidden_names: [ localhost ]
+# "location" establishes how the hostname is set:
+#   - "None" for no hostname.
+#   - "Etc" for writting it into "/etc/hostname".
+#   - "Hostnamed" for using systemd-hostnamed over dbus.
+#   - "Transient" for removing "/etc/hostname" from the target.
+#
+# "writeHostsFile" creates "/etc/hosts", which lists host network addresses.
+#
+# "template" makes a suggestion for the hostname based on the following vars:
+#   - "${first}" for the user first name.
+#   - "${name}" for the user full name.
+#   - "${login}" for the user login name.
+#   - "${product}" for the hardware product.
+#   - "${product2}" for the software product.
+#   - "${cpu}" for the CPU.
+#   - "${host}" for the current hostname, which can be transient.
+#
+# "forbidden_names" sets which hostnames cannot be used, as they will cause
+# problems.
+
+presets:
+    fullName:
+        value:
+        editable: true
+    loginName:
+        value:
+        editable: true

--- a/src/modules/users/users.conf
+++ b/src/modules/users/users.conf
@@ -145,7 +145,8 @@ doAutologin: false
 #  - set 'allowWeakPasswords' to false (the default)
 #  - configure password-checking, e.g. with NIST settings
 #
-# The defaults follow NIST-800-63B guidelines.
+# The defaults follow NIST password guidelines:
+# (https://pages.nist.gov/800-63-3/sp800-63b.html)
 
 passwordRequirements:
     minLength: 8

--- a/src/modules/users/users.conf
+++ b/src/modules/users/users.conf
@@ -148,6 +148,22 @@ doAutologin: false
 #
 # The defaults follow NIST password guidelines:
 # (https://pages.nist.gov/800-63-3/sp800-63b.html)
+#
+# And are:
+# passwordRequirements:
+#     minLength: 8
+#     maxLength: 64
+#     libpwquality:
+#         - minlen=6
+#         - maxrepeat=3
+#         - maxsequence=3
+#         - usersubstr=4
+#         - badwords=user password linux
+#
+# For no password requirements:
+# passwordRequirements:
+#     minLength: -1
+#     maxLength: -1
 
 passwordRequirements:
     minLength: 8

--- a/src/modules/users/users.conf
+++ b/src/modules/users/users.conf
@@ -106,7 +106,7 @@ doReusePassword: true
 #  - true to check or
 #  - false to uncheck
 # These set the **initial** state of the checkbox.
-doAutologin:     true
+doAutologin: false
 
 # These are optional password-requirements that a distro can enforce
 # on the user. The values given in this sample file set only very weak
@@ -115,8 +115,7 @@ doAutologin:     true
 # Calamares itself supports two checks:
 #   - minLength
 #   - maxLength
-# In this sample file, the values are set to -1 which means "no
-# minimum", "no maximum". This allows any password at all.
+# A value of -1 disables the check.
 # No effort is done to ensure that the checks are consistent
 # (e.g. specifying a maximum length less than the minimum length
 # will annoy users).
@@ -145,47 +144,27 @@ doAutologin:     true
 # To require specific password characteristics:
 #  - set 'allowWeakPasswords' to false (the default)
 #  - configure password-checking, e.g. with NIST settings
+#
+# The defaults follow NIST-800-63B guidelines.
 
-
-# These are very weak -- actually, none at all -- requirements
 passwordRequirements:
-    minLength: -1  # Password at least this many characters
-    maxLength: -1  # Password at most this many characters
+    minLength: 8
+    maxLength: 64
     libpwquality:
-        - minlen=0
-        - minclass=0
-
-# These are "you must have a password, any password" -- requirements
-#
-# passwordRequirements:
-#     minLength: 1
-
-# These are requirements the try to follow the suggestions from
-#     https://pages.nist.gov/800-63-3/sp800-63b.html , "Digital Identity Guidelines".
-# Note that requiring long and complex passwords has its own cost,
-# because the user has to come up with one at install time.
-# Setting 'allowWeakPasswords' to false and 'doAutologin' to false
-# will require a strong password and prevent (graphical) login
-# without the password. It is likely to be annoying for casual users.
-#
-# passwordRequirements:
-#     minLength: 8
-#     maxLength: 64
-#     libpwquality:
-#         - minlen=8
-#         - maxrepeat=3
-#         - maxsequence=3
-#         - usersubstr=4
-#         - badwords=linux
+        - minlen=6
+        - maxrepeat=4
+        - maxsequence=3
+        - usersubstr=4
+        - badwords=user password linux
 
 # You can control the visibility of the 'strong passwords' checkbox here.
 # Possible values are:
-#  - true to show or
-#  - false to hide  (default)
+#  - true to show  (default)
+#  - false to hide
 # the checkbox. This checkbox allows the user to choose to disable
 # password-strength-checks. By default the box is **hidden**, so
 # that you have to pick a password that satisfies the checks.
-allowWeakPasswords: false
+allowWeakPasswords: true
 # You can control the initial state for the 'strong passwords' checkbox here.
 # Possible values are:
 #  - true to uncheck or

--- a/src/modules/users/users.conf
+++ b/src/modules/users/users.conf
@@ -164,6 +164,10 @@ doAutologin: false
 # passwordRequirements:
 #     minLength: -1
 #     maxLength: -1
+#
+# For accepting any password:
+# passwordRequirements:
+#     minLength: 1
 
 passwordRequirements:
     minLength: 8

--- a/src/modules/users/users.conf
+++ b/src/modules/users/users.conf
@@ -152,7 +152,7 @@ passwordRequirements:
     maxLength: 64
     libpwquality:
         - minlen=6
-        - maxrepeat=4
+        - maxrepeat=3
         - maxsequence=3
         - usersubstr=4
         - badwords=user password linux

--- a/src/modules/users/users.conf
+++ b/src/modules/users/users.conf
@@ -115,7 +115,8 @@ doAutologin: false
 # Calamares itself supports two checks:
 #   - minLength
 #   - maxLength
-# A value of -1 disables the check.
+# Setting these to -1 disables them.
+#
 # No effort is done to ensure that the checks are consistent
 # (e.g. specifying a maximum length less than the minimum length
 # will annoy users).

--- a/src/modules/users/users.schema.yaml
+++ b/src/modules/users/users.schema.yaml
@@ -35,7 +35,7 @@ properties:
     setRootPassword: { type: boolean, default: true }
     doReusePassword: { type: boolean, default: true }
     # Passwords that don't pass a quality test
-    allowWeakPasswords: { type: boolean, default: false }
+    allowWeakPasswords: { type: boolean, default: true }
     allowWeakPasswordsDefault: { type: boolean, default: false }
     passwordRequirements:
         additionalProperties: false


### PR DESCRIPTION
Encourages the user to follow [NIST password guidelines](https://blog.netwrix.com/2022/11/14/nist-password-guidelines/).

But allows to ignore the guidelines, by unchecking the box "use secure password".