### PR TITLE
Add environment-setting, port ProcessJob to CommandLine

### DIFF
--- a/CHANGES-3.3
+++ b/CHANGES-3.3
@@ -9,11 +9,28 @@ the history of the 3.2 series (2018-05 - 2022-08).
 
 # 3.3.4 (unreleased)
 
+In this release, process jobmodules -- a particular kind of module
+recognizable by `type: job` and `interface: process` in the descriptor
+file -- undergo a large change to resemble *shellprocess* more.
+
+Users of process jobmodules are encouraged to double-check the Functionality
+of those modules in this release.
+
 This release contains contributions from (alphabetically by first name):
+ - Adriaan de Groot
 
 ## Core ##
+ - Process jobs (a job type provided by Calamares core) now share more
+   code with *contextualprocess* and *shellprocess* jobs. The execution
+   mechanism is the same, and always invokes the shell, whether the command
+   runs in the host or in the target system. It is no longer necessary to
+   add `/bin/sh` in the *command* key -- this is always present.
 
 ## Modules ##
+ - *contextualprocess* and *shellprocess* can now set environment variables
+   as part of the configuration. See *shellprocess* documentation for details.
+   This is optional, and does not do anything that could not already be done
+   by putting `export VAR=value ;` in front of the command before.
 
 
 # 3.3.3 (2024-02-24)

--- a/src/libcalamares/ProcessJob.cpp
+++ b/src/libcalamares/ProcessJob.cpp
@@ -10,8 +10,8 @@
 
 #include "ProcessJob.h"
 
+#include "utils/CommandList.h"
 #include "utils/Logger.h"
-#include "utils/System.h"
 
 #include <QDir>
 
@@ -57,23 +57,9 @@ ProcessJob::prettyStatusMessage() const
 JobResult
 ProcessJob::exec()
 {
-    using Calamares::System;
-
-    if ( m_runInChroot )
-    {
-        return Calamares::System::instance()
-            ->targetEnvCommand( { m_command }, m_workingPath, QString(), m_timeoutSec )
-            .explainProcess( m_command, m_timeoutSec );
-    }
-    else
-    {
-        return System::runCommand( System::RunLocation::RunInHost,
-                                   { "/bin/sh", "-c", m_command },
-                                   m_workingPath,
-                                   QString(),
-                                   m_timeoutSec )
-            .explainProcess( m_command, m_timeoutSec );
-    }
+    Calamares::CommandList l( m_runInChroot, m_timeoutSec );
+    l.push_back( Calamares::CommandLine { m_command } );
+    return l.run();
 }
 
 }  // namespace Calamares

--- a/src/libcalamares/utils/CommandList.cpp
+++ b/src/libcalamares/utils/CommandList.cpp
@@ -94,12 +94,29 @@ get_gs_expander( System::RunLocation location )
     return expander;
 }
 
+CommandLine::CommandLine( const QVariantMap& m )
+{
+    const QString command = Calamares::getString( m, "command" );
+    const qint64 timeout = Calamares::getInteger( m, "timeout", -1 );
+    if ( !command.isEmpty() )
+    {
+        m_command = command;
+        m_timeout = timeout >= 0 ? std::chrono::seconds( timeout ) : CommandLine::TimeoutNotSet();
+        m_environment = Calamares::getStringList( m, "environment" );
+    }
+    else
+    {
+        cWarning() << "Bad CommandLine element" << m;
+        // this CommandLine is invalid
+    }
+}
+
 CommandLine
 CommandLine::expand( KMacroExpanderBase& expander ) const
 {
-    QString c = first;
+    QString c = m_command;
     expander.expandMacrosShellQuote( c );
-    return { c, second };
+    return { c, m_environment, m_timeout };
 }
 
 Calamares::CommandLine

