### PR TITLE
[plasmalnf] enabled Plasma 6 build

### DIFF
--- a/CHANGES-3.3
+++ b/CHANGES-3.3
@@ -29,6 +29,7 @@ This release contains contributions from (alphabetically by first name):
    with the live-system's NetPlan settings. (thanks Lukas)
  - *partition* module can now also define unencrypted partitions
    when encryption is used. (thanks Aaron)
+ - *plasmalnf* module ported to Plasma 6
 
 
 # 3.3.1 (2024-01-15)

--- a/src/modules/plasmalnf/CMakeLists.txt
+++ b/src/modules/plasmalnf/CMakeLists.txt
@@ -1,23 +1,30 @@
 # === This file is part of Calamares - <https://calamares.io> ===
 #
 #   SPDX-FileCopyrightText: 2020 Adriaan de Groot <groot@kde.org>
+#   SPDX-FileCopyrightText: 2024 Anke Boersma <demm@kaosx.us>
 #   SPDX-License-Identifier: BSD-2-Clause
 #
-if(WITH_QT6)
-    calamares_skip_module( "plasmalnf (KDE Frameworks 5 only)" )
-    return()
-endif()
 
 # Requires a sufficiently recent Plasma framework, but also
 # needs a runtime support component (which we don't test for).
 
-find_package(${kfname} ${KF_VERSION} QUIET COMPONENTS Config Plasma Package)
+if(WITH_QT6)
+    set(PLASMA_VERSION "5.93.0")
+    set(_plasma_libraries "Plasma::Plasma")
+    set(_plasma_name "Plasma")
+    find_package(${kfname} ${KF_VERSION} QUIET COMPONENTS Config Package)
+    find_package(Plasma ${PLASMA_VERSION} REQUIRED)
+else()
+    set(_plasma_libraries "${kfname}::Plasma")
+    set(_plasma_name "KF5Plasma")
+    find_package(${kfname} ${KF_VERSION} QUIET COMPONENTS Config Plasma Package)
+endif()
 
-set_package_properties(KF5Config PROPERTIES PURPOSE "For finding default Plasma Look-and-Feel")
-set_package_properties(KF5Plasma PROPERTIES PURPOSE "For Plasma Look-and-Feel selection")
-set_package_properties(KF5Package PROPERTIES PURPOSE "For Plasma Look-and-Feel selection")
+set_package_properties(${kfname}Config PROPERTIES PURPOSE "For finding default Plasma Look-and-Feel")
+set_package_properties(${_plasma_name} PROPERTIES PURPOSE "For Plasma Look-and-Feel selection")
+set_package_properties(${kfname}Package PROPERTIES PURPOSE "For Plasma Look-and-Feel selection")
 
-if(KF5Plasma_FOUND AND KF5Package_FOUND)
+if(${_plasma_name}_FOUND AND ${kfname}Package_FOUND)
     calamares_add_plugin(plasmalnf
         TYPE viewmodule
         EXPORT_MACRO PLUGINDLLEXPORT_PRO
@@ -35,10 +42,10 @@ if(KF5Plasma_FOUND AND KF5Package_FOUND)
             page_plasmalnf.ui
         LINK_PRIVATE_LIBRARIES
             ${kfname}::Package
-            ${kfname}::Plasma
+            ${_plasma_libraries}
         SHARED_LIB
     )
-    if(KF5Config_FOUND)
+    if(${kfname}Config_FOUND)
         target_compile_definitions(calamares_viewmodule_plasmalnf PRIVATE WITH_KCONFIG)
     endif()
 else()

--- a/src/modules/plasmalnf/Config.cpp
+++ b/src/modules/plasmalnf/Config.cpp
@@ -12,6 +12,7 @@
 #include "PlasmaLnfJob.h"
 #include "ThemeInfo.h"
 
+#include "compat/Variant.h"
 #include "utils/Logger.h"
 #include "utils/System.h"
 #include "utils/Variant.h"
@@ -68,7 +69,8 @@ Config::setConfigurationMap( const QVariantMap& configurationMap )
     }
     m_preselectThemeId = preselect;
 
-    if ( configurationMap.contains( "themes" ) && configurationMap.value( "themes" ).type() == QVariant::List )
+    if ( configurationMap.contains( "themes" )
+         && Calamares::typeOf( configurationMap.value( "themes" ) ) == Calamares::StringVariantType )
     {
         QMap< QString, QString > listedThemes;
         auto themeList = configurationMap.value( "themes" ).toList();
@@ -77,12 +79,12 @@ Config::setConfigurationMap( const QVariantMap& configurationMap )
         // are filled in by update_names() in PlasmaLnfPage.
         for ( const auto& i : themeList )
         {
-            if ( i.type() == QVariant::Map )
+            if ( Calamares::typeOf( i ) == Calamares::MapVariantType )
             {
                 auto iv = i.toMap();
                 listedThemes.insert( iv.value( "theme" ).toString(), iv.value( "image" ).toString() );
             }
-            else if ( i.type() == QVariant::String )
+            else if ( Calamares::typeOf( i ) == Calamares::StringVariantType )
             {
                 listedThemes.insert( i.toString(), QString() );
             }


### PR DESCRIPTION
plasma-framework has been renamed to libplasma and moved away from frameworks now part of plasma (6 only)