### PR TITLE
A SEGV may occur when collecting boot loader information.(#2405)

### DIFF
--- a/src/modules/partition/core/BootLoaderModel.cpp
+++ b/src/modules/partition/core/BootLoaderModel.cpp
@@ -42,6 +42,7 @@ BootLoaderModel::~BootLoaderModel() {}
 void
 BootLoaderModel::init( const QList< Device* >& devices )
 {
+    QMutexLocker lock( &m_lock );
     beginResetModel();
     blockSignals( true );
 
@@ -65,6 +66,7 @@ BootLoaderModel::createMbrItems()
 void
 BootLoaderModel::update()
 {
+    QMutexLocker lock( &m_lock );
     beginResetModel();
     blockSignals( true );
     updateInternal();
@@ -76,7 +78,7 @@ BootLoaderModel::update()
 void
 BootLoaderModel::updateInternal()
 {
-    QMutexLocker lock( &m_lock );
+    QMutexLocker lock( &m_lock_data );
     clear();
     createMbrItems();
 
@@ -135,7 +137,12 @@ BootLoaderModel::updateInternal()
 QVariant
 BootLoaderModel::data( const QModelIndex& index, int role ) const
 {
-    QMutexLocker lock( &m_lock );
+    QMutexLocker lock( &m_lock_data );
+
+    if (!index.isValid()) {
+        return QVariant();
+    }
+
     if ( role == Qt::DisplayRole )
     {
         QString displayRole = QStandardItemModel::data( index, Qt::DisplayRole ).toString();

--- a/src/modules/partition/core/BootLoaderModel.h
+++ b/src/modules/partition/core/BootLoaderModel.h
@@ -58,6 +58,7 @@ public:
 private:
     DeviceList m_devices;
     mutable QMutex m_lock;
+    mutable QMutex m_lock_data;
 
     void createMbrItems();
     void updateInternal();


### PR DESCRIPTION
fix #2405

    14:33:33 [2]: WARNING (Qt): beginResetModel called on BootLoaderModel(0x5555565c5b70) without calling endResetModel first
    14:33:33 [2]: WARNING (Qt): endResetModel called on BootLoaderModel(0x5555565c5b70) without calling beginResetModel first
    14:33:33 [2]: WARNING (Qt): beginResetModel called on BootLoaderModel(0x5555565c5b70) without calling endResetModel first
    14:33:33 [2]: WARNING (Qt): endResetModel called on BootLoaderModel(0x5555565c5b70) without calling beginResetModel first

    Thread 1 "calamares" received signal SIGSEGV, Segmentation fault. 0x00007ffff60c8b65 in ?? () from /usr/lib/libQt6Gui.so.6