### PR TITLE
[users] Add a choice to display autologin checkbox

### DIFF
--- a/src/modules/users/Config.cpp
+++ b/src/modules/users/Config.cpp
@@ -1017,6 +1017,7 @@ Config::setConfigurationMap( const QVariantMap& configurationMap )
 
     // Renaming of Autologin -> AutoLogin in 4ffa79d4cf also affected
     // configuration keys, which was not intended. Accept both.
+    m_displayAutoLogin = Calamares::getBool( configurationMap, "displayAutologin", false );
     m_doAutoLogin = either(
         Calamares::getBool, configurationMap, QStringLiteral( "doAutologin" ), QStringLiteral( "doAutoLogin" ), false );
 

--- a/src/modules/users/Config.h
+++ b/src/modules/users/Config.h
@@ -216,6 +216,8 @@ public:
     /// Write /etc/hosts ?
     bool writeEtcHosts() const { return m_writeEtcHosts; }
 
+    /// Should the user be able to changed the value of autologin?
+    bool displayAutoLogin() const { return m_displayAutoLogin; }
     /// Should the user be automatically logged-in?
     bool doAutoLogin() const { return m_doAutoLogin; }
     /// Should the root password be written (if false, no password is set and the root account is disabled for login)
@@ -343,6 +345,7 @@ private:
     QString m_rootPassword;
     QString m_rootPasswordSecondary;
 
+    bool m_displayAutoLogin = false;
     bool m_doAutoLogin = false;
 
     bool m_writeRootPassword = true;

--- a/src/modules/users/UsersPage.cpp
+++ b/src/modules/users/UsersPage.cpp
@@ -136,6 +136,7 @@ UsersPage::UsersPage( Config* config, QWidget* parent )
     connect( config, &Config::loginNameChanged, ui->textBoxLoginName, &QLineEdit::setText );
     connect( config, &Config::loginNameStatusChanged, this, &UsersPage::reportLoginNameStatus );
 
+    ui->checkBoxDoAutoLogin->setVisible( m_config->displayAutoLogin() );
     ui->checkBoxDoAutoLogin->setChecked( m_config->doAutoLogin() );
     connect( ui->checkBoxDoAutoLogin,
              Calamares::checkBoxStateChangedSignal,

--- a/src/modules/users/users.conf
+++ b/src/modules/users/users.conf
@@ -101,6 +101,13 @@ doReusePassword: true
 # or another. Weak(er) passwords may be allowed, may cause a warning,
 # or may be forbidden entirely.
 
+# Autologin choice can be display to the user.
+# Possible values are:
+#  - true to display it
+#  - false to hide it
+# By default, this value is set to false.
+displayAutologin:   false
+
 # You can control the initial state for the 'autologin checkbox' here.
 # Possible values are:
 #  - true to check or

--- a/src/modules/users/users.conf
+++ b/src/modules/users/users.conf
@@ -105,8 +105,8 @@ doReusePassword: true
 # Possible values are:
 #  - true to display it
 #  - false to hide it
-# By default, this value is set to false.
-displayAutologin:   false
+# By default, this value is set to true.
+displayAutologin:   true
 
 # You can control the initial state for the 'autologin checkbox' here.
 # Possible values are:

--- a/src/modules/users/users.schema.yaml
+++ b/src/modules/users/users.schema.yaml
@@ -31,6 +31,7 @@ properties:
     sudoersGroup: { type: string }
     sudoersConfigureWithGroup: { type: boolean, default: false }
     # Skip login (depends on displaymanager support)
+    displayAutologin: { type: boolean, default: true }
     doAutologin: { type: boolean, default: true }
     # Root password separate from user password?
     setRootPassword: { type: boolean, default: true }


### PR DESCRIPTION
By default, the autologin checkbox is display to the user and he can choose if he wants to enable it or not. By adding a variable to display the checkbox or not, this checkbox can be not displaying to the user and avoid him to change it.