### PR TITLE
[libcalamares] Use Qt helper macros for compiler warnings

### DIFF
--- a/src/libcalamares/utils/moc-warnings.h
+++ b/src/libcalamares/utils/moc-warnings.h
@@ -22,6 +22,8 @@
  * automoc does all the work for us.
  */
 #ifdef __clang__
+#include <qglobal.h>
+QT_WARNING_PUSH
 QT_WARNING_DISABLE_CLANG( "-Wextra-semi-stmt" )
 QT_WARNING_DISABLE_CLANG( "-Wredundant-parens" )
 QT_WARNING_DISABLE_CLANG( "-Wreserved-identifier" )
@@ -29,4 +31,5 @@ QT_WARNING_DISABLE_CLANG( "-Wreserved-identifier" )
 #if __clang_major__ >= 17
 QT_WARNING_DISABLE_CLANG( "-Wunsafe-buffer-usage" )
 #endif
+QT_WARNING_POP
 #endif


### PR DESCRIPTION
Fixed to the same format as [src/libcalamares/partition/KPMHelper.h](https://github.com/calamares/calamares/blob/e6fa229b18992e5d26cd4493c942af6748d70fe7/src/libcalamares/partition/KPMHelper.h).

```
In file included from src/calamares/build/src/libcalamares/calamares_autogen/mocs_compilation.cpp:2:
In file included from src/calamares/build/src/libcalamares/calamares_autogen/EWIEGA46WW/moc_CppJob.cpp:9:
src/calamares/src/libcalamares/utils/moc-warnings.h:25:1: error: a type specifier is required for all declarations
   25 | QT_WARNING_DISABLE_CLANG( "-Wextra-semi-stmt" )
      | ^
src/calamares/src/libcalamares/utils/moc-warnings.h:25:48: error: expected ';' after top level declarator
   25 | QT_WARNING_DISABLE_CLANG( "-Wextra-semi-stmt" )
      |                                                ^
      |                                                ;
```
