### PR TITLE
make first arg of accumulate func obj to be prvalue

### DIFF
--- a/src/libcalamares/CalamaresAbout.cpp
+++ b/src/libcalamares/CalamaresAbout.cpp
@@ -60,10 +60,9 @@ aboutMaintainers()
     return std::accumulate( std::cbegin( maintainers ),
                             std::cend( maintainers ),
                             QString(),
-                            []( QString& s, const Maintainer& m )
+                            []( QString s, const Maintainer& m )
                             {
-                                s += m.text();
-                                return s;
+                                return std::move( s ) + m.text();
                             } );
 }
 

--- a/src/modules/partition/PartitionViewStep.cpp
+++ b/src/modules/partition/PartitionViewStep.cpp
@@ -223,8 +223,8 @@ PartitionViewStep::prettyStatus() const
     const QList< PartitionCoreModule::SummaryInfo > list = m_core->createSummaryInfo();
 
     cDebug() << "Summary for Partition" << list.length() << choice;
-    auto joinDiskInfo = [ choice ]( QString& s, const PartitionCoreModule::SummaryInfo& i )
-    { return s + diskDescription( 1, i, choice ); };
+    auto joinDiskInfo = [ choice ]( QString s, const PartitionCoreModule::SummaryInfo& i )
+    { return std::move( s ) + diskDescription( 1, i, choice ); };
     const QString diskInfoLabel = std::accumulate( list.begin(), list.end(), QString(), joinDiskInfo );
     const QString jobsLabel = jobDescriptions( jobs() ).join( QStringLiteral( "<br/>" ) );
     return diskInfoLabel + "<br/>" + jobsLabel;


### PR DESCRIPTION
since C++20 first argument to std::accumulate cannot be lvalue, before C++20 it could be lvalue.

see 2) in https://en.cppreference.com/w/cpp/algorithm/accumulate