### PR TITLE
Add cancellation support to view-steps

### DIFF
--- a/CHANGES-3.3
+++ b/CHANGES-3.3
@@ -19,8 +19,14 @@ This release contains contributions from (alphabetically by given name):
    consistent. At least one valid Python program would work with
    the Boost::Python bindings, but not the pybind11 bindings. A
    memory-corruption problem in the Boost::Python bindings was resolved.
+ - Steps in the UI now have a hook to undo any changes they have made
+   to the live system, if the user cancels the installation.
 
 ## Modules ##
+ - *keyboard* module undoes changes to the keyboard layout if the
+   user cancels the installation (returning the system to whatever
+   layout was in use when Calamares started). (#2377, #2431)
+ - *locale* module undoes changes to the timezone. (#2377, #2431)
  - *partition* module stores a global storage value in luksPassphrase,
    for later modules that need to manipulate the encrypted partition.
    (thanks vincent, #2424)

--- a/src/calamares/CalamaresWindow.cpp
+++ b/src/calamares/CalamaresWindow.cpp
@@ -534,7 +534,13 @@ CalamaresWindow::ensureSize( QSize size )
 void
 CalamaresWindow::closeEvent( QCloseEvent* event )
 {
-    if ( ( !m_viewManager ) || m_viewManager->confirmCancelInstallation() )
+    if ( m_viewManager )
+    {
+        m_viewManager->quit();
+        // If it didn't actually exit, eat the event to ignore close
+        event->ignore();
+    }
+    else
     {
         event->accept();
 #if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
@@ -542,9 +548,5 @@ CalamaresWindow::closeEvent( QCloseEvent* event )
 #else
         QApplication::exit( EXIT_SUCCESS );
 #endif
-    }
-    else
-    {
-        event->ignore();
     }
 }

--- a/src/libcalamares/geoip/Interface.h
+++ b/src/libcalamares/geoip/Interface.h
@@ -60,6 +60,8 @@ public:
         return std::tie( lhs.m_region, lhs.m_zone ) == std::tie( rhs.m_region, rhs.m_zone );
     }
 
+    QString asString() const { return isValid() ? region() + QChar( '/' ) + zone() : QString(); }
+
 private:
     QString m_region;
     QString m_zone;
@@ -68,13 +70,13 @@ private:
 inline QDebug&
 operator<<( QDebug&& s, const RegionZonePair& tz )
 {
-    return s << tz.region() << '/' << tz.zone();
+    return s << tz.asString();
 }
 
 inline QDebug&
 operator<<( QDebug& s, const RegionZonePair& tz )
 {
-    return s << tz.region() << '/' << tz.zone();
+    return s << tz.asString();
 }
 
 /** @brief Splits a region/zone string into a pair.

--- a/src/libcalamaresui/ViewManager.h
+++ b/src/libcalamaresui/ViewManager.h
@@ -101,14 +101,21 @@ public:
      */
     int currentStepIndex() const;
 
+    enum class Confirmation
+    {
+        Continue,  // User rejects cancel / close question
+        CancelInstallation,  // User accepts cancel / close question
+        EndOfInstallation,  // There was no question because the installation was already done
+    };
+
     /**
      * @brief Called when "Cancel" is clicked; asks for confirmation.
      * Other means of closing Calamares also call this method, e.g. alt-F4.
      * At the end of installation, no confirmation is asked.
      *
-     * @return @c true if the user confirms closing the window.
+     * @return a Confirmation value, @c Unasked if the installation is complete
      */
-    bool confirmCancelInstallation();
+    Confirmation confirmCancelInstallation();
 
     Qt::Orientations panelSides() const { return m_panelSides; }
     void setPanelSides( Qt::Orientations panelSides ) { m_panelSides = panelSides; }

--- a/src/libcalamaresui/viewpages/ViewStep.cpp
+++ b/src/libcalamaresui/viewpages/ViewStep.cpp
@@ -46,6 +46,11 @@ ViewStep::onLeave()
 }
 
 void
+ViewStep::onCancel()
+{
+}
+
+void
 ViewStep::next()
 {
 }

--- a/src/libcalamaresui/viewpages/ViewStep.h
+++ b/src/libcalamaresui/viewpages/ViewStep.h
@@ -168,6 +168,15 @@ public:
      */
     virtual RequirementsList checkRequirements();
 
+    /**
+     * @brief Called when the user cancels the installation
+     *
+     * View steps are expected to leave the system unchanged when
+     * the installation is cancelled. The default implementation
+     * does nothing.
+     */
+    virtual void onCancel();
+
 signals:
     /// @brief Tells the viewmanager to enable the *next* button according to @p status
     void nextStatusChanged( bool status );

--- a/src/modules/keyboard/AdditionalLayoutInfo.h
+++ b/src/modules/keyboard/AdditionalLayoutInfo.h
@@ -12,6 +12,14 @@
 
 #include <QString>
 
+struct BasicLayoutInfo
+{
+    QString selectedLayout;
+    QString selectedModel;
+    QString selectedVariant;
+    QString selectedGroup;
+};
+
 struct AdditionalLayoutInfo
 {
     QString additionalLayout;

--- a/src/modules/keyboard/Config.cpp
+++ b/src/modules/keyboard/Config.cpp
@@ -571,11 +571,26 @@ Config::detectCurrentKeyboardLayout()
             break;
         }
     }
