### PR TITLE
[RFC] networkcfg: Configure NetworkManager to be the default Netplan renderer

### DIFF
--- a/src/modules/networkcfg/main.py
+++ b/src/modules/networkcfg/main.py
@@ -138,7 +138,27 @@ def run():
     target_netplan = os.path.join(root_mount_point, source_netplan.lstrip('/'))
 
     if os.path.exists(source_netplan) and os.path.exists(target_netplan):
-        for cfg in glob.glob(os.path.join(source_netplan, "90-NM-*")):
+        # Set NetworkManager to be the default renderer if Netplan is installed
+        # TODO: We might rather do that inside the network-manager package, see:
+        # https://bugs.launchpad.net/ubuntu/+source/ubuntu-settings/+bug/2020110
+        default_renderer = os.path.join(root_mount_point, "usr/lib/netplan",
+                                        "00-network-manager-all.yaml")
+        if not os.path.exists(default_renderer):
+            renderer_file = os.path.join(target_netplan,
+                                         "01-network-manager-all.yaml")
+            nm_renderer = """# This file was written by calamares.
+# Let NetworkManager manage all devices on this system.
+# For more information, see netplan(5).
+network:
+  version: 2
+  renderer: NetworkManager
+"""
+            with open(renderer_file, 'w') as f:
+                f.writelines(nm_renderer)
+                os.chmod(f, 0o600)
+
+        # Copy existing Netplan configuration
+        for cfg in glob.glob(os.path.join(source_netplan, "*.yaml")):
             source_cfg = os.path.join(source_netplan, cfg)
             target_cfg = os.path.join(target_netplan, os.path.basename(cfg))
 


### PR DESCRIPTION
When Netplan is installed in the target system:

In case NM is not yet set to be the default Netplan renderer (e.g. through a `/usr/lib/netplan/00-network-manager-all.yaml` file shipped by an installed package), create the `/etc/netplan/01-network-manager-all.yaml` configuration and copy over all other Netplan configuration from the installer system.

This change would enable to install target systems similar to what is being proposed for the `debian-installer`: https://salsa.debian.org/installer-team/netcfg/-/merge_requests/9 but always using the NetworkManager backend, as that's what we do on Calamares when installing a desktop system.