### PR TITLE
Fix a syntax error in Presentation.qml which prevents the slideshow from displaying

### DIFF
--- a/src/qml/calamares-qt6/slideshow/Presentation.qml
+++ b/src/qml/calamares-qt6/slideshow/Presentation.qml
@@ -196,12 +196,7 @@ Item {
                 Text {
                     id: notesText
 
-                    property real padding: 16;
-
-                    x: padding
-                    y: padding
-                    width: parent.width - 2 * padding
-
+                    anchors.margins: 16
 
                     font.pixelSize: 16
                     wrapMode: Text.WordWrap


### PR DESCRIPTION
This was the only change necessary for switching to Qt 6 on Lubuntu's end