### PR TITLE
Allow hiding LVM buttons

### DIFF
--- a/CMakeModules/KPMcoreHelper.cmake
+++ b/CMakeModules/KPMcoreHelper.cmake
@@ -41,8 +41,8 @@ if(NOT TARGET calapmcore)
 
         target_link_libraries(calapmcore INTERFACE kpmcore ${qtname}::DBus ${kfname}::I18n ${kfname}::WidgetsAddons)
         target_include_directories(calapmcore INTERFACE ${KPMCORE_INCLUDE_DIR})
-        # If there were KPMcore API variations, figure them out here
-        # target_compile_definitions(calapmcore INTERFACE WITH_KPMcore)
+        math(EXPR _kpm_version_number "(0x${KPMcore_VERSION_MAJOR} * 0x10000)+(0x${KPMcore_VERSION_MINOR} * 0x100)+(0x${KPMcore_VERSION_PATCH})" OUTPUT_FORMAT HEXADECIMAL)
+        target_compile_definitions(calapmcore INTERFACE WITH_KPMcore=${_kpm_version_number})
 
         # Flag that this library has KPMcore support. A variable
         # set here has the wrong scope. ENV{} would be visible

--- a/src/modules/partition/Config.cpp
+++ b/src/modules/partition/Config.cpp
@@ -448,6 +448,12 @@ Config::setConfigurationMap( const QVariantMap& configurationMap )
     m_showNotEncryptedBootMessage = Calamares::getBool( configurationMap, "showNotEncryptedBootMessage", true );
     m_requiredPartitionTableType = Calamares::getStringList( configurationMap, "requiredPartitionTableType" );
 
+    {
+        bool bogus = true;
+        const auto lvmConfiguration = Calamares::getSubMap( configurationMap, "lvm", bogus );
+        m_isLVMEnabled = Calamares::getBool( lvmConfiguration, "enable", true);
+    }
+
     Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
     gs->insert( "armInstall", Calamares::getBool( configurationMap, "armInstall", false ) );
     fillGSConfigurationEFI( gs, configurationMap );

--- a/src/modules/partition/Config.h
+++ b/src/modules/partition/Config.h
@@ -38,6 +38,8 @@ class Config : public QObject
     Q_PROPERTY( bool preCheckEncryption READ preCheckEncryption CONSTANT FINAL )
     Q_PROPERTY( bool showNotEncryptedBootMessage READ showNotEncryptedBootMessage CONSTANT FINAL )
 
+    Q_PROPERTY( bool lvmEnabled READ isLVMEnabled CONSTANT FINAL )
+
 public:
     Config( QObject* parent );
     ~Config() override = default;
@@ -174,6 +176,8 @@ public:
     /// @brief If zfs encryption should be allowed
     bool allowZfsEncryption() const { return m_allowZfsEncryption; }
 
+    bool isLVMEnabled() const { return m_isLVMEnabled; }
+
 public Q_SLOTS:
     void setInstallChoice( int );  ///< Translates a button ID or so to InstallChoice
     void setInstallChoice( InstallChoice );
@@ -208,6 +212,7 @@ private:
     bool m_allowManualPartitioning = true;
     bool m_preCheckEncryption = false;
     bool m_showNotEncryptedBootMessage = true;
+    bool m_isLVMEnabled = true;
 };
 
 /** @brief Given a set of swap choices, return a sensible value from it.

--- a/src/modules/partition/PartitionViewStep.cpp
+++ b/src/modules/partition/PartitionViewStep.cpp
@@ -361,7 +361,7 @@ PartitionViewStep::next()
         {
             if ( !m_manualPartitionPage )
             {
-                m_manualPartitionPage = new PartitionPage( m_core );
+                m_manualPartitionPage = new PartitionPage( m_core, *m_config );
                 m_widget->addWidget( m_manualPartitionPage );
             }
 

--- a/src/modules/partition/core/KPMHelpers.h
+++ b/src/modules/partition/core/KPMHelpers.h
@@ -149,6 +149,19 @@ execute( Operation&& operation, const QString& failureMessage )
     return execute( operation, failureMessage );
 }
 
+/** @brief Is this an MSDOS partition table?
+ *
+ * Deals with KPMcore deprecations in the TableType enum.
+ */
+inline bool isMSDOSPartition(PartitionTable::TableType t)
+{
+#if WITH_KPMcore > 0x240801
+    return t == PartitionTable::TableType::msdos;
+#else
+    return t == PartitionTable::TableType::msdos || t == PartitionTable::TableType::msdos_sectorbased;
+#endif
+}
+
 }  // namespace KPMHelpers
 
 #endif /* KPMHELPERS_H */

--- a/src/modules/partition/gui/CreatePartitionDialog.cpp
+++ b/src/modules/partition/gui/CreatePartitionDialog.cpp
@@ -82,8 +82,7 @@ CreatePartitionDialog::CreatePartitionDialog( Device* device,
         m_ui->lvNameLineEdit->setValidator( validator );
     }
 
