### PR TITLE
Add support for splash for non-grub bootloaders and fix adding crypto_keyfile when it's missing

### DIFF
--- a/src/modules/bootloader/main.py
+++ b/src/modules/bootloader/main.py
@@ -127,7 +127,6 @@ def is_zfs_root(partition):
 
 def get_kernel_params(uuid):
     kernel_params = libcalamares.job.configuration.get("kernelParams", ["quiet"])
-    kernel_params.append("rw")
 
     partitions = libcalamares.globalstorage.value("partitions")
     swap_uuid = ""
@@ -136,11 +135,17 @@ def get_kernel_params(uuid):
 
     cryptdevice_params = []
 
+    has_plymouth = libcalamares.utils.target_env_call(["sh", "-c", "which plymouth"]) == 0
     has_dracut = libcalamares.utils.target_env_call(["sh", "-c", "which dracut"]) == 0
     uses_systemd_hook = libcalamares.utils.target_env_call(["sh", "-c",
                                                             "grep -q \"^HOOKS.*systemd\" /etc/mkinitcpio.conf"]) == 0
     use_systemd_naming = has_dracut or uses_systemd_hook
 
+    # If plymouth installed, add splash screen parameter early
+    if has_plymouth:
+        kernel_params.append("splash")
+
+    kernel_params.append("rw")
 
     # Take over swap settings:
     #  - unencrypted swap partition sets swap_uuid

--- a/src/modules/fstab/main.py
+++ b/src/modules/fstab/main.py
@@ -169,6 +169,11 @@ class FstabGenerator(object):
                 password = "none"
                 crypttab_options = ""
 
+        # Make sure we do not add missing crypto_keyfile and options for it
+        if not os.path.isfile(os.path.join(self.root_mount_point, "crypto_keyfile.bin")):
+            password = "none"
+            crypttab_options = ""
+
         return dict(
             name=mapper_name,
             device="UUID=" + luks_uuid,


### PR DESCRIPTION
The following enables adding "splash" to cmdline when plymouth is installed (independently of grubcfg) and fixes adding crypto_keyfile when it's missing (for example when luksbootkeyfile is disabled).
Fixes https://github.com/calamares/calamares/issues/2311 and https://github.com/calamares/calamares/issues/2310 respectively.

TLDR;
Improvements for systemd-boot support.
With those fixes, it's possible to configure Kubuntu/Lubuntu installer to utilize 2 partition config (EFI + Encrypted root).