### PR TITLE
Save obfuscated luks passphrase in calamares globals variables

### DIFF
--- a/src/modules/partition/gui/ChoicePage.cpp
+++ b/src/modules/partition/gui/ChoicePage.cpp
@@ -41,6 +41,7 @@
 #include "utils/Logger.h"
 #include "utils/Retranslator.h"
 #include "utils/Units.h"
+#include "utils/String.h"
 #include "widgets/PrettyRadioButton.h"
 
 #include <kpmcore/core/device.h>
@@ -689,6 +690,13 @@ ChoicePage::onHomeCheckBoxStateChanged()
 void
 ChoicePage::onLeave()
 {
+    Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
+    if ( m_encryptWidget->state() == EncryptWidget::Encryption::Confirmed ) {
+        gs->insert( "passphrase", Calamares::String::obscure( m_encryptWidget->passphrase() ) );
+    }else{
+        gs->insert( "passphrase", "" );
+    }
+
     if ( m_config->installChoice() == InstallChoice::Alongside )
     {
         if ( m_afterPartitionSplitterWidget->splitPartitionSize() >= 0


### PR DESCRIPTION
Save obfuscated luks passphrase in calamares globals variables.
We use the same obfuscating function as for user password.
Passphrase can be used later in a dedicated calamares module to associates token device with passphrase to unlock a Luks partition at boot.
