### PR TITLE
Refactor crypto_keyfile addition in fstab module and skip it when it's missing

### DIFF
--- a/src/modules/fstab/main.py
+++ b/src/modules/fstab/main.py
@@ -151,8 +151,12 @@ class FstabGenerator(object):
         if not mapper_name or not luks_uuid:
             return None
 
-        password = "/crypto_keyfile.bin"
         crypttab_options = self.crypttab_options
+        # Make sure to not use missing keyfile
+        if os.path.isfile(os.path.join(self.root_mount_point, "crypto_keyfile.bin")):
+            password = "/crypto_keyfile.bin"
+        else:
+            password = "none"
 
         # Set crypttab password for partition to none and remove crypttab options
         # if root partition was not encrypted


### PR DESCRIPTION
Fixes https://github.com/calamares/calamares/issues/2310
Replaces https://github.com/calamares/calamares/pull/2313
