### PR TITLE
initcpiocfg: Remove crc32c-intel since it got merged into the crc32c …

### DIFF
--- a/src/modules/initcpiocfg/main.py
+++ b/src/modules/initcpiocfg/main.py
@@ -243,7 +243,7 @@ def find_initcpio_features(partitions, root_mount_point):
         hooks.extend(["filesystems"])
 
     if uses_btrfs:
-        modules.append("crc32c-intel" if cpuinfo().is_intel else "crc32c")
+        modules.append("crc32c")
     else:
         hooks.append("fsck")
 


### PR DESCRIPTION
Fix install using btrfs remove old lib crc32c-intel