### PR TITLE
fstab: do not overwrite partition["mountPoint"]

### DIFF
--- a/src/modules/fstab/main.py
+++ b/src/modules/fstab/main.py
@@ -14,6 +14,7 @@
 
 import os
 import re
+import copy
 
 import libcalamares
 
@@ -201,7 +202,7 @@ class FstabGenerator(object):
                     # so all subvolumes here should be safe to add to fstab
                     btrfs_subvolumes = libcalamares.globalstorage.value("btrfsSubvolumes")
                     for s in btrfs_subvolumes:
-                        mount_entry = partition
+                        mount_entry = copy.deepcopy(partition)
                         mount_entry["mountPoint"] = s["mountPoint"]
                         mount_entry["subvol"] = s["subvolume"]
                         dct = self.generate_fstab_line_info(mount_entry)


### PR DESCRIPTION
When using BTRFS multiple subvolumes exist and whilst iterating them the partition["mountPoint"] is inadvertently changed due to taking a reference rather than a copy.

Closes: issue #2281