### PR TITLE
Update Presentation.qml

### DIFF
--- a/src/qml/calamares-qt6/slideshow/Presentation.qml
+++ b/src/qml/calamares-qt6/slideshow/Presentation.qml
@@ -196,6 +196,8 @@ Item {
                 Text {
                     id: notesText
 
+                    property real padding: 16;
+
                     x: padding
                     y: padding
                     width: parent.width - 2 * padding


### PR DESCRIPTION
The `padding` property is present in the qt5 version, but not the qt6 version. I notice a syntax error as a result of this missing propertly.