### PR TITLE
Hybrid bootloader (BIOS+UEFI) installation support

### DIFF
--- a/src/modules/bootloader/bootloader.conf
+++ b/src/modules/bootloader/bootloader.conf
@@ -81,3 +81,6 @@ efiBootMgr: "efibootmgr"
 # to add another module to optionally install the fallback on those
 # boards that need it.
 installEFIFallback: true
+
+# Optionally install both BIOS and UEFI GRUB bootloaders.
+installHybridGRUB: false

--- a/src/modules/bootloader/bootloader.schema.yaml
+++ b/src/modules/bootloader/bootloader.schema.yaml
@@ -24,3 +24,4 @@ properties:
 
     efiBootloaderId:  { type: string }
     installEFIFallback: { type: boolean }
+    installHybridGRUB: { type: boolean }

--- a/src/modules/bootloader/main.py
+++ b/src/modules/bootloader/main.py
@@ -658,7 +658,7 @@ def run_grub_install(fw_type, partitions, efi_directory, install_hybrid_grub):
                 return
             
         # boot_loader_install_path points to the physical disk to install GRUB
-        # to. It should start with "/dev/", and be at least as long as the 
+        # to. It should start with "/dev/", and be at least as long as the
         # string "/dev/sda".
         if not boot_loader_install_path.startswith("/dev/") or len(boot_loader_install_path) < 8:
             raise ValueError(f"boot_loader_install_path contains unexpected value '{boot_loader_install_path}'")

--- a/src/modules/bootloader/main.py.orig
+++ b/src/modules/bootloader/main.py.orig
@@ -637,20 +637,16 @@ def run_grub_install(fw_type, partitions, efi_directory, install_hybrid_grub):
                                    "--bootloader-id=" + efi_bootloader_id,
                                    "--force"])
     else:
-        if efi_directory is not None and not install_hybrid_grub:
-            libcalamares.utils.warning(_("Cannot install BIOS bootloader on UEFI installation when install_hybrid_grub is 'False'!"))
-            return
+        if efi_directory is not None:
+            if not install_hybrid_grub:
+                return
 
         if libcalamares.globalstorage.value("bootLoader") is None:
             efi_install_path = libcalamares.globalstorage.value("efiSystemPartition")
             if efi_install_path is None or efi_install_path == "":
                 efi_install_path = "/boot/efi"
-            find_esp_disk_command = f"lsblk -o PKNAME \"$(df --output=source '{efi_install_path}' | tail -n1)\""
+            find_esp_disk_command = f"echo \"/dev/$(lsblk -o PKNAME $(df --output=source '{efi_install_path}' | tail -n1) | tail -n1)\""
             boot_loader_install_path = check_target_env_output(["sh", "-c", find_esp_disk_command]).strip()
-            if not "\n" in boot_loader_install_path:
-                libcalamares.utils.warning(_("Cannot find the drive containing the EFI system partition!"))
-                return
-            boot_loader_install_path = "/dev/" + boot_loader_install_path.split("\n")[1]
         else:
             boot_loader = libcalamares.globalstorage.value("bootLoader")
             boot_loader_install_path = boot_loader["installPath"]
@@ -658,8 +654,8 @@ def run_grub_install(fw_type, partitions, efi_directory, install_hybrid_grub):
                 return
             
         # boot_loader_install_path points to the physical disk to install GRUB
-        # to. It should start with "/dev/", and be at least as long as the 
-        # string "/dev/sda".
+        # to. It should start with `/dev/` be at least as long as the string
+        # `/dev/sda`.
         if not boot_loader_install_path.startswith("/dev/") or len(boot_loader_install_path) < 8:
             raise ValueError(f"boot_loader_install_path contains unexpected value '{boot_loader_install_path}'")
 

--- a/src/modules/partition/PartitionViewStep.cpp
+++ b/src/modules/partition/PartitionViewStep.cpp
@@ -918,6 +918,8 @@ PartitionViewStep::setConfigurationMap( const QVariantMap& configurationMap )
                       "will use gpt for efi or msdos for bios";
     }
     gs->insert( "defaultPartitionTableType", partitionTableName );