+    // The models have updated the m_current settings, copy them
+    m_original = m_current;
 }
 
 void
 Config::cancel()
 {
+    const auto extra = getAdditionalLayoutInfo( m_original.selectedLayout );
+    if ( m_configureXkb )
+    {
+        applyXkb( m_original, m_additionalLayoutInfo );
+    }
+    if ( m_configureLocale1 )
+    {
+        applyLocale1( m_original, m_additionalLayoutInfo );
+    }
+    if ( m_configureKWin )
+    {
+        applyKWin( m_original, m_additionalLayoutInfo );
+    }
 }
 
 QString

--- a/src/modules/keyboard/Config.cpp
+++ b/src/modules/keyboard/Config.cpp
@@ -169,7 +169,7 @@ Config::Config( QObject* parent )
              &KeyboardModelsModel::currentIndexChanged,
              [ & ]( int index )
              {
-                 m_selectedModel = m_keyboardModelsModel->key( index );
+                 m_current.selectedModel = m_keyboardModelsModel->key( index );
                  somethingChanged();
              } );
 
@@ -177,7 +177,7 @@ Config::Config( QObject* parent )
              &KeyboardLayoutModel::currentIndexChanged,
              [ & ]( int index )
              {
-                 m_selectedLayout = m_keyboardLayoutsModel->item( index ).first;
+                 m_current.selectedLayout = m_keyboardLayoutsModel->item( index ).first;
                  updateVariants( QPersistentModelIndex( m_keyboardLayoutsModel->index( index ) ) );
                  emit prettyStatusChanged();
              } );
@@ -186,14 +186,14 @@ Config::Config( QObject* parent )
              &KeyboardVariantsModel::currentIndexChanged,
              [ & ]( int index )
              {
-                 m_selectedVariant = m_keyboardVariantsModel->key( index );
+                 m_current.selectedVariant = m_keyboardVariantsModel->key( index );
                  somethingChanged();
              } );
     connect( m_KeyboardGroupSwitcherModel,
              &KeyboardGroupsSwitchersModel::currentIndexChanged,
              [ & ]( int index )
              {
-                 m_selectedGroup = m_KeyboardGroupSwitcherModel->key( index );
+                 m_current.selectedGroup = m_KeyboardGroupSwitcherModel->key( index );
                  somethingChanged();
              } );
 
@@ -207,10 +207,10 @@ Config::Config( QObject* parent )
              this,
              &Config::selectionChange );
 
-    m_selectedModel = m_keyboardModelsModel->key( m_keyboardModelsModel->currentIndex() );
-    m_selectedLayout = m_keyboardLayoutsModel->item( m_keyboardLayoutsModel->currentIndex() ).first;
-    m_selectedVariant = m_keyboardVariantsModel->key( m_keyboardVariantsModel->currentIndex() );
-    m_selectedGroup = m_KeyboardGroupSwitcherModel->key( m_KeyboardGroupSwitcherModel->currentIndex() );
+    m_current.selectedModel = m_keyboardModelsModel->key( m_keyboardModelsModel->currentIndex() );
+    m_current.selectedLayout = m_keyboardLayoutsModel->item( m_keyboardLayoutsModel->currentIndex() ).first;
+    m_current.selectedVariant = m_keyboardVariantsModel->key( m_keyboardVariantsModel->currentIndex() );
+    m_current.selectedGroup = m_KeyboardGroupSwitcherModel->key( m_KeyboardGroupSwitcherModel->currentIndex() );
 }
 
 void