--- a/src/libcalamares/utils/CommandList.cpp
+++ b/src/libcalamares/utils/CommandList.cpp
@@ -25,20 +25,6 @@
 namespace Calamares
 {
 
-static CommandLine
-get_variant_object( const QVariantMap& m )
-{
-    QString command = Calamares::getString( m, "command" );
-    qint64 timeout = Calamares::getInteger( m, "timeout", -1 );
-
-    if ( !command.isEmpty() )
-    {
-        return CommandLine( command, timeout >= 0 ? std::chrono::seconds( timeout ) : CommandLine::TimeoutNotSet() );
-    }
-    cWarning() << "Bad CommandLine element" << m;
-    return CommandLine();
-}
-
 static CommandList_t
 get_variant_stringlist( const QVariantList& l )
 {
@@ -52,7 +38,7 @@ get_variant_stringlist( const QVariantList& l )
         }
         else if ( Calamares::typeOf( v ) == Calamares::MapVariantType )
         {
-            auto command( get_variant_object( v.toMap() ) );
+            CommandLine command( v.toMap() );
             if ( command.isValid() )
             {
                 retl.append( command );
@@ -153,7 +139,7 @@ CommandList::CommandList::CommandList( const QVariant& v, bool doChroot, std::ch
     }
     else if ( Calamares::typeOf( v ) == Calamares::MapVariantType )
     {
-        auto c( get_variant_object( v.toMap() ) );
+        CommandLine c( v.toMap() );
         if ( c.isValid() )
         {
             append( c );

--- a/src/libcalamares/utils/CommandList.h
+++ b/src/libcalamares/utils/CommandList.h
@@ -28,30 +28,43 @@ namespace Calamares
  * Each command can have an associated timeout in seconds. The timeout
  * defaults to 10 seconds. Provide some convenience naming and construction.
  */
-struct CommandLine
+class CommandLine
 {
+public:
     static inline constexpr std::chrono::seconds TimeoutNotSet() { return std::chrono::seconds( -1 ); }
 
     /// An invalid command line
     CommandLine() = default;
 
     CommandLine( const QString& s )
-        : first( s )
-        , second( TimeoutNotSet() )
+        : m_command( s )
     {
     }
 
     CommandLine( const QString& s, std::chrono::seconds t )
-        : first( s )
-        , second( t )
+        : m_command( s )
+        , m_timeout( t )
     {
     }
 
-    QString command() const { return first; }
+    CommandLine( const QString& s, const QStringList& env, std::chrono::seconds t )
+        : m_command( s )
+        , m_environment( env )
+        , m_timeout( t )
+    {
+    }
 
-    std::chrono::seconds timeout() const { return second; }
+    /** @brief Constructs a CommandLine from a map with keys
+     *
+     * Relevant keys are *command*, *environment* and *timeout*.
+     */
+    CommandLine( const QVariantMap& m );
 
-    bool isValid() const { return !first.isEmpty(); }
+    QString command() const { return m_command; }
+    [[nodiscard]] QStringList environment() const { return m_environment; }
+    std::chrono::seconds timeout() const { return m_timeout; }
+
+    bool isValid() const { return !m_command.isEmpty(); }
 
     /** @brief Returns a copy of this one command, with variables expanded
      *
@@ -60,6 +73,7 @@ struct CommandLine
      * instance, which handles the ROOT and USER variables.
      */
     DLLEXPORT CommandLine expand( KMacroExpanderBase& expander ) const;
+
     /** @brief As above, with a default macro-expander.
      *
      * The default macro-expander assumes RunInHost (e.g. ROOT will
@@ -68,8 +82,9 @@ struct CommandLine
     DLLEXPORT CommandLine expand() const;
 
 private:
-    QString first;
-    std::chrono::seconds second = std::chrono::seconds( -1 );
+    QString m_command;
+    QStringList m_environment;
+    std::chrono::seconds m_timeout = TimeoutNotSet();
 };
 
 /** @brief Abbreviation, used internally. */
@@ -109,6 +124,7 @@ public:
      * @see CommandLine::expand() for details.
      */
     CommandList expand( KMacroExpanderBase& expander ) const;
+
     /** @brief As above, with a default macro-expander.
      *
      * Each command-line in the list is expanded with that default macro-expander.

--- a/src/libcalamares/utils/CommandList.h
+++ b/src/libcalamares/utils/CommandList.h
@@ -106,6 +106,7 @@ public:
     CommandList( const QVariant& v, bool doChroot = true, std::chrono::seconds timeout = std::chrono::seconds( 10 ) );
 
     bool doChroot() const { return m_doChroot; }
+    std::chrono::seconds defaultTimeout() const { return m_timeout; }
 
     Calamares::JobResult run();
 

--- a/src/libcalamares/utils/Tests.cpp
+++ b/src/libcalamares/utils/Tests.cpp
@@ -54,6 +54,7 @@ private Q_SLOTS:
     void testCommandExpansion();  // See also shellprocess tests
     void testCommandConstructors();
     void testCommandConstructorsYAML();
+    void testCommandRunning();
 
     /** @section Test that all the UMask objects work correctly. */
     void testUmask();
@@ -373,6 +374,18 @@ commands:
         QCOMPARE( cmds.at( 0 ).timeout(), Calamares::CommandLine::TimeoutNotSet() );
         QCOMPARE( cmds.at( 2 ).timeout(), std::chrono::seconds( 12 ) );
     }
+}
+
+void LibCalamaresTests::testCommandRunning()
+{
+    const QString echoCommand = QStringLiteral("echo \"$calamares_test_variable\"");
+
+    Calamares::CommandList l(false); // no chroot
+    Calamares::CommandLine c(echoCommand, {}, std::chrono::seconds(2));
+    l.push_back(c);
+
+    const auto r = l.run();
+    const auto output = r.readAll();
 }
 
 void

--- a/src/libcalamares/utils/Tests.cpp
+++ b/src/libcalamares/utils/Tests.cpp
@@ -52,6 +52,8 @@ private Q_SLOTS:
     void testCommands();
     void testCommandExpansion_data();
     void testCommandExpansion();  // See also shellprocess tests
+    void testCommandConstructors();
+    void testCommandConstructorsYAML();
 
     /** @section Test that all the UMask objects work correctly. */
     void testUmask();
@@ -298,6 +300,79 @@ LibCalamaresTests::testCommandExpansion()
 
     QCOMPARE( c.command(), command );
     QCOMPARE( e.command(), expected );
+}
+
+void
+LibCalamaresTests::testCommandConstructors()
+{
+    const QString command( "do this" );
+    Calamares::CommandLine c0( command );
+
+    QCOMPARE( c0.command(), command );
+    QCOMPARE( c0.timeout(), Calamares::CommandLine::TimeoutNotSet() );
+    QVERIFY( c0.environment().isEmpty() );
+
+    const QStringList env { "-la", "/tmp" };
+    Calamares::CommandLine c1( command, env, Calamares::CommandLine::TimeoutNotSet() );
+
+    QCOMPARE( c1.command(), command );
+    QCOMPARE( c1.timeout(), Calamares::CommandLine::TimeoutNotSet() );
+    QVERIFY( !c1.environment().isEmpty() );
+    QCOMPARE( c1.environment().count(), 2 );
+    QCOMPARE( c1.environment(), env );
+}
+
+void
+LibCalamaresTests::testCommandConstructorsYAML()
+{
+    QTemporaryFile f;
+    QVERIFY( f.open() );
+    f.write( R"(---
+commands:
+  - one-string-command
+  - command: only-command
+  - command: with-timeout
+    timeout: 12
+  - command: all-three
+    timeout: 20
+    environment:
+      - PATH=/USER
+      - DISPLAY=:0
+      )" );
+    f.close();
+    bool ok = false;
+    QVariantMap m = Calamares::YAML::load( f.fileName(), &ok );
+
+    QVERIFY( ok );
+    QCOMPARE( m.count(), 1 );
+    QCOMPARE( m[ "commands" ].toList().count(), 4 );
+
+    {
+        // Take care! The second parameter is a bool, so "3" here means "true"
+        Calamares::CommandList cmds( m[ "commands" ], 3 );
+        QCOMPARE( cmds.defaultTimeout(), std::chrono::seconds( 10 ) );
+        // But the 4 commands are there anyway
+        QCOMPARE( cmds.count(), 4 );
+        QCOMPARE( cmds.at( 0 ).command(), QString( "one-string-command" ) );
+        QCOMPARE( cmds.at( 0 ).environment(), QStringList() );
+        QCOMPARE( cmds.at( 0 ).timeout(), Calamares::CommandLine::TimeoutNotSet() );
+        QCOMPARE( cmds.at( 1 ).command(), QString( "only-command" ) );
+        QCOMPARE( cmds.at( 2 ).command(), QString( "with-timeout" ) );
+        QCOMPARE( cmds.at( 2 ).environment(), QStringList() );
+        QCOMPARE( cmds.at( 2 ).timeout(), std::chrono::seconds( 12 ) );
+
+        QStringList expectedEnvironment = { "PATH=/USER", "DISPLAY=:0" };
+        QCOMPARE( cmds.at( 3 ).command(), QString( "all-three" ) );
+        QCOMPARE( cmds.at( 3 ).environment(), expectedEnvironment );
+        QCOMPARE( cmds.at( 3 ).timeout(), std::chrono::seconds( 20 ) );
+    }
+
+    {
+        Calamares::CommandList cmds( m[ "commands" ], true, std::chrono::seconds( 3 ) );
+        QCOMPARE( cmds.defaultTimeout(), std::chrono::seconds( 3 ) );
+        QCOMPARE( cmds.at( 0 ).timeout(), Calamares::CommandLine::TimeoutNotSet() );
+        QCOMPARE( cmds.at( 2 ).timeout(), std::chrono::seconds( 12 ) );
+    }
 }
 
 void

--- a/src/modules/README.md
+++ b/src/modules/README.md
@@ -508,7 +508,10 @@ while the module type must be *job* or *jobmodule*.
 The module-descriptor key *command* should have a string as value, which is
 passed to the shell -- remember to quote it properly. It is generally
 recommended to use a *shellprocess* job module instead (less configuration,
-easier to have multiple instances).
+easier to have multiple instances). There is no configuration outside
+of the module-descriptor.
+
+Optional keys are *timeout* and *chroot*.
 
 `CMakeLists.txt` is *not* used for process jobmodules.
 

--- a/src/modules/contextualprocess/contextualprocess.conf
+++ b/src/modules/contextualprocess/contextualprocess.conf
@@ -7,14 +7,13 @@
 # When a given global value (string) equals a given value, then
 # the associated command is executed.
 #
-# The special top-level keys *dontChroot* and *timeout* have
-# meaning just like in shellprocess.conf. They are excluded from
-# the comparison with global variables.
-#
 # Configuration consists of keys for global variable names (except
 # *dontChroot* and *timeout*), and the sub-keys are strings to compare
 # to the variable's value. If the variable has that particular value, the
-# corresponding value (script) is executed.
+# corresponding value (script) is executed. The top-level keys *dontChroot*
+# and *timeout* are not global variable names. They have
+# meaning just like in shellprocess.conf, that is they
+# determine **where** the command runs and how long it has.
 #
 # The variable **may** contain dots, in which case the dot is used
 # to select into maps inside global storage, e.g.

--- a/src/modules/shellprocess/shellprocess.conf
+++ b/src/modules/shellprocess/shellprocess.conf
@@ -14,6 +14,10 @@
 #  - `USER` is replaced by the username, set on the user page.
 #
 # Variables are written as `${var}`, e.g. `${ROOT}`.
+# Write `$$` to get a shell-escaped `\$` in the shell command.
+# It is not possible to get an un-escaped `$` in the shell command
+# (either the command will fail because of undefined variables, or
+# you get a shell-escaped `\$`).
 #
 # The (global) timeout for the command list can be set with
 # the *timeout* key. The value is a time in seconds, default
@@ -35,19 +39,32 @@
 #
 # The value of *script* may be:
 #   - a single string; this is one command that is executed.
-#   - a single object (this is not useful).
+#   - a single object (see below).
 #   - a list of items; these are executed one at a time, by
 #     separate shells (/bin/sh -c is invoked for each command).
 #     Each list item may be:
 #     - a single string; this is one command that is executed.
 #     - a single object, specifying a key *command* and (optionally)
 #       a key *timeout* to set the timeout for this specific
-#       command differently from the global setting.
+#       command differently from the global setting. An optional
+#       key *environment* is a list of strings to put into the
+#       environment of the command.
 #
-# Using a single object is not useful because the same effect can
-# be obtained with a single string and a global timeout, but when
-# there are multiple commands to execute, one of them might have
+# Using a single object is not generally useful because the same effect
+# can be obtained with a single string and a global timeout, except
+# when the command needs environment-settings. When there are
+# multiple commands to execute, one of them might have
 # a different timeout than the others.
+#
+# The environment strings should all be "KEY='some value'" strings,
+# as if they can be typed into the shell. Quoting the environment
+# strings with "" in YAML is recommended. Adding the '' quotes ensures
+# that the value will not be interpreted by the shell. Writing
+# environment strings is the same as placing `export KEY='some value' ;`
+# in front of the *command*.
+#
+# Calamares variable expansion is **also** done on the environment strings.
+# Write `$$` to get a literal `$` in the shell command.
 #
 # To change the description of the job, set the *name* entries in *i18n*.
 ---


### PR DESCRIPTION
FIXES #2212

There's some superfluous environment-setting (could be done in another way already), but mostly: port the ProcessJob to invoke the command in the same way that shellprocess does.