### PR TITLE
Handle Keyboard on Ubuntu 24.10+ when using Wayland and Gnome.

### DIFF
--- a/src/modules/keyboard/Config.h
+++ b/src/modules/keyboard/Config.h
@@ -121,6 +121,7 @@ private:
     bool m_configureEtcDefaultKeyboard = true;
     bool m_configureLocale1 = false;
     bool m_configureKWin = false;
+    bool m_configureGnome = false;
     bool m_guessLayout = false;
 
     // The state determines whether we guess settings or preserve them:

--- a/src/modules/keyboard/keyboard.conf
+++ b/src/modules/keyboard/keyboard.conf
@@ -43,3 +43,5 @@ configure:
     # compositor KWin with command-line argument `--locale1`. That
     # argument makes this configuration option unnecessary.
     kwin: false
+    # Configure keyboard when using Wayland with Gnome on Ubuntu 24.10+
+    gnome: false


### PR DESCRIPTION
With Ubuntu 24.10+ (Oracular) it seem's that way to handle Keyboard has changed when using Gnome and Wayland.
X11 commands don't work anymore and Keyboard management seem's to be per account.

Here is a way to handle keyboard using gsettings. All configurations are handle as before (extra-keyboard, shortcuts, etc..)

As Calamares need root privileges, we need to get default user DBUS_SESSION_BUS_ADRESSE to change keyboard for it.
This is done getting username associated to userid 1000.

By default Calamares will not use this code, but it can be activated changing this keyboard.conf value to True:
```
configure:
    gnome: false
```
