### PR TITLE
Fix mounting encrypted swap partition

### DIFF
--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -345,7 +345,8 @@ def run():
                 _("No partitions are defined for <pre>{!s}</pre> to use.").format("mount"))
 
     # Find existing swap partitions that are part of the installation and enable them now
-    swap_devices = [p["device"] for p in partitions if (p["fs"] == "linuxswap" and p.get("claimed", False))]
+    swap_devices = [p["device"] for p in partitions if (p["fs"] == "linuxswap" and p.get("claimed", False) and p["fsName"] == "linuxswap")] \
+       + ["/dev/mapper/" + p["luksMapperName"] for p in partitions if (p["fs"] == "linuxswap" and p.get("claimed", False) and (p["fsName"] == "luks" or p["fsName"] == "luks2"))]
 
     enable_swap_partition(swap_devices)
 


### PR DESCRIPTION
#2102 allows for mounting a swap partition during installation, however luks encrypted swap partitions are not mounted. This change enables the mounting of luks and luks2 encrypted swap partitions. 