### PR TITLE
[partition] Fix crash on filesystem changes when encryption is checked

### DIFF
--- a/src/modules/partition/gui/ChoicePage.cpp
+++ b/src/modules/partition/gui/ChoicePage.cpp
@@ -467,8 +467,6 @@ ChoicePage::onActionChanged()
         {
             m_encryptWidget->setFilesystem( FileSystem::typeForName( m_replaceFsTypesChoiceComboBox->currentText() ) );
         }
-
-        m_encryptWidget->setEncryptionCheckbox( m_config->preCheckEncryption() );
     }
 
     Device* currd = selectedDevice();
@@ -1035,6 +1033,10 @@ ChoicePage::updateActionChoicePreview( InstallChoice choice )
         if ( m_enableEncryptionWidget )
         {
             m_encryptWidget->show();
+            if ( m_config->preCheckEncryption() )
+            {
+                m_encryptWidget->setEncryptionCheckbox( true );
+            }
         }
         m_previewBeforeLabel->setText( tr( "Current:", "@label" ) );
         m_selectLabel->setText( tr( "<strong>Select a partition to shrink, "
@@ -1087,7 +1089,14 @@ ChoicePage::updateActionChoicePreview( InstallChoice choice )
     case InstallChoice::Erase:
     case InstallChoice::Replace:
     {
-        m_encryptWidget->setVisible( shouldShowEncryptWidget( choice ) );
+        if ( shouldShowEncryptWidget( choice ) )
+        {
+            m_encryptWidget->show();
+            if ( m_config->preCheckEncryption() )
+            {
+                m_encryptWidget->setEncryptionCheckbox( true );
+            }
+        }
         m_previewBeforeLabel->setText( tr( "Current:", "@label" ) );
         m_afterPartitionBarsView = new PartitionBarsView( m_previewAfterFrame );
         m_afterPartitionBarsView->setNestedPartitionsMode( mode );

--- a/src/modules/partition/gui/EncryptWidget.cpp
+++ b/src/modules/partition/gui/EncryptWidget.cpp
@@ -182,10 +182,15 @@ EncryptWidget::updateState( const bool notify )
         }
     }
 
-    m_state = state();
-    if ( notify )
+    Encryption newState = state();
+
+    if ( newState != m_state )
     {
-        Q_EMIT stateChanged( m_state );
+        m_state = newState;
+        if ( notify )
+        {
+            Q_EMIT stateChanged( m_state );
+        }
     }
 }
 


### PR DESCRIPTION
This fixes the current crash when selecting encryption and changing the filesystem.

There is one remaining issue which is if the `preCheckEncryption` conf option is set to `true` AND you select erase disk AND you try to uncheck the encryption checkbox, you need to click it twice.

Ideally this would be fixed but since the current situation is an application crash on a fairly common use case and the above is an edge case, we should probably merge this unless someone has time to track that last bit down.