### PR TITLE
[users] Use yescrypt instead of sha512

### DIFF
--- a/src/modules/users/SetPasswordJob.cpp
+++ b/src/modules/users/SetPasswordJob.cpp
@@ -64,7 +64,7 @@ SetPasswordJob::make_salt( int length )
         cWarning() << "Entropy data for salt is low-quality.";
     }
 
-    salt_string.insert( 0, "$6$" );
+    salt_string.insert( 0, "$y$" );
     salt_string.append( '$' );
     return salt_string;
 }


### PR DESCRIPTION
Use yescrypt instead of sha512 when CRYPT_GENSALT is not used and the salt is manually determined.

yescrypt is the default key derivation function in almost every modern distro and grants higher levels of security.

https://www.openwall.com/yescrypt/