@@ -224,38 +224,56 @@ Config::somethingChanged()
     emit prettyStatusChanged();
 }
 
-void
-Config::apply()
+static void
+applyXkb( const BasicLayoutInfo& settings, AdditionalLayoutInfo& extra )
 {
-    if ( m_configureXkb )
+    QStringList basicArguments = xkbmap_model_args( settings.selectedModel );
+    if ( !extra.additionalLayout.isEmpty() )
     {
-        applyXkb();
+        if ( !settings.selectedGroup.isEmpty() )
+        {
+            extra.groupSwitcher = "grp:" + settings.selectedGroup;
+        }
+
+        if ( extra.groupSwitcher.isEmpty() )
+        {
+            extra.groupSwitcher = xkbmap_query_grp_option();
+        }
+        if ( extra.groupSwitcher.isEmpty() )
+        {
+            extra.groupSwitcher = "grp:alt_shift_toggle";
+        }
+
+        basicArguments.append(
+            xkbmap_layout_args_with_group_switch( { extra.additionalLayout, settings.selectedLayout },
+                                                  { extra.additionalVariant, settings.selectedVariant },
+                                                  extra.groupSwitcher ) );
+        QProcess::execute( "setxkbmap", basicArguments );
+
+        cDebug() << "xkbmap selection changed to: " << settings.selectedLayout << '-' << settings.selectedVariant
+                 << "(added " << extra.additionalLayout << "-" << extra.additionalVariant
+                 << " since current layout is not ASCII-capable)";
     }
-    if ( m_configureLocale1 )
+    else
     {
-        applyLocale1();
+        basicArguments.append( xkbmap_layout_args( settings.selectedLayout, settings.selectedVariant ) );
+        QProcess::execute( "setxkbmap", basicArguments );
+        cDebug() << "xkbmap selection changed to: " << settings.selectedLayout << '-' << settings.selectedVariant;
     }
-    if ( m_configureKWin )
-    {
-        applyKWin();
-    }
-    // Writing /etc/ files is not needed "live"
 }
 
