### PR TITLE
initcpiocfg: Add microcode module

### DIFF
--- a/CHANGES-3.3
+++ b/CHANGES-3.3
@@ -12,6 +12,7 @@ the history of the 3.2 series (2018-05 - 2022-08).
 This release contains contributions from (alphabetically by first name):
  - Adriaan de Groot
  - Evan James
+ - Peter Jung
 
 ## Core ##
  - Calamares logs more information about how the executable was created
@@ -22,6 +23,7 @@ This release contains contributions from (alphabetically by first name):
 ## Modules ##
  - *displaymanager* module can configure an alternate SDDM configuration file.
  - *networkcfg* a bug affecting NetPlan + NetworkManager was fixed.
+ - *initcpiocfg* Add microcode hook to initcpiocfg
 
 
 # 3.3.4 (2024-02-27)

--- a/src/modules/initcpiocfg/main.py
+++ b/src/modules/initcpiocfg/main.py
@@ -148,6 +148,7 @@ def find_initcpio_features(partitions, root_mount_point):
     """
     hooks = [
         "autodetect",
+        "microcode",
         "kms",
         "modconf",
         "block",


### PR DESCRIPTION
As mentioned in the recent mkinitcpio and archlinux news, the ALL_MICROCODE way got deprecated and there is now a 'microcode' hook.
This should be adapted.

https://archlinux.org/news/mkinitcpio-hook-migration-and-early-microcode/