### PR TITLE
If you selected "Manual Partitioning", Scan for partition information.

### DIFF
--- a/src/modules/partition/gui/ChoicePage.cpp
+++ b/src/modules/partition/gui/ChoicePage.cpp
@@ -586,8 +586,21 @@ ChoicePage::applyActionChoice( InstallChoice choice )
                  &ChoicePage::doAlongsideSetupSplitter,
                  Qt::UniqueConnection );
         break;
-    case InstallChoice::NoChoice:
     case InstallChoice::Manual:
+        if ( m_core->isDirty() )
+        {
+            ScanningDialog::run(
+                QtConcurrent::run(
+                    [ = ]
+                    {
+                        QMutexLocker locker( &m_coreMutex );
+                        m_core->revertDevice( selectedDevice() );
+                    } ),
+                [] {},
+                this );
+        }
+        break;
+    case InstallChoice::NoChoice:
         break;
     }
     updateNextEnabled();


### PR DESCRIPTION
fix for #2405
When you select manual partitioning and click Next, after the screen changes, a partition information scan is performed, and then a SEGV may occur.
To prevent this, I added a process to scan the partition information when you select manual partitioning in the menu, just like when you select other menus.