### PR TITLE
[packages] Add a DNF5 PM backend

### DIFF
--- a/src/modules/packages/main.py
+++ b/src/modules/packages/main.py
@@ -279,6 +279,11 @@ class PMApt(PackageManager):
 
 
 class PMDnf(PackageManager):
+    """
+    This is "legacy" DNF, called DNF-4 even though the
+    executable is dnf-3 in modern Fedora. Executable dnf
+    is a symlink to dnf-3 in systems that use it.
+    """
     backend = "dnf"
 
     def install(self, pkgs, from_local=False):
@@ -296,6 +301,30 @@ class PMDnf(PackageManager):
 
     def update_system(self):
         check_target_env_call(["dnf-3", "-y", "upgrade"])
+
+
+class PMDnf5(PackageManager):
+    """
+    This is "modern" DNF, DNF-5 which is for Fedora 41 (presumably)
+    and later. Executable dnf is a symlink to dnf5 in systems that use it.
+    """
+    backend = "dnf5"
+
+    def install(self, pkgs, from_local=False):
+        check_target_env_call(["dnf5", "-y", "install"] + pkgs)
+
+    def remove(self, pkgs):
+        # ignore the error code for now because dnf thinks removing a
+        # nonexistent package is an error
+        target_env_call(["dnf5", "--disablerepo=*", "-C", "-y",
+                         "remove"] + pkgs)
+
+    def update_db(self):
+        # Doesn't need updates
+        pass
+
+    def update_system(self):
+        check_target_env_call(["dnf5", "-y", "upgrade"])
 
 
 class PMDummy(PackageManager):

--- a/src/modules/packages/packages.conf
+++ b/src/modules/packages/packages.conf
@@ -23,6 +23,7 @@
 #  - apk         - Alpine Linux package manager
 #  - apt         - APT frontend for DEB and RPM
 #  - dnf         - DNF, the new RPM frontend
+#  - dnf5        - DNF5, the newer new RPM frontend
 #  - entropy     - Sabayon package manager (is being deprecated)
 #  - luet        - Sabayon package manager (next-gen)
 #  - packagekit  - PackageKit CLI tool

--- a/src/modules/packages/packages.schema.yaml
+++ b/src/modules/packages/packages.schema.yaml
@@ -12,6 +12,7 @@ properties:
             - apk
             - apt
             - dnf
+            - dnf5
             - entropy
             - luet
             - packagekit


### PR DESCRIPTION
I just made this up, checked that the `dnf5` command in Fedora 39 exists and can run the command-lines created by this PM backend. (I did install dnf5 into that Fedora 39 system first)

FIXES #2145