### PR TITLE
[dracut] Add an options setting for additional Dracut parameters

### DIFF
--- a/src/modules/dracut/dracut.conf
+++ b/src/modules/dracut/dracut.conf
@@ -8,3 +8,8 @@
 # set a custom name, including the path
 #
 initramfsName: /boot/initramfs-freebsd.img
+
+# Optional: define a list of strings to be passed as arguments to Dracut
+# By default, -f is always included
+options:
+  - "-f"

--- a/src/modules/dracut/dracut.conf
+++ b/src/modules/dracut/dracut.conf
@@ -11,5 +11,4 @@ initramfsName: /boot/initramfs-freebsd.img
 
 # Optional: define a list of strings to be passed as arguments to Dracut
 # By default, -f is always included
-options:
-  - "-f"
+options: [ "-f" ]

--- a/src/modules/dracut/dracut.schema.yaml
+++ b/src/modules/dracut/dracut.schema.yaml
@@ -7,3 +7,4 @@ additionalProperties: false
 type: object
 properties:
     initramfsName: { type: string }
+    options: { type: array, items: { type: string } }

--- a/src/modules/dracut/main.py
+++ b/src/modules/dracut/main.py
@@ -35,15 +35,22 @@ def run_dracut():
 
     :return:
     """
+    # Fetch the job configuration
+    cli_options = ["-f"]
+    initramfs_name = libcalamares.job.configuration.get('initramfsName', None)
+    dracut_options = libcalamares.job.configuration.get('options', [])
+
+    # Parse the custom options if there are any
+    for option in dracut_options:
+        # Deduplication check
+        if option not in cli_options:
+            cli_options.append(option)
+
+    if initramfs_name:
+        cli_options.append(initramfs_name)
+
     try:
-        initramfs_name = libcalamares.job.configuration['initramfsName']
-        target_env_process_output(['dracut', '-f', initramfs_name])
-    except KeyError:
-        try:
-            target_env_process_output(['dracut', '-f'])
-        except subprocess.CalledProcessError as cpe:
-            libcalamares.utils.warning(f"Dracut failed with output: {cpe.output}")
-            return cpe.returncode
+        target_env_process_output(['dracut'] + cli_options)
     except subprocess.CalledProcessError as cpe:
         libcalamares.utils.warning(f"Dracut failed with output: {cpe.output}")
         return cpe.returncode

--- a/src/modules/dracut/main.py
+++ b/src/modules/dracut/main.py
@@ -36,21 +36,14 @@ def run_dracut():
     :return:
     """
     # Fetch the job configuration
-    cli_options = ["-f"]
     initramfs_name = libcalamares.job.configuration.get('initramfsName', None)
-    dracut_options = libcalamares.job.configuration.get('options', [])
-
-    # Parse the custom options if there are any
-    for option in dracut_options:
-        # Deduplication check
-        if option not in cli_options:
-            cli_options.append(option)
+    dracut_options = libcalamares.job.configuration.get('options', ['-f'])
 
     if initramfs_name:
-        cli_options.append(initramfs_name)
+        dracut_options.append(initramfs_name)
 
     try:
-        target_env_process_output(['dracut'] + cli_options)
+        target_env_process_output(['dracut'] + dracut_options)
     except subprocess.CalledProcessError as cpe:
         libcalamares.utils.warning(f"Dracut failed with output: {cpe.output}")
         return cpe.returncode


### PR DESCRIPTION
Lubuntu is in the process of switching to Dracut.

Due to [Ubuntu bug 2084809](https://bugs.launchpad.net/ubuntu/+source/dracut/+bug/2084809), we need to be able to override the options passed to Dracut.

This adds the `options` config entry, which is optional.