### PR TITLE
[partition] Make default partition entry have `partNoEncrypt` be false

### DIFF
--- a/src/modules/partition/core/PartitionLayout.h
+++ b/src/modules/partition/core/PartitionLayout.h
@@ -37,7 +37,7 @@ public:
         quint64 partAttributes = 0;
         QString partMountPoint;
         FileSystem::Type partFileSystem = FileSystem::Unknown;
-        bool partNoEncrypt;
+        bool partNoEncrypt = false;
         QVariantMap partFeatures;
         Calamares::Partition::PartitionSize partSize;
         Calamares::Partition::PartitionSize partMinSize;


### PR DESCRIPTION
#2280 added the `noEncrypt` field to `PartitionEntry`s. However, the current initialization in the `PartitionLayout` class leaves the value uninitialized, leading to the default system partition not being included in encryption.

Before my patch:
![before patch, system partition is not encrypted with LUKS](https://github.com/calamares/calamares/assets/20145996/424a9401-65ad-4197-914d-1368d67c1979)

After my patch:
![after patch, system partition is encrypted with LUKS](https://github.com/calamares/calamares/assets/20145996/2b50b490-3076-49d2-98f5-61a1a1c62245)
