### PR TITLE
[umount] Also unmount the root filesystem

### DIFF
--- a/src/modules/umount/UmountJob.cpp
+++ b/src/modules/umount/UmountJob.cpp
@@ -78,6 +78,18 @@ unmountTargetMounts( const QString& rootMountPoint )
                     .arg( m.device, m.mountPoint ) );
         }
     }
+
+    // Last we unmount the root
+    if ( Calamares::Partition::unmount( rootMountPoint, { "-lv" } ) != 0 )
+    {
+        return Calamares::JobResult::error(
+            QCoreApplication::translate( UmountJob::staticMetaObject.className(),
+                                         "Could not unmount the root of target system." ),
+            QCoreApplication::translate( UmountJob::staticMetaObject.className(),
+                                         "The device mounted at %1 could not be unmounted." )
+                .arg( rootMountPoint ) );
+    }
+
     return Calamares::JobResult::ok();
 }
 
@@ -139,6 +151,7 @@ UmountJob::exec()
             return r;
         }
     }
+
     // For ZFS systems, export the pools
     {
         auto r = exportZFSPools();


### PR DESCRIPTION
Currently, Calamares doesn't unmount the root.  It only unmounts everything under the root.

I fixed this quickly during an EndeavourOS release.  

After reviewing it, I realized I didn't upstream it because I am not sure this is the most elegant solution.  I think it would be better to figure out why the root isn't being added to the list and fix that.

Fixes https://github.com/calamares/calamares/issues/2366