### PR TITLE
on Qt6 we need to build with position independent code

### DIFF
--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -36,3 +36,4 @@ calamares_qrc_translations(calamares-i18n
 )
 
 add_library(calamares-i18n OBJECT ${translation_outfile})
+set_property(TARGET calamares-i18n PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
otherwise linking may fail with

> copy relocation against non-copyable protected symbol `qt_resourceFeatureZstd@@Qt_6'

(don't ask me why, we did the same in KDE code and I didn't bother to ask why XD)