### PR TITLE
[grubcfg] Fix /etc/default/grub.d config file name

### DIFF
--- a/src/modules/grubcfg/grubcfg.conf
+++ b/src/modules/grubcfg/grubcfg.conf
@@ -22,7 +22,7 @@ overwrite: false
 
 # If set to true, prefer to write files in /etc/default/grub.d/
 # rather than the single file /etc/default/grub. If this is set,
-# Calamares will write /etc/default/grub.d/00Calamares instead.
+# Calamares will write /etc/default/grub.d/00calamares.cfg instead.
 prefer_grub_d: false
 
 # If set to true, an **existing** setting for GRUB_DISTRIBUTOR is

--- a/src/modules/grubcfg/main.py
+++ b/src/modules/grubcfg/main.py
@@ -45,7 +45,7 @@ def get_grub_config_path(root_mount_point):
         possible_dir = os.path.join(root_mount_point, "etc/default/grub.d")
         if os.path.exists(possible_dir) and os.path.isdir(possible_dir):
             default_dir = possible_dir
-            default_config_file = "00calamares"
+            default_config_file = "00calamares.cfg"
 
     if not os.path.exists(default_dir):
         try:


### PR DESCRIPTION
Under at least Debian, files under /etc/default/grub.d that don't carry a file name extension of '.cfg' are ignored. Change the filename used when grubcfg's prefer_grub_d option is set to 'true' to 00calamares.cfg, so that it is detected properly.