-void
-Config::applyLocale1()
+static void
+applyLocale1( const BasicLayoutInfo& settings, AdditionalLayoutInfo& extra )
 {
-    m_additionalLayoutInfo = getAdditionalLayoutInfo( m_selectedLayout );
-
-    QString layout = m_selectedLayout;
-    QString variant = m_selectedVariant;
+    QString layout = settings.selectedLayout;
+    QString variant = settings.selectedVariant;
     QString option;
 
-    if ( !m_additionalLayoutInfo.additionalLayout.isEmpty() )
+    if ( !extra.additionalLayout.isEmpty() )
     {
-        layout = m_additionalLayoutInfo.additionalLayout + "," + layout;
-        variant = m_additionalLayoutInfo.additionalVariant + "," + variant;
-        option = m_additionalLayoutInfo.groupSwitcher;
+        layout = extra.additionalLayout + "," + layout;
+        variant = extra.additionalVariant + "," + variant;
+        option = extra.groupSwitcher;
     }
 
     QDBusInterface locale1( "org.freedesktop.locale1",
@@ -270,53 +288,13 @@ Config::applyLocale1()
 
     // Using convert=true, this also updates the VConsole config
     {
-        QDBusReply< void > r = locale1.call( "SetX11Keyboard", layout, m_selectedModel, variant, option, true, false );
+        QDBusReply< void > r
+            = locale1.call( "SetX11Keyboard", layout, settings.selectedModel, variant, option, true, false );
         if ( !r.isValid() )
         {
             cWarning() << "Could not set keyboard config through org.freedesktop.locale1.X11Keyboard." << r.error();
         }
     }
-}
-
-void
-Config::applyXkb()
-{
-    m_additionalLayoutInfo = getAdditionalLayoutInfo( m_selectedLayout );
-
-    QStringList basicArguments = xkbmap_model_args( m_selectedModel );
-    if ( !m_additionalLayoutInfo.additionalLayout.isEmpty() )
-    {
-        if ( !m_selectedGroup.isEmpty() )
-        {
-            m_additionalLayoutInfo.groupSwitcher = "grp:" + m_selectedGroup;
-        }
-
-        if ( m_additionalLayoutInfo.groupSwitcher.isEmpty() )
-        {
-            m_additionalLayoutInfo.groupSwitcher = xkbmap_query_grp_option();
-        }
-        if ( m_additionalLayoutInfo.groupSwitcher.isEmpty() )
-        {
-            m_additionalLayoutInfo.groupSwitcher = "grp:alt_shift_toggle";
-        }
-
-        basicArguments.append(
-            xkbmap_layout_args_with_group_switch( { m_additionalLayoutInfo.additionalLayout, m_selectedLayout },
-                                                  { m_additionalLayoutInfo.additionalVariant, m_selectedVariant },
-                                                  m_additionalLayoutInfo.groupSwitcher ) );
-        QProcess::execute( "setxkbmap", basicArguments );
-
-        cDebug() << "xkbmap selection changed to: " << m_selectedLayout << '-' << m_selectedVariant << "(added "
-                 << m_additionalLayoutInfo.additionalLayout << "-" << m_additionalLayoutInfo.additionalVariant
-                 << " since current layout is not ASCII-capable)";
-    }
-    else
-    {
-        basicArguments.append( xkbmap_layout_args( m_selectedLayout, m_selectedVariant ) );
-        QProcess::execute( "setxkbmap", basicArguments );
-        cDebug() << "xkbmap selection changed to: " << m_selectedLayout << '-' << m_selectedVariant;
-    }
-    m_applyTimer.stop();
 }
 
 // In a config-file's list of lines, replace lines <key>=<something> by <key>=<value>
@@ -368,21 +346,21 @@ rewriteKWin( const QString& path, const QString& model, const QString& layouts, 
 }
 
 void
-Config::applyKWin()
+applyKWin( const BasicLayoutInfo& settings, AdditionalLayoutInfo& extra )
 {
     const auto paths = QStandardPaths::standardLocations( QStandardPaths::ConfigLocation );
 
-    auto join = [ &additional = m_additionalLayoutInfo.additionalLayout ]( const QString& s1, const QString& s2 )
+    auto join = [ &additional = extra.additionalLayout ]( const QString& s1, const QString& s2 )
     { return additional.isEmpty() ? s1 : QStringLiteral( "%1,%2" ).arg( s1, s2 ); };
 
-    const QString layouts = join( m_selectedLayout, m_additionalLayoutInfo.additionalLayout );
-    const QString variants = join( m_selectedVariant, m_additionalLayoutInfo.additionalVariant );
+    const QString layouts = join( settings.selectedLayout, extra.additionalLayout );
+    const QString variants = join( settings.selectedVariant, extra.additionalVariant );
 
     bool updated = false;
     for ( const auto& path : paths )
     {
         const QString candidate = path + QStringLiteral( "/kxkbrc" );
-        if ( rewriteKWin( candidate, m_selectedModel, layouts, variants ) )
+        if ( rewriteKWin( candidate, settings.selectedModel, layouts, variants ) )
         {
             updated = true;
             break;
@@ -397,6 +375,25 @@ Config::applyKWin()
     }
 }
 
+void
+Config::apply()
+{
+    m_additionalLayoutInfo = getAdditionalLayoutInfo( m_current.selectedLayout );
+    if ( m_configureXkb )
+    {
+        applyXkb( m_current, m_additionalLayoutInfo );
+    }
+    if ( m_configureLocale1 )
+    {
+        applyLocale1( m_current, m_additionalLayoutInfo );
+    }
+    if ( m_configureKWin )
+    {
+        applyKWin( m_current, m_additionalLayoutInfo );
+    }
+    m_applyTimer.stop();
+    // Writing /etc/ files is not needed "live"
+}
 
 KeyboardModelsModel*
 Config::keyboardModels() const
@@ -604,9 +601,9 @@ Config::createJobs()
 {
     QList< Calamares::job_ptr > list;
 
-    Calamares::Job* j = new SetKeyboardLayoutJob( m_selectedModel,
-                                                  m_selectedLayout,
-                                                  m_selectedVariant,
+    Calamares::Job* j = new SetKeyboardLayoutJob( m_current.selectedModel,
+                                                  m_current.selectedLayout,
+                                                  m_current.selectedVariant,
                                                   m_additionalLayoutInfo,
                                                   m_xOrgConfFileName,
                                                   m_convertedKeymapPath,
@@ -753,10 +750,10 @@ void
 Config::finalize()
 {
     Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
-    if ( !m_selectedLayout.isEmpty() )
+    if ( !m_current.selectedLayout.isEmpty() )
     {
-        gs->insert( "keyboardLayout", m_selectedLayout );
-        gs->insert( "keyboardVariant", m_selectedVariant );  //empty means default variant
+        gs->insert( "keyboardLayout", m_current.selectedLayout );
+        gs->insert( "keyboardVariant", m_current.selectedVariant );  //empty means default variant
 
         if ( !m_additionalLayoutInfo.additionalLayout.isEmpty() )
         {

--- a/src/modules/keyboard/Config.cpp
+++ b/src/modules/keyboard/Config.cpp
@@ -576,6 +576,11 @@ Config::detectCurrentKeyboardLayout()
     }
 }
 
+void
+Config::cancel()
+{
+}
+
 QString
 Config::prettyStatus() const
 {

--- a/src/modules/keyboard/Config.h
+++ b/src/modules/keyboard/Config.h
@@ -97,9 +97,6 @@ private:
      */
     void somethingChanged();
     void apply();
-    void applyLocale1();
-    void applyXkb();
-    void applyKWin();
 
     void getCurrentKeyboardLayoutXkb( QString& currentLayout, QString& currentVariant, QString& currentModel );
     void getCurrentKeyboardLayoutLocale1( QString& currentLayout, QString& currentVariant, QString& currentModel );
@@ -109,10 +106,7 @@ private:
     KeyboardVariantsModel* m_keyboardVariantsModel;
     KeyboardGroupsSwitchersModel* m_KeyboardGroupSwitcherModel;
 
-    QString m_selectedLayout;
-    QString m_selectedModel;
-    QString m_selectedVariant;
-    QString m_selectedGroup;
+    BasicLayoutInfo m_current;
 
     // Layout (and corresponding info) added if current one doesn't support ASCII (e.g. Russian or Japanese)
     AdditionalLayoutInfo m_additionalLayoutInfo;

--- a/src/modules/keyboard/Config.h
+++ b/src/modules/keyboard/Config.h
@@ -44,6 +44,9 @@ public:
     /// @brief When leaving the page, write to GS
     void finalize();
 
+    /// @brief Restore the system to whatever layout was in use when detectCurrentKeyboardLayout() was called
+    void cancel();
+
     static AdditionalLayoutInfo getAdditionalLayoutInfo( const QString& layout );
 
     /* A model is a physical configuration of a keyboard, e.g. 105-key PC

--- a/src/modules/keyboard/Config.h
+++ b/src/modules/keyboard/Config.h
@@ -107,6 +107,7 @@ private:
     KeyboardGroupsSwitchersModel* m_KeyboardGroupSwitcherModel;
 
     BasicLayoutInfo m_current;
+    BasicLayoutInfo m_original;
 
     // Layout (and corresponding info) added if current one doesn't support ASCII (e.g. Russian or Japanese)
     AdditionalLayoutInfo m_additionalLayoutInfo;

--- a/src/modules/keyboard/KeyboardViewStep.cpp
+++ b/src/modules/keyboard/KeyboardViewStep.cpp
@@ -104,6 +104,11 @@ KeyboardViewStep::onLeave()
     m_config->finalize();
 }
 
+void
+KeyboardViewStep::onCancel()
+{
+    m_config->cancel();
+}
 
 void
 KeyboardViewStep::setConfigurationMap( const QVariantMap& configurationMap )

--- a/src/modules/keyboard/KeyboardViewStep.h
+++ b/src/modules/keyboard/KeyboardViewStep.h
@@ -43,6 +43,7 @@ public:
 
     void onActivate() override;
     void onLeave() override;
+    void onCancel() override;
 
     void setConfigurationMap( const QVariantMap& configurationMap ) override;
 

--- a/src/modules/keyboardq/KeyboardQmlViewStep.cpp
+++ b/src/modules/keyboardq/KeyboardQmlViewStep.cpp
@@ -80,6 +80,12 @@ KeyboardQmlViewStep::onLeave()
     m_config->finalize();
 }
 
+void
+KeyboardQmlViewStep::onCancel()
+{
+    m_config->cancel();
+}
+
 QObject*
 KeyboardQmlViewStep::getConfig()
 {

--- a/src/modules/keyboardq/KeyboardQmlViewStep.h
+++ b/src/modules/keyboardq/KeyboardQmlViewStep.h
@@ -39,6 +39,7 @@ public:
 
     void onActivate() override;
     void onLeave() override;
+    void onCancel() override;
 
     void setConfigurationMap( const QVariantMap& configurationMap ) override;
     QObject* getConfig() override;

--- a/src/modules/locale/Config.cpp
+++ b/src/modules/locale/Config.cpp
@@ -378,7 +378,7 @@ Config::currentLocationStatus() const
 {
     if ( m_currentLocation )
     {
-        return tr( "Set timezone to %1.", "@action" ).arg( currentTimezoneName());
+        return tr( "Set timezone to %1.", "@action" ).arg( currentTimezoneName() );
     }
     return QString();
 }
@@ -513,6 +513,8 @@ getGeoIP( const QVariantMap& configurationMap, std::unique_ptr< Calamares::GeoIP
 void
 Config::setConfigurationMap( const QVariantMap& configurationMap )
 {
+    m_originalTimezone = Calamares::GeoIP::splitTZString( QTimeZone::systemTimeZoneId() );
+
     getLocaleGenLines( configurationMap, m_localeGenLines );
     getAdjustLiveTimezone( configurationMap, m_adjustLiveTimezone );
     getStartingTimezone( configurationMap, m_startingTimezone );
@@ -587,4 +589,13 @@ Config::completeGeoIP()
     }
     m_geoipWatcher.reset();
     m_geoip.reset();
+}
+
+void
+Config::cancel()
+{
+    if ( m_adjustLiveTimezone && m_originalTimezone.isValid() )
+    {
+        QProcess::execute( "timedatectl", { "set-timezone", m_originalTimezone.asString() } );
+    }
 }

--- a/src/modules/locale/Config.h
+++ b/src/modules/locale/Config.h
@@ -83,9 +83,11 @@ public:
 
     const Calamares::Locale::TimeZoneData* currentLocation() const { return m_currentLocation; }
 
-
     /// Special case, set location from starting timezone if not already set
     void setCurrentLocation();
+
+    /// Restores original timezone, if any
+    void cancel();
 
 private:
     Calamares::Locale::TimeZoneData* currentLocation_c() const
@@ -175,6 +177,9 @@ private:
      * GeoIP settings.
      */
     Calamares::GeoIP::RegionZonePair m_startingTimezone;
+
+    /// @brief The timezone set in the system when Calamares started (not from config)
+    Calamares::GeoIP::RegionZonePair m_originalTimezone;
 
     /** @brief Handler for GeoIP lookup (if configured)
      *

--- a/src/modules/locale/LocaleViewStep.cpp
+++ b/src/modules/locale/LocaleViewStep.cpp
@@ -131,6 +131,12 @@ LocaleViewStep::onLeave()
 }
 
 void
+LocaleViewStep::onCancel()
+{
+    m_config->cancel();
+}
+
+void
 LocaleViewStep::setConfigurationMap( const QVariantMap& configurationMap )
 {
     m_config->setConfigurationMap( configurationMap );

--- a/src/modules/locale/LocaleViewStep.h
+++ b/src/modules/locale/LocaleViewStep.h
@@ -44,6 +44,7 @@ public:
 
     void onActivate() override;
     void onLeave() override;
+    void onCancel() override;
 
     void setConfigurationMap( const QVariantMap& configurationMap ) override;
 

--- a/src/modules/localeq/LocaleQmlViewStep.cpp
+++ b/src/modules/localeq/LocaleQmlViewStep.cpp
@@ -84,6 +84,12 @@ LocaleQmlViewStep::onLeave()
 }
 
 void
+LocaleQmlViewStep::onCancel()
+{
+    m_config->cancel();
+}
+
+void
 LocaleQmlViewStep::setConfigurationMap( const QVariantMap& configurationMap )
 {
     m_config->setConfigurationMap( configurationMap );

--- a/src/modules/localeq/LocaleQmlViewStep.h
+++ b/src/modules/localeq/LocaleQmlViewStep.h
@@ -34,8 +34,9 @@ public:
     bool isAtBeginning() const override;
     bool isAtEnd() const override;
 
-    virtual void onActivate() override;
-    virtual void onLeave() override;
+    void onActivate() override;
+    void onLeave() override;
+    void onCancel() override;
 
     Calamares::JobList jobs() const override;
 


### PR DESCRIPTION
Add cancellation to all view steps, and when the installation is cancelled, back out changes (if any). The only step that currently supports this is the keyboard step, although the locale / timezone step might do so as well.

FIXES #2377