### PR TITLE
KaOS has moved to Qt6/kf6 only for Calamares

### DIFF
--- a/ci/deps-kaos.sh
+++ b/ci/deps-kaos.sh
@@ -11,15 +11,15 @@ pacman -Syu --noconfirm git cmake ninja # No jq available
 pacman -S --noconfirm \
 	"gcc" \
 	"boost" \
-	"qt5-tools" \
+	"qt6-tools" \
 	"yaml-cpp" \
 	"kpmcore" \
 	"icu"
 pacman -S --noconfirm \
 	"extra-cmake-modules" \
-	"kiconthemes" \
-	"kservice" \
-	"kio" \
-	"kparts" \
-	"qtwebengine"
+	"kiconthemes6" \
+	"kservice6" \
+	"kio6" \
+	"kparts6" \
+	"qt6-webengine"
 true


### PR DESCRIPTION
adjust deps-kaos.sh accordingly