### PR TITLE
Properly close LUKS partitions after installation is complete

### DIFF
--- a/src/libcalamares/partition/Mount.cpp
+++ b/src/libcalamares/partition/Mount.cpp
@@ -84,6 +84,15 @@ unmount( const QString& path, const QStringList& options )
     return r.getExitCode();
 }
 
+int
+closeCryptsetup( const QString& luksMapperName )
+{
+    QStringList args = { "cryptsetup", "close", luksMapperName };
+    auto r = Calamares::System::runCommand( QStringList { "cryptsetup", "close", luksMapperName } , std::chrono::seconds( 10 ) );
+    sync();
+    return r.getExitCode();
+}
+
 struct TemporaryMount::Private
 {
     QString m_devicePath;

--- a/src/libcalamares/partition/Mount.h
+++ b/src/libcalamares/partition/Mount.h
@@ -51,6 +51,13 @@ DLLEXPORT int mount( const QString& devicePath,
  */
 DLLEXPORT int unmount( const QString& path, const QStringList& options = QStringList() );
 
+/** @brief Use cryptsetup to close the given @p LUKS mapper name.
+ *
+ * Runs cryptsetup(8) in the host system.
+ *
+ * @returns the program's exit code
+ */
+DLLEXPORT int closeCryptsetup( const QString& luksMapperName );
 
 /** @brief Mount and automatically unmount a device
  *


### PR DESCRIPTION
The unmount module only unmounts the root partition, and does not close any encrypted partitions. This allows the user to still re-mount the drive without having to enter the encryption password again.

This pull request fixes it. There is some further cleanup to do in the `partition` module, to move the unmount and mount calls (encryption and not) to libcalamares. I'd like to see #2400 merged before that.