+    gs->insert( "createHybridBootloaderLayout",
+                Calamares::getBool( configurationMap, "createHybridBootloaderLayout", false ) );
 
     // Now that we have the config, we load the PartitionCoreModule in the background
     // because it could take a while. Then when it's done, we can set up the widgets

--- a/src/modules/partition/gui/PartitionLabelsView.cpp
+++ b/src/modules/partition/gui/PartitionLabelsView.cpp
@@ -13,6 +13,7 @@
 #include "core/ColorUtils.h"
 #include "core/PartitionModel.h"
 #include "core/SizeUtils.h"
+#include "core/KPMHelpers.h"
 
 #include "utils/Gui.h"
 #include "utils/Logger.h"
@@ -20,6 +21,7 @@
 
 #include <kpmcore/core/device.h>
 #include <kpmcore/fs/filesystem.h>
+#include <kpmcore/core/partition.h>
 
 // Qt
 #include <QGuiApplication>
@@ -39,6 +41,12 @@ buildUnknownDisklabelTexts( Device* dev )
     QStringList texts = { QObject::tr( "Unpartitioned space or unknown partition table", "@info" ),
                           formatByteSize( dev->totalLogical() * dev->logicalSize() ) };
     return texts;
+}
+
+static uint
+getPartitionModelIndexFlags( const QModelIndex& index )
+{
+    return static_cast< Partition* >( index.data( PartitionModel::PartitionPtrRole ).value< void* >() )->property( "_calamares_flags" ).toUInt();
 }
 
 PartitionLabelsView::PartitionLabelsView( QWidget* parent )
@@ -189,6 +197,11 @@ PartitionLabelsView::buildTexts( const QModelIndex& index ) const
                       && index.data( PartitionModel::FileSystemTypeRole ).toInt() == FileSystem::Fat32 )
             {
                 firstLine = tr( "EFI system", "@label" );
+            }
+            else if ( index.data( PartitionModel::FileSystemTypeRole ).toInt() == FileSystem::Unformatted
+                      && getPartitionModelIndexFlags( index ) & KPM_PARTITION_FLAG( BiosGrub ) )
+            {
+                firstLine = tr("BIOS boot", "@label" );
             }
             else if ( index.data( PartitionModel::FileSystemTypeRole ).toInt() == FileSystem::LinuxSwap )
             {

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -178,6 +178,13 @@ initialSwapChoice: none
 #
 # defaultPartitionTableType: msdos
 
+# Specify whether to create a partition table layout suitable for a hybrid
+# (BIOS + EFI) bootloader installation. This will prepend both bios-boot and
+# EFI system partitions to the partition layout, regardless of whether the
+# booted system uses BIOS or EFI firmware. Defaults to false.
+#
+# createHybridBootloaderLayout: false
+
 # Requirement for partition table type
 #
 # Restrict the installation on disks that match the type of partition


### PR DESCRIPTION
It would be very handy for some use case scenarios if Calamares could be configured to install both BIOS and GRUB bootloaders on the same system. The primary use for this would be portable installations, where someone does a full install of a distro onto a USB flash drive that they then intend to run on multiple physical machines with varying types of firmware. Currently Calamares can only install the bootloader matching the firmware type of the system being booted though. This PR attempts to change that by adding an option `installHybridGRUB` to `bootloader.conf`. When enabled, Calamares will attempt to install both BIOS and UEFI GRUB bootloaders.

Note, I'm not sure if the approach I'm taking here is correct - it seems a bit overly hacky. This PR also isn't complete - it still needs to tackle a problem with partitioning (namely, the EFI system partition is only made on EFI systems, so on BIOS systems, one has to specify an ESP themselves in partition.conf... but if you do that, you end up with two ESPs on EFI systems, because Calamares will add an ESP regardless of whether one already exists in the partition layout or not).