### PR TITLE
[partition] Don't crash when going back without selecting a partition

### DIFF
--- a/src/modules/partition/gui/ChoicePage.cpp
+++ b/src/modules/partition/gui/ChoicePage.cpp
@@ -679,7 +679,11 @@ ChoicePage::onLeave()
 {
     if ( m_config->installChoice() == InstallChoice::Alongside )
     {
-        doAlongsideApply();
+        if ( m_afterPartitionSplitterWidget->splitPartitionSize() >= 0
+             && m_afterPartitionSplitterWidget->newPartitionSize() >= 0 )
+        {
+            doAlongsideApply();
+        }
     }
 
     if ( m_isEfi


### PR DESCRIPTION
While testing something else I discovered an issue where if you choose "Install Alongside" and then hit the back button without choosing a partition, it causes a crash do to the assertions in `doAlongsideApply()`