-    if ( device->partitionTable()->type() == PartitionTable::msdos
-         || device->partitionTable()->type() == PartitionTable::msdos_sectorbased )
+    if ( KPMHelpers::isMSDOSPartition( device->partitionTable()->type() ) )
     {
         initMbrPartitionTypeUi();
     }

--- a/src/modules/partition/gui/DeviceInfoWidget.cpp
+++ b/src/modules/partition/gui/DeviceInfoWidget.cpp
@@ -73,7 +73,15 @@ DeviceInfoWidget::retranslateUi()
     switch ( m_tableType )
     {
     case PartitionTable::msdos:
+#if WITH_KPMcore > 0x240801
+    // Pick your warning: either deprecation warning, or unchecked enum-switch
+QT_WARNING_PUSH
+QT_WARNING_DISABLE_DEPRECATED
+#endif
     case PartitionTable::msdos_sectorbased:
+#if WITH_KPMcore > 0x240801
+QT_WARNING_POP
+#endif
         typeString = "MBR";
         toolTipString += tr( "<br><br>This partition table type is only advisable on older "
                              "systems which start from a <strong>BIOS</strong> boot "

--- a/src/modules/partition/gui/PartitionPage.cpp
+++ b/src/modules/partition/gui/PartitionPage.cpp
@@ -54,16 +54,6 @@
 #include <QPointer>
 #include <QtConcurrent/QtConcurrent>
 
-///@brief At some point the msdos_sectorbased partition table type was retired
-static bool isMSDOSPartition(PartitionTable::TableType t)
-{
-#if WITH_KPMcore > 0x240801
-    return t == PartitionTable::TableType::msdos;
-#else
-    return t == PartitionTable::TableType::msdos || t == PartitionTable::TableType::msdos_sectorbased;
-#endif
-}
-
 PartitionPage::PartitionPage( PartitionCoreModule* core, const Config & config, QWidget* parent )
     : QWidget( parent )
     , m_ui( new Ui_PartitionPage )
@@ -265,7 +255,7 @@ PartitionPage::checkCanCreate( Device* device )
 {
     auto table = device->partitionTable();
 
-    if ( isMSDOSPartition( table->type() ) )
+    if ( KPMHelpers::isMSDOSPartition( table->type() ) )
     {
         cDebug() << "Checking MSDOS partition" << table->numPrimaries() << "primaries, max" << table->maxPrimaries();
 

--- a/src/modules/partition/gui/PartitionPage.cpp
+++ b/src/modules/partition/gui/PartitionPage.cpp
@@ -15,6 +15,7 @@
 #include "PartitionPage.h"
 
 // Local
+#include "Config.h"
 #include "core/BootLoaderModel.h"
 #include "core/DeviceModel.h"
 #include "core/KPMHelpers.h"
@@ -39,14 +40,12 @@
 #include "utils/Retranslator.h"
 #include "widgets/TranslationFix.h"
 
-// KPMcore
 #include <kpmcore/core/device.h>
 #include <kpmcore/core/partition.h>
 #include <kpmcore/core/softwareraid.h>
 #include <kpmcore/ops/deactivatevolumegroupoperation.h>
 #include <kpmcore/ops/removevolumegroupoperation.h>
 
-// Qt
 #include <QDir>
 #include <QFutureWatcher>
 #include <QHeaderView>
@@ -55,13 +54,18 @@
 #include <QPointer>
 #include <QtConcurrent/QtConcurrent>
 
-PartitionPage::PartitionPage( PartitionCoreModule* core, QWidget* parent )
+PartitionPage::PartitionPage( PartitionCoreModule* core, const Config & config, QWidget* parent )
     : QWidget( parent )
     , m_ui( new Ui_PartitionPage )
     , m_core( core )
     , m_lastSelectedBootLoaderIndex( -1 )
     , m_isEfi( PartUtils::isEfiSystem() )
 {
+    if ( config.installChoice() != Config::InstallChoice::Manual )
+    {
+        cWarning() << "Manual partitioning page created without user choosing manual-partitioning.";
+    }
+
     m_ui->setupUi( this );
     m_ui->partitionLabelsView->setVisible(
         Calamares::JobQueue::instance()->globalStorage()->value( "alwaysShowPartitionLabels" ).toBool() );

--- a/src/modules/partition/gui/PartitionPage.cpp
+++ b/src/modules/partition/gui/PartitionPage.cpp
@@ -54,6 +54,16 @@
 #include <QPointer>
 #include <QtConcurrent/QtConcurrent>
 
+///@brief At some point the msdos_sectorbased partition table type was retired
+static bool isMSDOSPartition(PartitionTable::TableType t)
+{
+#if WITH_KPMcore > 0x240801
+    return t == PartitionTable::TableType::msdos;
+#else
+    return t == PartitionTable::TableType::msdos || t == PartitionTable::TableType::msdos_sectorbased;
+#endif
+}
+
 PartitionPage::PartitionPage( PartitionCoreModule* core, const Config & config, QWidget* parent )
     : QWidget( parent )
     , m_ui( new Ui_PartitionPage )
@@ -253,7 +263,7 @@ PartitionPage::checkCanCreate( Device* device )
 {
     auto table = device->partitionTable();
 
-    if ( table->type() == PartitionTable::msdos || table->type() == PartitionTable::msdos_sectorbased )
+    if ( isMSDOSPartition( table->type() ) )
     {
         cDebug() << "Checking MSDOS partition" << table->numPrimaries() << "primaries, max" << table->maxPrimaries();
 

--- a/src/modules/partition/gui/PartitionPage.cpp
+++ b/src/modules/partition/gui/PartitionPage.cpp
@@ -88,6 +88,8 @@ PartitionPage::PartitionPage( PartitionCoreModule* core, const Config & config, 
         ? PartitionBarsView::DrawNestedPartitions
         : PartitionBarsView::NoNestedPartitions;
     m_ui->partitionBarsView->setNestedPartitionsMode( mode );
+    m_ui->lvmButtonPanel->setVisible( config.isLVMEnabled() );
+
     updateButtons();
     updateBootLoaderInstallPath();
 

--- a/src/modules/partition/gui/PartitionPage.cpp
+++ b/src/modules/partition/gui/PartitionPage.cpp
@@ -60,10 +60,8 @@ PartitionPage::PartitionPage( PartitionCoreModule* core, QWidget* parent )
     , m_ui( new Ui_PartitionPage )
     , m_core( core )
     , m_lastSelectedBootLoaderIndex( -1 )
-    , m_isEfi( false )
+    , m_isEfi( PartUtils::isEfiSystem() )
 {
-    m_isEfi = PartUtils::isEfiSystem();
-
     m_ui->setupUi( this );
     m_ui->partitionLabelsView->setVisible(
         Calamares::JobQueue::instance()->globalStorage()->value( "alwaysShowPartitionLabels" ).toBool() );

--- a/src/modules/partition/gui/PartitionPage.h
+++ b/src/modules/partition/gui/PartitionPage.h
@@ -16,6 +16,7 @@
 #include <QScopedPointer>
 #include <QWidget>
 
+class Config;
 class PartitionCoreModule;
 class Ui_PartitionPage;
 
@@ -32,7 +33,7 @@ class PartitionPage : public QWidget
 {
     Q_OBJECT
 public:
-    explicit PartitionPage( PartitionCoreModule* core, QWidget* parent = nullptr );
+    explicit PartitionPage( PartitionCoreModule* core, const Config & config, QWidget* parent = nullptr );
     ~PartitionPage() override;
 
     void onRevertClicked();

--- a/src/modules/partition/gui/PartitionPage.ui
+++ b/src/modules/partition/gui/PartitionPage.ui
@@ -11,7 +11,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <x>0</x>
     <y>0</y>
     <width>684</width>
-    <height>304</height>
+    <height>327</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -129,36 +129,38 @@ SPDX-License-Identifier: GPL-3.0-or-later
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <widget class="QPushButton" name="newVolumeGroupButton">
-       <property name="text">
-        <string>New Volume Group</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="resizeVolumeGroupButton">
-       <property name="text">
-        <string>Resize Volume Group</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="deactivateVolumeGroupButton">
-       <property name="text">
-        <string>Deactivate Volume Group</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="removeVolumeGroupButton">
-       <property name="text">
-        <string>Remove Volume Group</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QWidget" name="lvmButtonPanel" native="true">
+     <layout class="QHBoxLayout" name="lvmButtonLayout">
+      <item>
+       <widget class="QPushButton" name="newVolumeGroupButton">
+        <property name="text">
+         <string>New Volume Group</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="resizeVolumeGroupButton">
+        <property name="text">
+         <string>Resize Volume Group</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="deactivateVolumeGroupButton">
+        <property name="text">
+         <string>Deactivate Volume Group</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="removeVolumeGroupButton">
+        <property name="text">
+         <string>Remove Volume Group</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <spacer name="verticalSpacer">

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -247,6 +247,13 @@ defaultFileSystemType:  "ext4"
 # to cypher their disk when installing in enterprise (for exemple).
 #preCheckEncryption:    false
 
+# LVM support
+#
+# There is only one sub-key available, *enable* (defaults to true)
+# which can be used to show (default) or hide the LVM buttons in the partitioning module.
+lvm:
+    enable: true
+
 # Partition layout.
 #
 # This optional setting specifies a custom partition layout.

--- a/src/modules/partition/partition.schema.yaml
+++ b/src/modules/partition/partition.schema.yaml
@@ -20,6 +20,12 @@ properties:
             mountPoint: { type: string }
         additionalProperties: false
 
+    lvm:
+        type: object
+        properties:
+            enable: { type: boolean, default: true }
+        additionalProperties: false
+
     userSwapChoices: { type: array, items: { type: string, enum: [ none, reuse, small, suspend, file ] } }
     # ensureSuspendToDisk: { type: boolean, default: true }  # Legacy
     # neverCreateSwap: { type: boolean, default: false }  # Legacy


### PR DESCRIPTION
Fixes #2343 , I suppose.

This adds a configuration option that hides the LVM buttons in the manual partitioning page. It doesn't change any of the LVM code. I think it's a bit of a cop-out on the part of people who might care about LVM -- but it seems that there are not enough (or any) of them. Distro's can then switch off the UI and the user can't footgun themselves.