### PR TITLE
[parition] Do not unmount /dev/mapper/ventoy

### DIFF
--- a/src/modules/partition/jobs/ClearMountsJob.cpp
+++ b/src/modules/partition/jobs/ClearMountsJob.cpp
@@ -105,18 +105,20 @@ getSwapsForDevice( const QString& deviceName )
 }
 
 static inline bool
-isControl( const QString& baseName )
-{
-    return baseName == "control";
-}
-
-static inline bool
-isFedoraSpecial( const QString& baseName )
+isSpecial( const QString& baseName )
 {
     // Fedora live images use /dev/mapper/live-* internally. We must not
     // unmount those devices, because they are used by the live image and
     // because we need /dev/mapper/live-base in the unpackfs module.
-    return baseName.startsWith( "live-" );
+    if (baseName.startsWith( "live-" ))
+        return true;
+    // Exclude /dev/mapper/control
+    if (baseName == "control")
+        return true;
+    // When ventoy is used, ventoy uses the /dev/mapper/ventoy device. We
+    // must not unmount this device, because it is used by the live image
+    // and because we need /dev/mapper/ventoy in the unpackfs module.
+    return baseName == "ventoy";
 }
 
 /** @brief Returns a list of unneeded crypto devices
@@ -135,7 +137,7 @@ getCryptoDevices( const QStringList& mapperExceptions )
     for ( const QFileInfo& fi : fiList )
     {
         QString baseName = fi.baseName();
-        if ( isControl( baseName ) || isFedoraSpecial( baseName ) || mapperExceptions.contains( baseName ) )
+        if ( isSpecial( baseName ) || mapperExceptions.contains( baseName ) )
         {
             continue;
         }


### PR DESCRIPTION
Ventoy uses /dev/mapper/ventoy to provide the ISO. Unmounting /dev/mapper/ventoy is not desired since certain ISOs may have mounts that rely on it existing for the unpackfs step (for example, Garuda Linux).

This patch reorganizes isControl and isFedoraSpecial into a new function called isSpecial, which combines the function of the previous 2 and also checks for /dev/mapper/ventoy.