### PR TITLE
plymouthcfg: Use plymouth-set-default-theme instead of sed

### DIFF
--- a/CHANGES-3.3
+++ b/CHANGES-3.3
@@ -24,6 +24,7 @@ This release contains contributions from (alphabetically by first name):
  - *displaymanager* module can configure an alternate SDDM configuration file.
  - *networkcfg* a bug affecting NetPlan + NetworkManager was fixed.
  - *initcpiocfg* Add microcode hook to initcpiocfg
+ - *plymouthcfg* Use plymouth-set-default-theme to avoid issues with configuration
 
 
 # 3.3.4 (2024-02-27)

--- a/src/modules/plymouthcfg/main.py
+++ b/src/modules/plymouthcfg/main.py
@@ -48,9 +48,7 @@ class PlymouthController:
 
     def setTheme(self):
         plymouth_theme = libcalamares.job.configuration["plymouth_theme"]
-        target_env_call(["sed", "-e", 's|^.*Theme=.*|Theme=' +
-                         plymouth_theme + '|', "-i",
-                         "/etc/plymouth/plymouthd.conf"])
+        target_env_call(["plymouth-set-default-theme",  plymouth_theme])
 
     def run(self):
         if detect_plymouth():


### PR DESCRIPTION
Currently we are running into an issue, when setting the default theme via "sed", since the "[DAEMON]" entry in /etc/plymouth/plymouthd.conf is commented, which results into that the theme is not correctly applied.