### PR TITLE
Should fix grub not adding lang section in /boot/grub/grub.cfg file as

### DIFF
--- a/src/modules/localecfg/main.py
+++ b/src/modules/localecfg/main.py
@@ -133,6 +133,9 @@ def run():
             'LC_IDENTIFICATION': 'en_US.UTF-8'
         }
 
+    # Should fix grub lang (set as IE at boot when not set) and locales in /boot/grub/grub.cfg
+    os.environ["LANG"]=locale_conf["LANG"]
+
     install_path = libcalamares.globalstorage.value("rootMountPoint")
 
     if install_path is None:


### PR DESCRIPTION
chroot take host env LANG variable and this value is usually LANG=C.UTF-8 when booting a live installer.

Pb is only visible at boot when prompted to unlock Luks partition. 
In this case, screen show a IE keymap instead of keymap of LANG selected by user in Calamares.

Note that in this case, on ubuntu,  a "setupcon --save-only" and "update-initramfs -u" may be missing to generate /etc/console-setup/cached_UTF-8_del.kmap.gz and make this file integrated in initramfs to be able to unlock Luks partitions with the keymap selected in calamares.

This quick fix is related to https://github.com/calamares/calamares/issues/2371