### PR TITLE
fix crc32c-intel is deprecated

### DIFF
--- a/src/modules/initcpiocfg/main.py
+++ b/src/modules/initcpiocfg/main.py
@@ -243,7 +243,8 @@ def find_initcpio_features(partitions, root_mount_point):
         hooks.extend(["filesystems"])
 
     if uses_btrfs:
-        modules.append("crc32c-intel" if cpuinfo().is_intel else "crc32c")
+        modules.append("crc32c-intel" if cpuinfo().is_intel else "crc32c") 
+        modules.append("crc32c")
     else:
         hooks.append("fsck")
 


### PR DESCRIPTION
Please initcpiocfg: Remove crc32c-intel since it got merged into the crc32c 